### PR TITLE
Template for stale draft

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -871,6 +871,10 @@ Twinkle.warn.messages = {
 		"uw-warn": { 
 			label:"Place user warning templates when reverting vandalism", 
 			summary:"Notice: You can use user warning templates when reverting vandalism"
+		},
+		"uw-userspace draft finish": { 
+			label:"Stale userspace draft", 
+			summary:"Notice: Stale Userspace draft" 
 		}
 	},
 	singlewarn: {


### PR DESCRIPTION
I would want that {{Uw-userspace draft finish}}, used for notifing users because of a stale draft.  This template was created recently for WP:WikiProject Abandoned Drafts.  Ebe123
