### PR TITLE
removing {{puffery}} tags as it redirects to {{peacock}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -321,7 +321,6 @@ Twinkle.tag.article.tags = {
 	"POV": "article does not maintain a neutral point of view",
 	"primary sources": "article relies too heavily on first-hand sources, and needs third-party sources",
 	"prose": "article is in a list format that may be better presented using prose",
-	"puffery": "article may contain wording that promotes the subject through exaggeration",
 	"recentism": "article is slanted towards recent events",
 	"ref improve": "article needs additional references or sources for verification",
 	"rough translation": "article is poorly translated and needs cleanup",
@@ -412,7 +411,6 @@ Twinkle.tag.article.tagCategories = {
 			"globalize",  // has subcategories and special-cased code
 			"peacock",
 			"POV",
-			"puffery",
 			"recentism",
 			"too few opinions",
 			"weasel"


### PR DESCRIPTION
and when merged could it be informed at http://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Puffery_template
