### PR TITLE
Set oldProtection after getting API result

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -109,6 +109,9 @@ Twinkle.protect.callback.protectionLevel = function twinkleprotectCallbackProtec
 	var xml = apiobj.getXML();
 	var result = [];
 
+	Twinkle.protect.oldEditProtection = {level: 'all', expiry: 'infinity'};
+	Twinkle.protect.oldMoveProtection = {level: 'all', expiry: 'infinity'};
+
 	$(xml).find('pr').each(function(index, pr) {
 		var $pr = $(pr);
 		var boldnode = document.createElement('b');


### PR DESCRIPTION
If a page is not protected at all, and a user tries to set the edit protection level (leaving the move protection level alone), then he'll get an alert saying "Twinkle couldn't retrieve the existing protection settings."

It seems that the MW API won't return a <pr> when the corresponding protection level is not set, therefore `Twinkle.protect.old{Edit,Move}Protection` remains null.

This commit tries to workaround the problem by defaulting those two to `all` after getting API responses.

(Seems ugly though. I don't know if I'm doing this correct, but at least it works.)
