### PR TITLE
batchdelete: decode location.pathname before using it as gapprefix

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -78,7 +78,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		}
 		else
 		{
-			var pathSplit = decodeURI(location.pathname).split('/');
+			var pathSplit = decodeURIComonent(location.pathname).split('/');
 			if (pathSplit.length < 3 || pathSplit[2] !== "Special:PrefixIndex") {
 				return;
 			}


### PR DESCRIPTION
Would cause double percent-encoding and `apinvalidtitle`.
