### PR TITLE
Add Template:uw-inline-el to user warnings

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -914,6 +914,10 @@ Twinkle.warn.messages = {
 			label: "Incomplete AFD",
 			summary: "Notice: Incomplete AFD"
 		},
+		"uw-inline-el": {
+			label: "Adding external links to the body of an article",
+			summary: "Notice: Keep external links to External links sections at the bottom of an article"
+		},
 		"uw-italicize": {
 			label: "Italicize books, films, albums, magazines, TV series, etc within articles",
 			summary: "Notice: Italicize books, films, albums, magazines, TV series, etc within articles"


### PR DESCRIPTION
I've recently scrubbed up the "[uw-inline-el](http://en.wikipedia.org/wiki/Template:Uw-inline-el)" template to match other templates in Twinkle. This commit adds the template to Twinkle for general use.
