### PR TITLE
morebits: use correct value for basetimestamp

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1892,6 +1892,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		if (ctx.editMode === 'all') {
 			ctx.loadQuery.rvprop = 'content|timestamp';  // get the page content at the same time, if needed
 		} else if (ctx.editMode === 'revert') {
+			ctx.loadQuery.rvprop = 'timestamp';
 			ctx.loadQuery.rvlimit = 1;
 			ctx.loadQuery.rvstartid = ctx.revertOldID;
 		}


### PR DESCRIPTION
Somehow I was getting weird `editconflict`s, and found out this was the cause. We should use the time last revision was made, not the page was touched.

Not sure I modified the right thing though :P
