### PR TITLE
morebits: while deleting, retry on DBQueryError

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2566,7 +2566,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 			ctx.statusElement.error( "Failed to delete the page: " + ctx.deleteProcessApi.getErrorText() );
 			if (ctx.onDeleteFailure) {
-				ctx.onDeleteFailure(this);  // invoke callback
+				ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
 			}
 		}
 	};


### PR DESCRIPTION
Sometimes Wikimedia servers would get so loaded that nearly two-thirds of all jobs in a `batchdelete` would fail as "Database query error". This commit retries the operation upon encountering the error code "`internal_api_error_DBQueryError`".
