### PR TITLE
morebits: make use of wgRelevantUserName in getPageAssociatedUser

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -15,7 +15,7 @@
 
 Twinkle.talkback = function() {
 
-	if ( Morebits.getPageAssociatedUser() === false ) {
+	if ( !mw.config.get('wgRelevantUserName') ) {
 		return;
 	}
 
@@ -23,7 +23,7 @@ Twinkle.talkback = function() {
 };
 
 Twinkle.talkback.callback = function( ) {
-	if( Morebits.getPageAssociatedUser() === mw.config.get("wgUserName") && !confirm("Is it really so bad that you're talking back to yourself?") ){
+	if( mw.config.get('wgRelevantUserName') === mw.config.get("wgUserName") && !confirm("Is it really so bad that you're talking back to yourself?") ){
 		return;
 	}
 
@@ -104,7 +104,7 @@ Twinkle.talkback.callback.optoutStatus = function(apiobj) {
 	var $el = $(xml).find('el');
 
 	if ($el.length) {
-		Twinkle.talkback.optout = Morebits.getPageAssociatedUser() + " prefers not to receive talkbacks";
+		Twinkle.talkback.optout = mw.config.get('wgRelevantUserName') + " prefers not to receive talkbacks";
 		var url = $el.text();
 		if (url.indexOf("reason=") > -1) {
 			Twinkle.talkback.optout += ": " + decodeURIComponent(url.substring(url.indexOf("reason=") + 7)) + ".";
@@ -310,7 +310,7 @@ var callback_evaluate = function( e ) {
 	var tbtarget = e.target.getChecked( "tbtarget" )[0];
 	var page = null;
 	var section = e.target.section.value;
-	var fullUserTalkPageName = mw.config.get("wgFormattedNamespaces")[ mw.config.get("wgNamespaceIds").user_talk ] + ":" + Morebits.getPageAssociatedUser();
+	var fullUserTalkPageName = mw.config.get("wgFormattedNamespaces")[ mw.config.get("wgNamespaceIds").user_talk ] + ":" + mw.config.get('wgRelevantUserName');
 
 	if( tbtarget === "usertalk" || tbtarget === "other" ) {
 		page = e.target.page.value;

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -14,8 +14,8 @@
  */
 
 Twinkle.arv = function twinklearv() {
-	var username = Morebits.getPageAssociatedUser();
-	if ( username === false ) {
+	var username = mw.config.get('wgRelevantUserName');
+	if ( !username ) {
 		return;
 	}
 

--- a/morebits.js
+++ b/morebits.js
@@ -1047,28 +1047,6 @@ Morebits.array = {
 
 
 /**
- * **************** Morebits.getPageAssociatedUser ****************
- * Get the user associated with the currently-viewed page.
- * Currently works on User:, User talk:, Special:Contributions.
- */
-
-Morebits.getPageAssociatedUser = function(){
-	var thisNamespaceId = mw.config.get('wgNamespaceNumber');
-
-	if ( thisNamespaceId === 2 /* User: */ || thisNamespaceId === 3 /* User talk: */ ) {
-		return mw.config.get('wgTitle').split( '/' )[0];  // only first part before any slashes, to work on subpages
-	}
-
-	if ( thisNamespaceId === -1 /* Special: */ && mw.config.get('wgCanonicalSpecialPageName') === "Contributions" ) {
-		return $('table.mw-contributions-table input[name="target"]')[0].getAttribute('value');
-	}
-
-	return false;
-};
-
-
-
-/**
  * **************** Morebits.pageNameNorm ****************
  * Stores a normalized version of the wgPageName variable (underscores converted to spaces).
  * For queen/king/whatever and country!


### PR DESCRIPTION
Previously when someone opens [[Special:Contribution]] and send a talkback, it would be posted to `User talk:Null`.

(Seriously, why do you even _try_ to send a talkback in the first place :)
