### PR TITLE
Slightly more accurate T3 desc label

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -673,7 +673,7 @@ Twinkle.speedy.templateList = [
 		hideWhenMultiple: true
 	},
 	{
-		label: 'T3: Templates that are not employed in any useful fashion',
+		label: 'T3: Templates that are substantial or hardcoded duplications of another template',
 		value: 't3',
 		tooltip: 'This criterion allows you to provide a rationale. In many cases, another criterion will be more appropriate, such as G1, G2, G6, or G8.',
 		subgroup: {


### PR DESCRIPTION
Per Andy Mabbett https://en.wikipedia.org/wiki/User:Pigsonthewing -- The wording this script offers for WP:CSD#T3 is quite broad:

```
Templates that are not used in any useful fashion
```

but the wording of the actual criterion is much stricter:

```
Templates that are substantial duplications of another template, or hardcoded instances of another template where the same functionality could be provided by that other template
```

Can the Twinkle version be tightened up, to more closely reflect the latter, please? Perhaps:

```
Templates that are substantial or hardcoded duplications of another template
```

Is this something editors such as I can do? Andy Mabbett (Pigsonthewing); Talk to Andy; Andy's edits 6:19 pm, Today (UTC−4)

```
Sure... Submit a pull request on GitHub ( https://github.com/azatoth/twinkle — more specifically near: https://github.com/azatoth/twinkle/blob/master/modules/twinklespeedy.js#L676 ). — {{U|Technical 13}} (t • e • c) 6:31 pm, Today (UTC−4)

    I'm neither a coder nor a github user. Andy Mabbett (Pigsonthewing); Talk to Andy; Andy's edits 6:37 pm, Today (UTC−4)
```
