### PR TITLE
Fix measuring of collapsible tabs

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -442,6 +442,10 @@ Twinkle.load = function () {
 		mw.util.addCSS( ".morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } " +
 			".morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }" );
 	}
+	
+	if ( typeof $.collapsibleTabs !== 'undefined' ) {
+		$.collapsibleTabs.handleResize();
+	}
 };
 
 } ( window, document, jQuery )); // End wrap with anonymous function


### PR DESCRIPTION
There is this problem where the width of Twinkle is not taken into account for the collapsible tabs, sometimes leading to the whole 'right navigation' falling down into the content space due to lack of horizontal space. This is not desirable of course.

This is one way of fixing that. Alternatively, we could trigger a resize event on widow as well.
