### PR TITLE
Use new RfD template format

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1393,7 +1393,7 @@ Twinkle.xfd.callbacks = {
 			var text = pageobj.getPageText();
 			var params = pageobj.getCallbackParameters();
 
-			pageobj.setPageText("{{subst:rfd}}\n" + text);
+			pageobj.setPageText("{{subst:rfd|content=\n" + text + "\n}}");
 			pageobj.setEditSummary("Listed for discussion at [[" + params.logpage + "#" + Morebits.pageNameNorm + "]]." + Twinkle.getPref('summaryAd'));
 			switch (Twinkle.getPref('xfdWatchPage')) {
 				case 'yes':


### PR DESCRIPTION
Place existing content of the redirect inside of the RfD template
so that it can be read by the module to make transclusions work
properly.
