### PR TITLE
Hide certain functions when the content model is non-normal

### DIFF
--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -14,7 +14,8 @@
  */
 
 Twinkle.diff = function twinklediff() {
-	if( mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') ) {
+	var ns = mw.config.get('wgNamespaceNumber');
+	if( ns < 0 || ns == 2600 || ns == 90 || !mw.config.get('wgArticleId') ) {
 		return;
 	}
 

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -16,7 +16,8 @@
 // Note: a lot of code in this module is re-used/called by batchprotect.
 
 Twinkle.protect = function twinkleprotect() {
-	if ( mw.config.get('wgNamespaceNumber') < 0 ) {
+	var ns = mw.config.get('wgNamespaceNumber');
+	if ( ns < 0 || ns == 8 ) {
 		return;
 	}
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -21,9 +21,11 @@
 
 Twinkle.speedy = function twinklespeedy() {
 	// Disable on:
+	// * Flow discussion boards
 	// * special pages
 	// * non-existent pages
-	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId')) {
+	var ns = mw.config.get('wgNamespaceNumber');
+	if ( ns < 0 || ns == 2600 || ns == 90 || !mw.config.get('wgArticleId') ) {
 		return;
 	}
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -15,11 +15,13 @@
 
 Twinkle.xfd = function twinklexfd() {
 	// Disable on:
+	// * Flow discussion boards
 	// * special pages
 	// * non-existent pages
 	// * files on Commons, whether there is a local page or not (unneeded local pages of files on Commons are eligible for CSD F2)
 	// * file pages without actual files (these are eligible for CSD G8)
-	if ( mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && (document.getElementById('mw-sharedupload') || (!document.getElementById('mw-imagepage-section-filehistory') && !Morebits.wiki.isPageRedirect()))) ) {
+	var ns = mw.config.get('wgNamespaceNumber');
+	if ( ns < 0 || ns == 2600 || ns == 90 || !mw.config.get('wgArticleId') || (ns === 6 && (document.getElementById('mw-sharedupload') || (!document.getElementById('mw-imagepage-section-filehistory') && !Morebits.wiki.isPageRedirect()))) ) {
 		return;
 	}
 	Twinkle.addPortletLink( Twinkle.xfd.callback, "XFD", "tw-xfd", "Nominate for deletion" );


### PR DESCRIPTION
Basic API functions like edit, protect and delete won't work on pages
with special content models like Flow discussion boards. So let's
hide functions requiring them on such pages.

Signed-off-by: Zhaofeng Li hello@zhaofeng.li
