### PR TITLE
Block module for administrators

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1,0 +1,1065 @@
+//<nowiki>
+
+
+(function($){
+
+var api = new mw.Api(), relevantUserName;
+
+/*
+ ****************************************
+ *** twinkleblock.js: Block module
+ ****************************************
+ * Mode of invocation:     Tab ("Block")
+ * Active on:              any page with relevant user name (userspace, contribs, etc.)
+ * Config directives in:   [soon to be TwinkleConfig]
+ */
+
+Twinkle.block = function twinkleblock() {
+	// should show on Contributions pages, anywhere there's a relevant user
+	if ( Morebits.userIsInGroup('sysop') && mw.config.get('wgRelevantUserName') ) {
+		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user' );
+	}
+};
+
+Twinkle.block.callback = function twinkleblockCallback() {
+	if( mw.config.get('wgRelevantUserName') === mw.config.get('wgUserName') &&
+			!confirm( 'You are about to block yourself! Are you sure you want to proceed?' ) ) {
+		return;
+	}
+
+	var Window = new Morebits.simpleWindow( 650, 530 );
+	// need to be verbose about who we're blocking
+	Window.setTitle( 'Block or issue block template to ' + mw.config.get('wgRelevantUserName') );
+	Window.setScriptName( 'Twinkle' );
+	Window.addFooterLink( 'Block templates', 'Template:Uw-block/doc/Block_templates' );
+	Window.addFooterLink( 'Block policy', 'WP:BLOCK' );
+	Window.addFooterLink( 'Twinkle help', 'WP:TW/DOC#block' );
+
+	// clean up preset data (defaults, etc.), done exactly once, must be before Twinkle.block.callback.change_action is called
+	Twinkle.block.transformBlockPresets();
+
+	Twinkle.block.currentBlockInfo = undefined;
+	Twinkle.block.field_block_options = {};
+	Twinkle.block.field_template_options = {};
+
+	var form = new Morebits.quickForm( Twinkle.block.callback.evaluate );
+	var actionfield = form.append( {
+			type: 'field',
+			label: 'Type of action'
+		} );
+	actionfield.append({
+			type: 'checkbox',
+			name: 'actiontype',
+			event: Twinkle.block.callback.change_action,
+			list: [
+				{
+					label: 'Block user',
+					value: 'block',
+					tooltip: 'Block the relevant user with given options.',
+					checked: true
+				},
+				{
+					label: 'Add block template to user talk page',
+					value: 'template',
+					tooltip: 'If the blocking admin forgot to issue a block template, or you have just blocked the user without templating them, you can use this to issue the appropriate template.',
+					checked: true
+				}
+			]
+		});
+
+	form.append({ type: 'field', label: 'Preset', name: 'field_preset' });
+	form.append({ type: 'field', label: 'Template options', name: 'field_template_options' });
+	form.append({ type: 'field', label: 'Block options', name: 'field_block_options' });
+
+	form.append( { type:'submit' } );
+
+	var result = form.render();
+	Window.setContent( result );
+	Window.display();
+	result.root = result;
+
+	Twinkle.block.fetchUserInfo(function() {
+		// init the controls after user and block info have been fetched
+		var evt = document.createEvent( 'Event' );
+		evt.initEvent( 'change', true, true );
+		result.actiontype[0].dispatchEvent( evt );
+	});
+};
+
+Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
+
+	api.get({
+		format: 'json',
+		action: 'query',
+		list: 'blocks|users|logevents',
+		letype: 'block',
+		lelimit: 1,
+		bkusers: mw.config.get('wgRelevantUserName'),
+		ususers: mw.config.get('wgRelevantUserName'),
+		letitle: 'User:' + mw.config.get('wgRelevantUserName')
+	})
+	.then(function(data){
+		var blockinfo = data.query.blocks[0],
+			userinfo = data.query.users[0];
+
+		Twinkle.block.isRegistered = !!userinfo.userid;
+		relevantUserName = Twinkle.block.isRegistered ? 'User:' + mw.config.get('wgRelevantUserName') : mw.config.get('wgRelevantUserName');
+
+		if (blockinfo) {
+			// handle frustrating system of inverted boolean values
+			blockinfo.disabletalk = blockinfo.allowusertalk === undefined;
+			blockinfo.hardblock = blockinfo.anononly === undefined;
+			Twinkle.block.currentBlockInfo = blockinfo;
+		}
+
+		Twinkle.block.hasBlockLog = !!data.query.logevents.length;
+
+		if (typeof fn === 'function') return fn();
+	}, function(msg) {
+		Morebits.status.init($('div[name="currentblock"] span').last()[0]);
+		Morebits.status.warn('Error fetching user info', msg);
+	});
+};
+
+Twinkle.block.callback.saveFieldset = function twinkleblockCallbacksaveFieldset(fieldset) {
+	Twinkle.block[$(fieldset).prop('name')] = {};
+	$(fieldset).serializeArray().forEach(function(el) {
+		Twinkle.block[$(fieldset).prop('name')][el.name] = el.value;
+	});
+};
+
+Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction(e) {
+	var field_preset, field_template_options, field_block_options, $form = $(e.target.form);
+
+	Twinkle.block.callback.saveFieldset($('[name=field_block_options]'));
+	Twinkle.block.callback.saveFieldset($('[name=field_template_options]'));
+
+	if ($form.find('[name=actiontype][value=block]').is(':checked')) {
+		field_preset = new Morebits.quickForm.element({ type: 'field', label: 'Preset', name: 'field_preset' });
+		field_preset.append({
+				type: 'select',
+				name: 'preset',
+				label: 'Choose a preset:',
+				event: Twinkle.block.callback.change_preset,
+				list: [{
+					label: '',
+					value: '',
+					type: 'option'
+				}].concat(Twinkle.block.callback.filtered_block_groups())
+			});
+
+		field_block_options = new Morebits.quickForm.element({ type: 'field', label: 'Block options', name: 'field_block_options' });
+		field_block_options.append({ type: 'div', name: 'hasblocklog', label: ' ' });
+		field_block_options.append({ type: 'div', name: 'currentblock', label: ' ' });
+		field_block_options.append({
+				type: 'select',
+				name: 'expiry_preset',
+				label: 'Expiry:',
+				event: Twinkle.block.callback.change_expiry,
+				list: [
+					{ label: 'custom', value: 'custom', selected: true },
+					{ label: 'indefinite', value: 'infinity' },
+					{ label: '3 hours', value: '3 hours' },
+					{ label: '12 hours', value: '12 hours' },
+					{ label: '24 hours', value: '24 hours' },
+					{ label: '31 hours', value: '31 hours' },
+					{ label: '36 hours', value: '36 hours' },
+					{ label: '48 hours', value: '48 hours' },
+					{ label: '60 hours', value: '60 hours' },
+					{ label: '72 hours', value: '72 hours' },
+					{ label: '1 week', value: '1 week' },
+					{ label: '2 weeks', value: '2 weeks' },
+					{ label: '1 month', value: '1 month' },
+					{ label: '3 months', value: '3 months' },
+					{ label: '6 months', value: '6 months' },
+					{ label: '1 year', value: '1 year' },
+					{ label: '2 years', value: '2 years' },
+					{ label: '3 years', value: '3 years' }
+				]
+			});
+			field_block_options.append({
+					type: 'input',
+					name: 'expiry',
+					label: 'Custom expiry',
+					tooltip: 'You can use relative times, like "1 minute" or "19 days", or absolute timestamps, "yyyymmddhhmm" (e.g. "200602011405" is Feb 1, 2006, at 14:05 UTC).',
+					value: Twinkle.block.field_block_options.expiry || Twinkle.block.field_template_options.template_expiry
+				});
+		var blockoptions = [
+				{
+					checked: Twinkle.block.field_block_options.nocreate,
+					label: 'Block account creation',
+					name: 'nocreate',
+					value: '1'
+				},
+				{
+					checked: Twinkle.block.field_block_options.noemail,
+					label: 'Block user from sending email',
+					name: 'noemail',
+					value: '1'
+				},
+				{
+					checked: Twinkle.block.field_block_options.disabletalk,
+					label: 'Prevent this user from editing their own talk page while blocked',
+					name: 'disabletalk',
+					value: '1'
+				}
+			];
+
+		if (Twinkle.block.isRegistered) {
+			blockoptions.push({
+					checked: Twinkle.block.field_block_options.autoblock,
+					label: 'Autoblock any IP addresses used (hardblock)',
+					name: 'autoblock',
+					value: '1'
+				});
+		} else {
+			blockoptions.push({
+					checked: Twinkle.block.field_block_options.hardblock,
+					label: 'Prevent logged-in users from editing from this IP address (hardblock)',
+					name: 'hardblock',
+					value: '1'
+				});
+		}
+
+		blockoptions.push({
+				checked: Twinkle.block.field_block_options.watchuser,
+				label: 'Watch user and user talk pages',
+				name: 'watchuser',
+				value: '1'
+			});
+
+		field_block_options.append({
+				type: 'checkbox',
+				name: 'blockoptions',
+				list: blockoptions
+			});
+		field_block_options.append({
+				type: 'textarea',
+				label: 'Reason (for block log):',
+				name: 'reason',
+				value: Twinkle.block.field_block_options.reason
+			});
+
+		if (Twinkle.block.currentBlockInfo) {
+			field_block_options.append( { type: 'hidden', name: 'reblock', value: '1' } );
+		}
+	}
+
+	if ($form.find('[name=actiontype][value=template]').is(':checked')) {
+		field_template_options = new Morebits.quickForm.element({ type: 'field', label: 'Template options', name: 'field_template_options' });
+		field_template_options.append( {
+				type: 'select',
+				name: 'template',
+				label: 'Choose talk page template:',
+				event: Twinkle.block.callback.change_template,
+				list: Twinkle.block.callback.filtered_block_groups(true),
+				value: Twinkle.block.field_template_options.template
+			} );
+		field_template_options.append( {
+				type: 'input',
+				name: 'article',
+				display: 'none',
+				label: 'Linked article',
+				value: Twinkle.block.field_template_options.article || ( Morebits.queryString.exists( 'vanarticle' ) ? Morebits.queryString.get( 'vanarticle' ) : '' ),
+				tooltip: 'An article can be linked within the notice, perhaps if it was the primary target of disruption. Leave empty for no article to be linked.'
+			} );
+		if (!$form.find('[name=actiontype][value=block]').is(':checked')) {
+			field_template_options.append( {
+				type: 'input',
+				name: 'template_expiry',
+				display: 'none',
+				label: 'Period of blocking: ',
+				value: Twinkle.block.field_template_options.template_expiry || Twinkle.block.field_block_options.expiry || $form.find('[name=template_expiry]').val() || '',
+				tooltip: 'The period the blocking is due for, for example 24 hours, 2 weeks, indefinite etc...'
+			} );
+		}
+		field_template_options.append( {
+			type: 'input',
+			name: 'block_reason',
+			label: '"You have been blocked for ..." ',
+			display: 'none',
+			tooltip: 'An optional reason, to replace the default generic reason. Only available for the generic block templates.',
+			value: Twinkle.block.field_template_options.block_reason
+		} );
+		var $previewlink = $( '<a id="twinkleblock-preivew-link">Preview</a>' );
+		$previewlink.off('click').on('click', function(){
+			Twinkle.block.callback.preview($form[0]);
+		});
+		$previewlink.css({cursor: 'pointer'});
+		field_template_options.append( { type: 'div', id: 'blockpreview', label: [ $previewlink[0] ] } );
+		field_template_options.append( { type: 'div', id: 'twinkleblock-previewbox', style: 'display: none' } );
+	}
+
+	var oldfield;
+	if (field_preset) {
+		oldfield = $form.find('fieldset[name="field_preset"]')[0];
+		oldfield.parentNode.replaceChild(field_preset.render(), oldfield);
+	} else {
+		$form.find('fieldset[name="field_preset"]').hide();
+	}
+	if (field_block_options) {
+		oldfield = $form.find('fieldset[name="field_block_options"]')[0];
+		oldfield.parentNode.replaceChild(field_block_options.render(), oldfield);
+	} else {
+		$form.find('fieldset[name="field_block_options"]').hide();
+	}
+	if (field_template_options) {
+		oldfield = $form.find('fieldset[name="field_template_options"]')[0];
+		oldfield.parentNode.replaceChild(field_template_options.render(), oldfield);
+		e.target.form.root.previewer = new Morebits.wiki.preview($(e.target.form.root).find('#twinkleblock-previewbox').last()[0]);
+	} else {
+		$form.find('fieldset[name="field_template_options"]').hide();
+	}
+
+	if (Twinkle.block.hasBlockLog) {
+		var $blockloglink = $( '<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgRelevantUserName'), type: 'block'}) + '">block log</a>)' );
+
+		Morebits.status.init($('div[name="hasblocklog"] span').last()[0]);
+		Morebits.status.warn('This user has been blocked in the past', $blockloglink[0]);
+	}
+
+	if (Twinkle.block.currentBlockInfo) {
+		Morebits.status.init($('div[name="currentblock"] span').last()[0]);
+		Morebits.status.warn(relevantUserName + ' is already blocked', 'Submit query to reblock with supplied options');
+		Twinkle.block.callback.update_form(e, Twinkle.block.currentBlockInfo);
+	}
+};
+
+/*
+ * Keep alphabetized by key name, Twinkle.block.blockGroups establishes
+ *    the order they will appear in the interface
+ *
+ * Block preset format, all keys accept only 'true' (omit for false) except where noted:
+ * <title of block template> : {
+ *   autoblock: <autoblock any IP addresses used (for registered users only)>
+ *   disabletalk: <disable user from editing their own talk page while blocked>
+ *   expiry: <string - expiry timestamp, can include relative times like "5 months", "2 weeks" etc, use "infinity" for indefinite>
+ *   forAnonOnly: <show block option in the interface only if the relevant user is an IP>
+ *   forRegisteredOnly: <show block option in the interface only if the relevant user is registered>
+ *   label: <string - label for the option of the dropdown in the interface (keep brief)>
+ *   noemail: prevent the user from sending email through Special:Emailuser
+ *   pageParam: <set if the associated block template accepts a page parameter>
+ *   prependReason: <string - prepends the value of 'reason' to the end of the existing reason, namely for when revoking talk page access>
+ *   nocreate: <block account creation from the user's IP (for anonymous users only)>
+ *   reason: <string - block rationale, as would appear in the block log,
+ *            and the edit summary for when adding block template, unless 'summary' is set>
+ *   reasonParam: <set if the associated block template accepts a reason parameter>
+ *   sig: <string - set to ~~~~ if block template does not accept "true" as the value, or set null to omit sig param altogether>
+ *   summary: <string - edit summary for when adding block template to user's talk page, if not set, 'reason' is used>
+ *   suppressArticleInSummary: <set to suppress showing the article name in the edit summary, as with attack pages>
+ *   templateName: <string - name of template to use (instead of key name), entry will be omitted from the Templates list.
+ *                  (e.g. use another template but with different block options)>
+ *   useInitialOptions: <when preset is chosen, only change given block options, leave others as they were>
+ *
+ * WARNING: 'anononly' and 'allowusertalk' are enabled by default.
+ *   To disable, set 'hardblock' and 'disabletalk', respectively
+ */
+Twinkle.block.blockPresetsInfo = {
+	'anonblock' : {
+		expiry: '31 hours',
+		forAnonOnly: true,
+		nocreate: true,
+		reason: '{{anonblock}}',
+		sig: '~~~~'
+	},
+	'anonblock - school' : {
+		expiry: '36 hours',
+		forAnonOnly: true,
+		nocreate: true,
+		reason: '{{anonblock}} <!-- Likely a school based on behavioral evidence -->',
+		templateName: 'anonblock',
+		sig: '~~~~'
+	},
+	'blocked proxy' : {
+		expiry: '1 year',
+		forAnonOnly: true,
+		nocreate: true,
+		reason: '{{blocked proxy}}',
+		sig: null
+	},
+	'blocked talk-revoked-notice' : {
+		disabletalk: true,
+		reason: 'Revoking talk page access: inappropriate use of user talk page while blocked',
+		prependReason: true,
+		summary: 'Your user talk page access has been disabled',
+		useInitialOptions: true
+	},
+	'CheckUser block' : {
+		reason: '{{CheckUser block}}',
+		sig: '~~~~'
+	},
+	'checkuserblock-account' : {
+		reason: '{{checkuserblock-account}}',
+		sig: '~~~~'
+	},
+	'checkuserblock-wide' : {
+		reason: '{{checkuserblock-wide}}',
+		sig: '~~~~'
+	},
+	'colocationwebhost' : {
+		expiry: '1 year',
+		forAnonOnly: true,
+		reason: '{{colocationwebhost}}',
+		sig: null
+	},
+	'oversightblock' : {
+		reason: '{{OversightBlock}}',
+		sig: '~~~~'
+	},
+	'school block' : {
+		forAnonOnly: true,
+		nocreate: true,
+		reason: '{{school block}}',
+		sig: '~~~~'
+	},
+	// Placeholder for when we add support for rangeblocks
+	// 'rangeblock' : {
+	//   reason: '{{rangeblock}}',
+	//   nocreate: true,
+	//   forAnonOnly: true,
+	//   sig: '~~~~'
+	// },
+	'tor' : {
+		expiry: '1 year',
+		forAnonOnly: true,
+		reason: '{{Tor}}',
+		sig: null
+	},
+	'webhostblock' : {
+		expiry: '1 year',
+		forAnonOnly: true,
+		reason: '{{webhostblock}}',
+		sig: null
+	},
+	// uw-prefixed
+	'uw-3block' : {
+		autoblock: true,
+		expiry: '24 hours',
+		nocreate: true,
+		pageParam: true,
+		reason: 'Violation of the [[WP:Three-revert rule|three-revert rule]]',
+		summary: 'You have been blocked from editing for violation of the [[WP:3RR|three-revert rule]]'
+	},
+	'uw-ablock' : {
+		autoblock: true,
+		expiry: '31 hours',
+		forAnonOnly: true,
+		nocreate: true,
+		pageParam: true,
+		reasonParam: true,
+		summary: 'Your IP address has been blocked from editing',
+		suppressArticleInSummary: true
+	},
+	'uw-adblock' : {
+		autoblock: true,
+		nocreate: true,
+		pageParam: true,
+		reason: 'Using Wikipedia for [[WP:Spam|spam]] or [[WP:NOTADVERTISING|advertising]] purposes',
+		summary: 'You have been blocked from editing for [[WP:SOAP|advertising or self-promotion]]'
+	},
+	'uw-aeblock' : {
+		autoblock: true,
+		nocreate: true,
+		pageParam: true,
+		reason: '[[WP:Arbitration enforcement|Arbitration enforcement]]',
+		reasonParam: true,
+		summary: 'You have been blocked from editing for violating an [[WP:Arbitration|arbitration decision]] with your edits'
+	},
+	'uw-aoablock' : {
+		autoblock: true,
+		forRegisteredOnly: true,
+		nocreate: true,
+		reason: '[[WP:No personal attacks|Personal attacks]] or [[WP:Harassment|harassment]]',
+		summary: 'You have been block from editing for making [[WP:NPA|personal attacks]] toward other users'
+	},
+	'uw-bioblock' : {
+		autoblock: true,
+		nocreate: true,
+		pageParam: true,
+		reason: 'Violations of the [[WP:Biographies of living persons|biographies of living persons]] policy',
+		summary: 'You have been blocked from editing for violations of Wikipedia\'s [[WP:BLP|biographies of living persons policy]]'
+	},
+	'uw-block' : {
+		autoblock: true,
+		expiry: '24 hours',
+		forRegisteredOnly: true,
+		nocreate: true,
+		pageParam: true,
+		reasonParam: true,
+		summary: 'You have been blocked from editing',
+		suppressArticleInSummary: true
+	},
+	'uw-blockindef' : {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		pageParam: true,
+		reasonParam: true,
+		summary: 'You have been indefinitely blocked from editing',
+		suppressArticleInSummary: true
+	},
+	'uw-blocknotalk' : {
+		disabletalk: true,
+		pageParam: true,
+		reasonParam: true,
+		summary: 'You have been blocked from editing and your user talk page access has been disabled',
+		suppressArticleInSummary: true
+	},
+	'uw-botblock': {
+		forRegisteredOnly: true,
+		pageParam: true,
+		reason: 'Running a [[WP:BOT|bot script]] without [[WP:BRFA|approval]]',
+		summary: 'You have been blocked from editing because it appears you are running a [[WP:BOT|bot script]] without [[WP:BRFA|approval]]'
+	},
+	'uw-botublock': {
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		reason: '{{uw-botublock}} <!-- Username implies a bot, soft block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] indicates this is a [[WP:BOT|bot]] account, which is currently not approved'
+	},
+	'uw-causeblock' : {
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		reason: '{{uw-causeblock}} <!-- Username represents a non-profit, soft block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] gives the impression that the account represents a group, organization or website'
+	},
+	'uw-compblock': {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		reason: 'Compromised account',
+		summary: 'You have been indefinitely blocked from editing because it is believed that your [[WP:SECURE|account has been compromised]]'
+	},
+	'uw-copyrightblock' : {
+		autoblock: true,
+		expiry: '24 hours',
+		nocreate: true,
+		pageParam: true,
+		reason: '[[WP:Copyright violations|Copyright violations]]',
+		summary: 'You have been blocked from editing for continued [[WP:COPYVIO|copyright infringement]]'
+	},
+	'uw-dblock': {
+		autoblock: true,
+		nocreate: true,
+		reason: 'Persistent removal of content',
+		pageParam: true,
+		summary: 'You have been blocked from editing for continued [[WP:VAND|removal of material]]'
+	},
+	'uw-disruptblock' : {
+		autoblock: true,
+		nocreate: true,
+		reason: '[[WP:Disruptive editing|Disruptive editing]]',
+		summary: 'You have been blocked from editing for [[WP:DE|disruptive editing]]'
+	},
+	'uw-efblock' : {
+		autoblock: true,
+		nocreate: true,
+		reason: 'Deliberately triggering the [[WP:Edit filter|Edit filter]]',
+		summary: 'You have been blocked from editing for making disruptive edits that repeatedly triggered the [[WP:EF|edit filter]]'
+	},
+	'uw-ewblock' : {
+		autoblock: true,
+		expiry: '24 hours',
+		nocreate: true,
+		reason: '[[WP:Edit warring|Edit warring]]',
+		summary: 'You have been blocked from editing to prevent further [[WP:DE|disruption]] caused by your engagement in an [[WP:EW|edit war]]'
+	},
+	'uw-hblock' : {
+		autoblock: true,
+		nocreate: true,
+		pageParam: true,
+		reason: '[[WP:No personal attacks|Personal attacks]] or [[WP:Harassment|harassment]]',
+		summary: 'You have been blocked from editing for attempting to [[WP:HARASS|harass]] other users'
+	},
+	'uw-ipevadeblock' : {
+		forAnonOnly: true,
+		nocreate: true,
+		reason: '[[WP:Blocking policy#Evasion of blocks|Block evasion]]',
+		summary: 'Your IP address has been blocked from editing because it has been used to [[WP:EVADE|evade a previous block]]'
+	},
+	'uw-lblock' : {
+		autoblock: true,
+		nocreate: true,
+		reason: 'Making [[WP:No legal threats|legal threats]]',
+		summary: 'You have been blocked from editing for making [[WP:NLT|legal threats or taking legal action]]'
+	},
+	'uw-memorialblock': {
+		forRegisteredOnly: true,
+		expiry: 'infinity',
+		reason: '{{uw-memorialblock}} <!-- Username indicates tribute to someone, soft block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] indicates this account may be used as a memorial or tribute to someone'
+	},
+	'uw-myblock': {
+		autoblock: true,
+		nocreate: true,
+		pageParam: true,
+		reason: 'Using Wikipedia as a [[WP:NOTMYSPACE|blog, web host, social networking site or forum]]',
+		summary: 'You have been blocked from editing for using user and/or article pages as a [[WP:NOTMYSPACE|blog, web host, social networking site or forum]]'
+	},
+	'uw-nothereblock' : {
+		autoblock: true,
+		expiry: 'infinity',
+		nocreate: true,
+		reason: 'Clearly [[WP:NOTHERE|not here to contribute to the encyclopedia]]',
+		forRegisteredOnly: true,
+		summary: 'You have been indefinitely blocked from editing because it appears that you are not here to [[WP:NOTHERE|build an encyclopedia]]'
+	},
+	'uw-npblock' : {
+		autoblock: true,
+		nocreate: true,
+		pageParam: true,
+		reason: 'Creating [[WP:Patent nonsense|patent nonsense]] or other inappropriate pages',
+		summary: 'You have been blocked from editing for creating [[WP:PN|nonsense pages]]'
+	},
+	'uw-sblock' : {
+		autoblock: true,
+		nocreate: true,
+		reason: 'Using Wikipedia for [[WP:SPAM|spam]] purposes',
+		summary: 'You have been blocked from editing for using Wikipedia for [[WP:SPAM|spam]] purposes'
+	},
+	'uw-soablock' : {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		pageParam: true,
+		reason: '[[WP:Spam|Spam]] / [[WP:NOTADVERTISING|advertising]]-only account',
+		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam, advertising, or promotion]]'
+	},
+	'uw-softerblock' : {
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		reason: '{{uw-softerblock}} <!-- Promotional username, soft block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] gives the impression that the account represents a group, organization or website'
+	},
+	'uw-spamublock' : {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		reason: '{{uw-spamublock}} <!-- Promotional username, promotional edits -->',
+		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] and your username is a violation of the [[WP:U|username policy]]'
+	},
+	'uw-spoablock' : {
+		autoblock: true,
+		nocreate: true,
+		reason: 'Abusing [[WP:Sock puppetry|multiple accounts]]',
+		summary: 'You have been blocked from editing for abusing [[WP:SOCK|multiple accounts]]'
+	},
+	'uw-ublock' : {
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		reason: '{{uw-ublock}} <!-- Username violation, soft block -->',
+		reasonParam: true,
+		summary: 'You have been indefinitely blocked from editing because your username is a violation of the [[WP:U|username policy]]'
+	},
+	'uw-ublock-double': {
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		reason: '{{uw-ublock-double}} <!-- Username closely resembles another user, soft block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] is too similar to the username of another Wikipedia user'
+	},
+	'uw-uhblock' : {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		reason: '{{uw-uhblock}} <!-- Username violation, hard block -->',
+		reasonParam: true,
+		summary: 'You have been indefinitely blocked from editing because your username is a blatant violation of the [[WP:U|username policy]]'
+	},
+	'uw-ublock-famous' : {
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		reason: '{{uw-ublock-famous}} <!-- Username represents a famous person, soft block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] matches the name of a well-known living individual'
+	},
+	'uw-uhblock-double': {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		reason: '{{uw-ublock-double}} <!-- Username closely resembles another user, hard block -->',
+		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] appears to impersonate another established Wikipedia user'
+	},
+	'uw-vaublock' : {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		pageParam: true,
+		reason: '{{uw-vaublock}} <!-- Username violation, vandalism-only account -->',
+		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:VOA|used only for vandalism]] and your username is a blatant violation of the [[WP:U|username policy]]'
+	},
+	'uw-vblock' : {
+		autoblock: true,
+		expiry: '31 hours',
+		nocreate: true,
+		pageParam: true,
+		reason: '[[WP:Vandalism|Vandalism]]',
+		summary: 'You have been blocked from editing for persistent [[WP:VAND|vandalism]]'
+	},
+	'uw-voablock' : {
+		autoblock: true,
+		expiry: 'infinity',
+		forRegisteredOnly: true,
+		nocreate: true,
+		pageParam: true,
+		reason: '[[WP:Vandalism-only account|Vandalism-only account]]',
+		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:VOA|used only for vandalism]]'
+	}
+};
+
+Twinkle.block.transformBlockPresets = function twinkleblockTransformBlockPresets() {
+	// supply sensible defaults
+	$.each(Twinkle.block.blockPresetsInfo, function(preset, settings) {
+		settings.summary = settings.summary || settings.reason;
+		settings.expiry = settings.expiry || '31 hours';
+		settings.sig = settings.sig !== undefined ? settings.sig : 'yes';
+		// despite this it's preferred that you use 'infinity' as the value for expiry
+		settings.indefinite = settings.indefinite || settings.expiry === 'infinity' || settings.expiry === 'indefinite' || settings.expiry === 'never';
+		Twinkle.block.blockPresetsInfo[preset] = settings;
+	});
+};
+
+Twinkle.block.blockGroups = [
+	{
+		label: 'Common block reasons',
+		list: [
+			{ label: 'anonblock', value: 'anonblock' },
+			{ label: 'anonblock - likely a school', value: 'anonblock - school' },
+			{ label: 'school block', value: 'school block' },
+			{ label: 'Generic block (custom reason)', value: 'uw-block' },
+			{ label: 'Generic block (custom reason) – IP', value: 'uw-ablock' },
+			{ label: 'Generic block (custom reason) – indefinite', value: 'uw-blockindef' },
+			{ label: 'Not here to contribute to the encyclopedia', value: 'uw-nothereblock' },
+			{ label: 'Vandalism', value: 'uw-vblock' },
+			{ label: 'Vandalism-only account', value: 'uw-voablock' }
+		],
+	},
+	{
+		label: 'Extended reasons',
+		list: [
+			{ label: 'Advertising', value: 'uw-adblock' },
+			{ label: 'Arbitration enforcement', value: 'uw-aeblock' },
+			{ label: 'Block evasion – IP', value: 'uw-ipevadeblock' },
+			{ label: 'BLP violations', value: 'uw-bioblock' },
+			{ label: 'Copyright violations', value: 'uw-copyrightblock' },
+			{ label: 'Creating inappropriate pages', value: 'uw-npblock' },
+			{ label: 'Disruptive editing', value: 'uw-disruptblock' },
+			{ label: 'Edit filter-related', value: 'uw-efblock' },
+			{ label: 'Edit warring', value: 'uw-ewblock' },
+			{ label: 'Generic block with talk page access revoked', value: 'uw-blocknotalk' },
+			{ label: 'Harassment', value: 'uw-hblock' },
+			{ label: 'Inappropriate use of user talk page while blocked', value: 'blocked talk-revoked-notice' },
+			{ label: 'Legal threats', value: 'uw-lblock' },
+			{ label: 'Personal attacks or harassment', value: 'uw-aoablock' },
+			{ label: 'Possible comprimised account', value: 'uw-compblock' },
+			{ label: 'Removal of content', value: 'uw-dblock' },
+			{ label: 'Sockpuppetry', value: 'uw-spoablock' },
+			{ label: 'Social networking', value: 'uw-myblock' },
+			{ label: 'Spam', value: 'uw-sblock' },
+			{ label: 'Spam/advertising-only account', value: 'uw-soablock' },
+			{ label: 'Unapproved bot', value: 'uw-botblock' },
+			{ label: 'Violating the three-revert rule', value: 'uw-3block' }
+		]
+	},
+	{
+		label: 'Username violations',
+		list: [
+			{ label: 'Bot username', value: 'uw-botublock' },
+			{ label: 'Memorial username soft block', value: 'uw-memorialblock' },
+			{ label: 'Promotional username, hard block', value: 'uw-spamublock' },
+			{ label: 'Promotional username, soft block', value: 'uw-softerblock' },
+			{ label: 'Similar username soft block', value: 'uw-ublock-double' },
+			{ label: 'Username violation, soft block', value: 'uw-ublock' },
+			{ label: 'Username violation, hard block', value: 'uw-uhblock' },
+			{ label: 'Username impersonation hard block', value: 'uw-uhblock-double' },
+			{ label: 'Username represents a famous person, soft block', value: 'uw-ublock-famous' },
+			{ label: 'Username represents a non-profit, soft block', value: 'uw-causeblock' },
+			{ label: 'Username violation, vandalism-only account', value: 'uw-vaublock' }
+		]
+	},
+	{
+		label: 'Templated reasons',
+		list: [
+			{ label: 'blocked proxy', value: 'blocked proxy' },
+			{ label: 'CheckUser block', value: 'CheckUser block' },
+			{ label: 'checkuserblock-account', value: 'checkuserblock-account' },
+			{ label: 'checkuserblock-wide', value: 'checkuserblock-wide' },
+			{ label: 'colocationwebhost', value: 'colocationwebhost' },
+			{ label: 'oversightblock', value: 'oversightblock' },
+			// { label: 'rangeblock', value: 'rangeblock' }, // placeholder for when we add support for rangeblocks
+			{ label: 'tor', value: 'tor' },
+			{ label: 'webhostblock', value: 'webhostblock' }
+		]
+	}
+];
+
+Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilteredBlockGroups(show_template) {
+	return $.map(Twinkle.block.blockGroups, function(blockGroup) {
+		var list = $.map(blockGroup.list, function(blockPreset) {
+				var blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
+				var registrationRestrict = blockSettings.forRegisteredOnly ? Twinkle.block.isRegistered : (blockSettings.forAnonOnly ? !Twinkle.block.isRegistered : true);
+				if (!(blockSettings.templateName && show_template) && registrationRestrict) {
+					var templateName = blockSettings.templateName || blockPreset.value;
+					return {
+						label: (show_template ? '{{' + templateName + '}}: ' : '') + blockPreset.label,
+						value: blockPreset.value,
+						data: [{
+							name: 'template-name',
+							value: templateName
+						}]
+					};
+				}
+			});
+		if (list.length) return {
+				label: blockGroup.label,
+				list: list
+			};
+	});
+};
+
+Twinkle.block.callback.change_preset = function twinkleblockCallbackChangePreset(e) {
+	var key = e.target.form.preset.value;
+	if (!key) return;
+
+	e.target.form.template.value = Twinkle.block.blockPresetsInfo[key].templateName || key;
+	Twinkle.block.callback.update_form(e, Twinkle.block.blockPresetsInfo[key]);
+	Twinkle.block.callback.change_template(e);
+};
+
+Twinkle.block.callback.change_expiry = function twinkleblockCallbackChangeExpiry(e) {
+	var expiry = e.target.form.expiry;
+	if (e.target.value === 'custom') {
+		Morebits.quickForm.setElementVisibility(expiry.parentNode, true);
+	} else {
+		Morebits.quickForm.setElementVisibility(expiry.parentNode, false);
+		expiry.value = e.target.value;
+	}
+};
+
+Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, data) {
+	var form = e.target.form, expiry_preset = form.expiry_preset,
+		expiry = data.expiry;
+
+	// don't override original expiry if useInitialOptions is set
+	if (!data.useInitialOptions) {
+		if (Date.parse(expiry)) {
+			expiry = new Date(expiry).toGMTString();
+			form.expiry_preset.value = 'custom';
+		} else {
+			form.expiry_preset.value = data.expiry || 'custom';
+		}
+
+		form.expiry.value = expiry;
+		if (form.expiry_preset.value === 'custom') {
+			Morebits.quickForm.setElementVisibility(form.expiry.parentNode, true);
+		} else {
+			Morebits.quickForm.setElementVisibility(form.expiry.parentNode, false);
+		}
+	}
+
+	// boolean-flipped options, more at [[mw:API:Block]]
+	data.disabletalk = data.disabletalk !== undefined ? data.disabletalk : false;
+	data.hardblock = data.hardblock !== undefined ? data.hardblock : false;
+
+	$(form.field_block_options).find(':checkbox').each(function(i, el) {
+		// don't override original options if useInitialOptions is set
+		if (data.useInitialOptions && data[el.name] === undefined) return;
+		var check = data[el.name] === '' || !!data[el.name];
+		$(el).prop('checked', check);
+	});
+
+	if (data.prependReason && data.reason) {
+		form.reason.value = data.reason + '; ' + form.reason.value;
+	} else {
+		form.reason.value = data.reason || '';
+	}
+};
+
+Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
+	var form = e.target.form, value = form.template.value;
+
+	if (!$(form).find('[name=actiontype][value=block]').is(':checked')) {
+		if( Twinkle.block.blockPresetsInfo[value].indefinite ) {
+			if(Twinkle.block.prev_template_expiry === null) {
+				Twinkle.block.prev_template_expiry = form.template_expiry.value || '';
+			}
+			form.template_expiry.parentNode.style.display = 'none';
+			form.template_expiry.value = 'indefinite';
+		} else if( form.template_expiry.parentNode.style.display === 'none' ) {
+			if(Twinkle.block.prev_template_expiry !== null) {
+				form.template_expiry.value = Twinkle.block.prev_template_expiry;
+				Twinkle.block.prev_template_expiry = null;
+			}
+			form.template_expiry.parentNode.style.display = 'block';
+		}
+		if (Twinkle.block.prev_template_expiry) form.expiry.value = Twinkle.block.prev_template_expiry;
+	}
+
+	Morebits.quickForm.setElementVisibility(form.article.parentNode, !!Twinkle.block.blockPresetsInfo[value].pageParam);
+	Morebits.quickForm.setElementVisibility(form.block_reason.parentNode, !!Twinkle.block.blockPresetsInfo[value].reasonParam);
+
+	e.target.form.root.previewer.closePreview();
+};
+Twinkle.block.prev_template_expiry = null;
+Twinkle.block.prev_block_reason = null;
+Twinkle.block.prev_article = null;
+Twinkle.block.prev_reason = null;
+
+Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
+	var templatename = form.template.value,
+		linkedarticle = form.article.value,
+		expiry = form.template_expiry ? form.template_expiry.value : form.expiry.value,
+		isIndefinite = !!(/indef|infinity|never|\*|max/).exec( expiry );
+
+	var templatetext = Twinkle.block.callback.getBlockNoticeWikitext(templatename, linkedarticle, expiry, form.block_reason.value, isIndefinite);
+
+	form.previewer.beginRender(templatetext);
+};
+
+Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
+	var $form = $(e.target),
+		toBlock = $form.find('[name=actiontype][value=block]').is(':checked'),
+
+		toWarn = $form.find('[name=actiontype][value=template]').is(':checked'),
+		blockoptions = {}, templateoptions = {};
+
+	Twinkle.block.callback.saveFieldset($form.find('[name=field_block_options]'));
+	Twinkle.block.callback.saveFieldset($form.find('[name=field_template_options]'));
+
+	blockoptions = Twinkle.block.field_block_options;
+
+	templateoptions = Twinkle.block.field_template_options;
+	delete blockoptions.expiry_preset; // remove extraneous
+
+	// use block settings as warn options where not supplied
+	templateoptions.summary = templateoptions.summary || blockoptions.reason;
+	templateoptions.expiry = templateoptions.template_expiry || blockoptions.expiry;
+
+	if (toBlock) {
+		if (!blockoptions.expiry) return alert('Please provide an expiry!');
+		if (!blockoptions.reason) return alert('Please provide a reason for the block!');
+
+		Morebits.simpleWindow.setButtonsEnabled( false );
+		Morebits.status.init( e.target );
+		var statusElement = new Morebits.status('Executing block');
+		blockoptions.action = 'block';
+		blockoptions.user = mw.config.get('wgRelevantUserName');
+
+		// boolean-flipped options
+		blockoptions.anononly = blockoptions.hardblock ? undefined : true;
+		blockoptions.allowusertalk = blockoptions.disabletalk ? undefined : true;
+
+		// fix for bug with block API, see [[phab:T68646]]
+		if (blockoptions.expiry === 'infinity') blockoptions.expiry = 'infinite';
+
+		// execute block
+		api.getToken('block').then(function(token) {
+			statusElement.status('Processing...');
+			blockoptions.token = token;
+			var mbApi = new Morebits.wiki.api( 'Executing block', blockoptions, function(data) {
+				statusElement.info('Completed');
+				if (toWarn) Twinkle.block.callback.warn_user(templateoptions);
+			});
+			mbApi.post();
+		}, function() {
+			statusElement.error('Unable to fetch block token');
+		});
+	} else if (toWarn) {
+		Morebits.simpleWindow.setButtonsEnabled( false );
+
+		Morebits.status.init( e.target );
+		Twinkle.block.callback.warn_user(templateoptions);
+	} else {
+		return alert('Please give Twinkle something to do!');
+	}
+};
+
+Twinkle.block.callback.warn_user = function twinkleblockCallbackWarnUser(formData) {
+	var userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
+
+	var params = $.extend(formData, {
+		messageData: Twinkle.block.blockPresetsInfo[formData.template]
+	});
+
+	Morebits.wiki.actionCompleted.redirect = userTalkPage;
+	Morebits.wiki.actionCompleted.notice = 'Actions complete, loading user talk page in a few seconds';
+
+	var wikipedia_page = new Morebits.wiki.page( userTalkPage, 'User talk page modification' );
+	wikipedia_page.setCallbackParameters( params );
+	wikipedia_page.setFollowRedirect( true );
+	wikipedia_page.load( Twinkle.block.callback.main );
+};
+
+Twinkle.block.callback.getBlockNoticeWikitext = function(templateName, article, blockTime, blockReason, isIndefinite) {
+	var text = '{{subst:' + templateName, settings = Twinkle.block.blockPresetsInfo[templateName];
+
+	if (article && settings.pageParam) text += '|page=' + article;
+
+	if (!/te?mp|^\s*$|min/.exec(blockTime)) {
+		if (isIndefinite) {
+			text += '|indef=yes';
+		} else {
+			text += '|time=' + blockTime;
+		}
+	}
+
+	if (blockReason) text += '|reason=' + blockReason;
+	if (settings.sig) text += '|sig=' + settings.sig;
+
+	return text + '}}';
+};
+
+Twinkle.block.callback.main = function twinkleblockcallbackMain( pageobj ) {
+	var text = pageobj.getPageText(),
+		params = pageobj.getCallbackParameters(),
+		messageData = params.messageData,
+		date = new Date();
+
+	var dateHeaderRegex = new RegExp( '^==+\\s*(?:' + date.getUTCMonthName() + '|' + date.getUTCMonthNameAbbrev() +
+		')\\s+' + date.getUTCFullYear() + '\\s*==+', 'mg' );
+	var dateHeaderRegexLast, dateHeaderRegexResult;
+	while ((dateHeaderRegexLast = dateHeaderRegex.exec( text )) !== null) {
+		dateHeaderRegexResult = dateHeaderRegexLast;
+	}
+	// If dateHeaderRegexResult is null then lastHeaderIndex is never checked. If it is not null but
+	// \n== is not found, then the date header must be at the very start of the page. lastIndexOf
+	// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
+	var lastHeaderIndex = text.lastIndexOf( '\n==' ) + 1;
+
+	if( text.length > 0 ) {
+		text += '\n\n';
+	}
+
+	var isIndefinite = !!(/indef|infinity|never|\*|max/).exec( params.expiry );
+
+	if( Twinkle.getPref('blankTalkpageOnIndefBlock') && params.template !== 'uw-lblock' && isIndefinite ) {
+		Morebits.status.info( 'Info', 'Blanking talk page per preferences and creating a new level 2 heading for the date' );
+		text = '== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ==\n';
+	} else if( !dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex ) {
+		Morebits.status.info( 'Info', 'Will create a new level 2 heading for the date, as none was found for this month' );
+		text += '== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ==\n';
+	}
+
+	text += Twinkle.block.callback.getBlockNoticeWikitext(params.template, params.article, params.expiry, params.block_reason, isIndefinite);
+
+	// build the edit summary
+	var summary = messageData.summary;
+	if ( messageData.suppressArticleInSummary !== true && params.article ) {
+		summary += ' on [[' + params.article + ']]';
+	}
+	summary += '.' + Twinkle.getPref('summaryAd');
+
+	pageobj.setPageText( text );
+	pageobj.setEditSummary( summary );
+	pageobj.setWatchlist( Twinkle.getPref('watchWarnings') );
+	pageobj.save();
+};
+
+})(jQuery);
+
+//</nowiki>

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -8,8 +8,8 @@
  ****************************************
  *** twinkleconfig.js: Preferences module
  ****************************************
- * Mode of invocation:     Adds configuration form to Wikipedia:Twinkle/Preferences and user 
-                           subpages named "/Twinkle preferences", and adds ad box to the top of user 
+ * Mode of invocation:     Adds configuration form to Wikipedia:Twinkle/Preferences and user
+                           subpages named "/Twinkle preferences", and adds ad box to the top of user
                            subpages belonging to the currently logged-in user which end in '.js'
  * Active on:              What I just said.  Yeah.
  * Config directives in:   TwinkleConfig
@@ -214,6 +214,21 @@ Twinkle.config.sections = [
 			label: "Add sockpuppet report pages to watchlist",
 			type: "enum",
 			enumValues: Twinkle.config.commonEnums.watchlist
+		}
+	]
+},
+
+{
+	title: "Block user",
+	adminOnly: true,
+	preferences: [
+		// TwinkleConfig.blankTalkpageOnIndefBlock (boolean)
+		// if true, blank the talk page when issuing an indef block notice (per [[WP:UW#Indefinitely blocked users]])
+		{
+			name: "blankTalkpageOnIndefBlock",
+			label: "Blank the talk page when indefinitely blocking users",
+			helptip: "See <a href=\"" + mw.util.getUrl("WP:UW#Indefinitely blocked users") + "\">WP:UW</a> for more information.",
+			type: "boolean"
 		}
 	]
 },
@@ -633,15 +648,6 @@ Twinkle.config.sections = [
 			type: "boolean"
 		},
 
-		// TwinkleConfig.blankTalkpageOnIndefBlock (boolean)
-		// if true, blank the talk page when issuing an indef block notice (per [[WP:UW#Indefinitely blocked users]])
-		{
-			name: "blankTalkpageOnIndefBlock",
-			label: "Blank the talk page when indefinitely blocking users",
-			helptip: "See <a href=\"" + mw.util.getUrl("WP:UW#Indefinitely blocked users") + "\">WP:UW</a> for more information.",
-			adminOnly: true,
-			type: "boolean"
-		},
 		{
 			name: "customWarningList",
 			label: "Custom warning templates to display",

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -70,9 +70,6 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	if( Twinkle.getPref( 'customWarningList' ).length ) {
 		main_group.append( { type: 'option', label: 'Custom warnings', value: 'custom', selected: ( defaultGroup === 9 ) } );
 	}
-	if( Morebits.userIsInGroup( 'sysop' ) ) {
-		main_group.append( { type: 'option', label: 'Blocking', value: 'block', selected: ( defaultGroup === 8 ) } );
-	}
 
 	main_select.append( { type: 'select', name: 'sub_group', event:Twinkle.warn.callback.change_subcategory } ); //Will be empty to begin with.
 
@@ -1156,217 +1153,9 @@ Twinkle.warn.messages = {
 			label: "Using inaccurate or inappropriate edit summaries",
 			summary: "Warning: Using inaccurate or inappropriate edit summaries"
 		}
-	},
-
-
-	block: {
-		"uw-block": {
-			label: "Block",
-			summary: "You have been blocked from editing",
-			pageParam: true,
-			reasonParam: true,  // allows editing of reason for generic templates
-			suppressArticleInSummary: true
-		},
-		"uw-blocknotalk": {
-			label: "Block - talk page disabled",
-			summary: "You have been blocked from editing and your user talk page has been disabled",
-			pageParam: true,
-			reasonParam: true,
-			suppressArticleInSummary: true
-		},
-		"uw-blockindef": {
-			label: "Block - indefinite",
-			summary: "You have been indefinitely blocked from editing",
-			indefinite: true,
-			pageParam: true,
-			reasonParam: true,
-			suppressArticleInSummary: true
-		},
-		"uw-ablock": {
-			label: "Block - IP address",
-			summary: "Your IP address has been blocked from editing",
-			pageParam: true,
-			suppressArticleInSummary: true
-		},
-		"uw-vblock": {
-			label: "Vandalism block",
-			summary: "You have been blocked from editing for persistent [[WP:VAND|vandalism]]",
-			pageParam: true
-		},
-		"uw-voablock": {
-			label: "Vandalism-only account block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your account is being [[WP:VOA|used only for vandalism]]",
-			indefinite: true,
-			pageParam: true
-		},
-		"uw-bioblock": {
-			label: "BLP violations block",
-			summary: "You have been blocked from editing for violations of Wikipedia's [[WP:BLP|biographies of living persons policy]]",
-			pageParam: true
-		},
-		"uw-sblock": {
-			label: "Spam block",
-			summary: "You have been blocked from editing for using Wikipedia for [[WP:SPAM|spam]] purposes"
-		},
-		"uw-adblock": {
-			label: "Advertising block",
-			summary: "You have been blocked from editing for [[WP:SOAP|advertising or self-promotion]]",
-			pageParam: true
-		},
-		"uw-soablock": {
-			label: "Spam/advertising-only account block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam, advertising, or promotion]]",
-			indefinite: true,
-			pageParam: true
-		},
-		"uw-nothereblock": {
-			label: "WP:NOTHERE block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because it appears that you are not here to [[WP:NOTHERE|build an encyclopedia]]",
-			indefinite: true
-		},
-		"uw-npblock": {
-			label: "Creating nonsense pages block",
-			summary: "You have been blocked from editing for creating [[WP:PN|nonsense pages]]",
-			pageParam: true
-		},
-		"uw-copyrightblock": {
-			label: "Copyright violation block",
-			summary: "You have been blocked from editing for continued [[WP:COPYVIO|copyright infringement]]",
-			pageParam: true
-		},
-		"uw-spoablock": {
-			label: "Sockpuppet account block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your account is being used only for [[WP:SOCK|sock puppetry]]",
-			indefinite: true
-		},
-		"uw-ipevadeblock": {
-			label: "Block-evasion block - IP address",
-			summary: "Your IP address has been blocked from editing because it has been used to [[WP:EVADE|evade a previous block]]"
-		},
-		"uw-hblock": {
-			label: "Harassment block",
-			summary: "You have been blocked from editing for attempting to [[WP:HARASS|harass]] other users",
-			pageParam: true
-		},
-		"uw-ewblock": {
-			label: "Edit warring block",
-			summary: "You have been blocked from editing to prevent further [[WP:DE|disruption]] caused by your engagement in an [[WP:EW|edit war]]",
-			pageParam: true
-		},
-		"uw-3block": {
-			label: "Three-revert rule violation block",
-			summary: "You have been blocked from editing for violation of the [[WP:3RR|three-revert rule]]",
-			pageParam: true
-		},
-		"uw-disruptblock": {
-			label: "Disruptive editing block",
-			summary: "You have been blocked from editing for [[WP:DE|disruptive editing]]",
-			pageParam: true
-		},
-		"uw-deoablock": {
-			label: "Disruption/trolling-only account block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your account is being used only for [[WP:DE|trolling, disruption or harassment]]",
-			indefinite: true,
-			pageParam: true
-		},
-		"uw-lblock": {
-			label: "Legal threat block (indefinite)",
-			summary: "You have been indefinitely blocked from editing for making [[WP:NLT|legal threats or taking legal action]]",
-			indefinite: true
-		},
-		"uw-aeblock": {
-			label: "Arbitration enforcement block",
-			summary: "You have been blocked from editing for violating an [[WP:Arbitration|arbitration decision]] with your edits",
-			pageParam: true,
-			reasonParam: true
-		},
-		"uw-efblock": {
-			label: "Edit filter-related block",
-			summary: "You have been blocked from editing for making disruptive edits that repeatedly triggered the [[WP:EF|edit filter]]"
-		},
-		"uw-myblock": {
-			label: "Social networking block",
-			summary: "You have been blocked from editing for using user and/or article pages as a [[WP:NOTMYSPACE|blog, web host, social networking site or forum]]",
-			pageParam: true
-		},
-		"uw-dblock": {
-			label: "Deletion/removal of content block",
-			summary: "You have been blocked from editing for continued [[WP:VAND|removal of material]]",
-			pageParam: true
-		},
-		"uw-compblock": {
-			label: "Possible compromised account block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because it is believed that your [[WP:SECURE|account has been compromised]]",
-			indefinite: true
-		},
-		"uw-botblock": {
-			label: "Unapproved bot block",
-			summary: "You have been blocked from editing because it appears you are running a [[WP:BOT|bot script]] without [[WP:BRFA|approval]]",
-			pageParam: true
-		},
-		"uw-ublock": {
-			label: "Username soft block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your username is a violation of the [[WP:U|username policy]]",
-			indefinite: true,
-			reasonParam: true
-		},
-		"uw-uhblock": {
-			label: "Username hard block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your username is a blatant violation of the [[WP:U|username policy]]",
-			indefinite: true,
-			reasonParam: true
-		},
-		"uw-softerblock": {
-			label: "Promotional username soft block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] gives the impression that the account represents a group, organization or website",
-			indefinite: true
-		},
-		"uw-causeblock": {
-			label: "Promotional username soft block, for charitable causes (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] gives the impression that the account represents a group, organization or website",
-			indefinite: true
-		},
-		"uw-botublock": {
-			label: "Bot username soft block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] indicates this is a [[WP:BOT|bot]] account, which is currently not approved",
-			indefinite: true
-		},
-		"uw-memorialblock": {
-			label: "Memorial username soft block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] indicates this account may be used as a memorial or tribute to someone",
-			indefinite: true
-		},
-		"uw-ublock-famous": {
-			label: "Famous username soft block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] matches the name of a well-known living individual",
-			indefinite: true
-		},
-		"uw-ublock-double": {
-			label: "Similar username soft block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] is too similar to the username of another Wikipedia user",
-			indefinite: true
-		},
-		"uw-uhblock-double": {
-			label: "Username impersonation hard block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your [[WP:U|username]] appears to impersonate another established Wikipedia user",
-			indefinite: true
-		},
-		"uw-vaublock": {
-			label: "Vandalism-only account and username hard block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your account is being [[WP:VOA|used only for vandalism]] and your username is a blatant violation of the [[WP:U|username policy]]",
-			indefinite: true,
-			pageParam: true
-		},
-		"uw-spamublock": {
-			label: "Spam-only account and promotional username hard block (indefinite)",
-			summary: "You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] and your username is a violation of the [[WP:U|username policy]]",
-			indefinite: true
-		}
 	}
 };
 
-Twinkle.warn.prev_block_timer = null;
-Twinkle.warn.prev_block_reason = null;
 Twinkle.warn.prev_article = null;
 Twinkle.warn.prev_reason = null;
 
@@ -1418,7 +1207,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		} );
 	};
 
-	if( value === "singlenotice" || value === "singlewarn" || value === "block" ) {
+	if( value === "singlenotice" || value === "singlewarn" ) {
 		// no categories, just create the options right away
 		createEntries( Twinkle.warn.messages[ value ], sub_group, true );
 	} else if( value === "custom" ) {
@@ -1435,63 +1224,6 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			// create the options
 			createEntries( groupContents, optgroup, false );
 		} );
-	}
-
-	if( value === 'block' ) {
-		// create the block-related fields
-		var more = new Morebits.quickForm.element( { type: 'div', id: 'block_fields' } );
-		more.append( {
-			type: 'input',
-			name: 'block_timer',
-			label: 'Period of blocking: ',
-			tooltip: 'The period the blocking is due for, for example 24 hours, 2 weeks, indefinite etc...'
-		} );
-		more.append( {
-			type: 'input',
-			name: 'block_reason',
-			label: '"You have been blocked for ..." ',
-			tooltip: 'An optional reason, to replace the default generic reason. Only available for the generic block templates.'
-		} );
-		e.target.root.insertBefore( more.render(), e.target.root.lastChild );
-
-		// restore saved values of fields
-		if(Twinkle.warn.prev_block_timer !== null) {
-			e.target.root.block_timer.value = Twinkle.warn.prev_block_timer;
-			Twinkle.warn.prev_block_timer = null;
-		}
-		if(Twinkle.warn.prev_block_reason !== null) {
-			e.target.root.block_reason.value = Twinkle.warn.prev_block_reason;
-			Twinkle.warn.prev_block_reason = null;
-		}
-		if(Twinkle.warn.prev_article === null) {
-			Twinkle.warn.prev_article = e.target.root.article.value;
-		}
-		e.target.root.article.disabled = false;
-
-		$(e.target.root.reason).parent().hide();
-		e.target.root.previewer.closePreview();
-	} else if( e.target.root.block_timer ) {
-		// hide the block-related fields
-		if(!e.target.root.block_timer.disabled && Twinkle.warn.prev_block_timer === null) {
-			Twinkle.warn.prev_block_timer = e.target.root.block_timer.value;
-		}
-		if(!e.target.root.block_reason.disabled && Twinkle.warn.prev_block_reason === null) {
-			Twinkle.warn.prev_block_reason = e.target.root.block_reason.value;
-		}
-
-		// hack to fix something really weird - removed elements seem to somehow keep an association with the form
-		e.target.root.block_reason = null;
-
-		$(e.target.root).find("#block_fields").remove();
-
-		if(e.target.root.article.disabled && Twinkle.warn.prev_article !== null) {
-			e.target.root.article.value = Twinkle.warn.prev_article;
-			Twinkle.warn.prev_article = null;
-		}
-		e.target.root.article.disabled = false;
-
-		$(e.target.root.reason).parent().show();
-		e.target.root.previewer.closePreview();
 	}
 
 	// clear overridden label on article textbox
@@ -1519,48 +1251,6 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 				Twinkle.warn.prev_article = null;
 			}
 			e.target.form.article.notArticle = false;
-		}
-	} else if( main_group === 'block' ) {
-		if( Twinkle.warn.messages.block[value].indefinite ) {
-			if(Twinkle.warn.prev_block_timer === null) {
-				Twinkle.warn.prev_block_timer = e.target.form.block_timer.value;
-			}
-			e.target.form.block_timer.disabled = true;
-			e.target.form.block_timer.value = 'indefinite';
-		} else if( e.target.form.block_timer.disabled ) {
-			if(Twinkle.warn.prev_block_timer !== null) {
-				e.target.form.block_timer.value = Twinkle.warn.prev_block_timer;
-				Twinkle.warn.prev_block_timer = null;
-			}
-			e.target.form.block_timer.disabled = false;
-		}
-
-		if( Twinkle.warn.messages.block[value].pageParam ) {
-			if(Twinkle.warn.prev_article !== null) {
-				e.target.form.article.value = Twinkle.warn.prev_article;
-				Twinkle.warn.prev_article = null;
-			}
-			e.target.form.article.disabled = false;
-		} else if( !e.target.form.article.disabled ) {
-			if(Twinkle.warn.prev_article === null) {
-				Twinkle.warn.prev_article = e.target.form.article.value;
-			}
-			e.target.form.article.disabled = true;
-			e.target.form.article.value = '';
-		}
-
-		if( Twinkle.warn.messages.block[value].reasonParam ) {
-			if(Twinkle.warn.prev_block_reason !== null) {
-				e.target.form.block_reason.value = Twinkle.warn.prev_block_reason;
-				Twinkle.warn.prev_block_reason = null;
-			}
-			e.target.form.block_reason.disabled = false;
-		} else if( !e.target.form.block_reason.disabled ) {
-			if(Twinkle.warn.prev_block_reason === null) {
-				Twinkle.warn.prev_block_reason = e.target.form.block_reason.value;
-			}
-			e.target.form.block_reason.disabled = true;
-			e.target.form.block_reason.value = '';
 		}
 	}
 
@@ -1601,11 +1291,11 @@ Twinkle.warn.callbacks = {
 		var text = "{{subst:" + templateName;
 
 		if (article) {
-			// add linked article for user warnings (non-block templates)
+			// add linked article for user warnings
 			text += '|1=' + article;
 		}
 		if (reason && !isCustom) {
-			// add extra message for non-block templates
+			// add extra message
 			if (templateName === 'uw-csd' || templateName === 'uw-probation' ||
 				templateName === 'uw-userspacenoindex' || templateName === 'uw-userpage') {
 				text += "|3=''" + reason + "''";
@@ -1622,40 +1312,13 @@ Twinkle.warn.callbacks = {
 
 		return text;
 	},
-	getBlockNoticeWikitext: function(templateName, article, blockTime, blockReason, isIndefTemplate) {
-		var text = "{{subst:" + templateName;
-
-		if (article && Twinkle.warn.messages.block[templateName].pageParam) {
-			text += '|page=' + article;
-		}
-
-		if (!/te?mp|^\s*$|min/.exec(blockTime) && !isIndefTemplate) {
-			if (/indef|\*|max/.exec(blockTime)) {
-				text += '|indef=yes';
-			} else {
-				text += '|time=' + blockTime;
-			}
-		}
-
-		if (blockReason) {
-			text += '|reason=' + blockReason;
-		}
-
-		text += "|sig=true}}";
-		return text;
-	},
 	preview: function(form) {
 		var templatename = form.sub_group.value;
 		var linkedarticle = form.article.value;
 		var templatetext;
 
-		if (templatename in Twinkle.warn.messages.block) {
-			templatetext = Twinkle.warn.callbacks.getBlockNoticeWikitext(templatename, linkedarticle, form.block_timer.value,
-				form.block_reason.value, Twinkle.warn.messages.block[templatename].indefinite);
-		} else {
-			templatetext = Twinkle.warn.callbacks.getWarningWikitext(templatename, linkedarticle, 
-				form.reason.value, form.main_group.value === 'custom');
-		}
+		templatetext = Twinkle.warn.callbacks.getWarningWikitext(templatename, linkedarticle,
+			form.reason.value, form.main_group.value === 'custom');
 
 		form.previewer.beginRender(templatetext);
 	},
@@ -1712,32 +1375,20 @@ Twinkle.warn.callbacks = {
 		// If dateHeaderRegexResult is null then lastHeaderIndex is never checked. If it is not null but
 		// \n== is not found, then the date header must be at the very start of the page. lastIndexOf
 		// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
-		var lastHeaderIndex = text.lastIndexOf( "\n==" ) + 1;   
+		var lastHeaderIndex = text.lastIndexOf( "\n==" ) + 1;
 
 		if( text.length > 0 ) {
 			text += "\n\n";
 		}
 
-		if( params.main_group === 'block' ) {
-			if( Twinkle.getPref('blankTalkpageOnIndefBlock') && params.sub_group !== 'uw-lblock' && ( messageData.indefinite || (/indef|\*|max/).exec( params.block_timer ) ) ) {
-				Morebits.status.info( 'Info', 'Blanking talk page per preferences and creating a new level 2 heading for the date' );
-				text = "== " + date.getUTCMonthName() + " " + date.getUTCFullYear() + " ==\n";
-			} else if( !dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex ) {
-				Morebits.status.info( 'Info', 'Will create a new level 2 heading for the date, as none was found for this month' );
-				text += "== " + date.getUTCMonthName() + " " + date.getUTCFullYear() + " ==\n";
-			}
-
-			text += Twinkle.warn.callbacks.getBlockNoticeWikitext(params.sub_group, params.article, params.block_timer, params.reason, messageData.indefinite);
-		} else {
-			if( messageData.heading ) {
-				text += "== " + messageData.heading + " ==\n";
-			} else if( !dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex ) {
-				Morebits.status.info( 'Info', 'Will create a new level 2 heading for the date, as none was found for this month' );
-				text += "== " + date.getUTCMonthName() + " " + date.getUTCFullYear() + " ==\n";
-			}
-			text += Twinkle.warn.callbacks.getWarningWikitext(params.sub_group, params.article, 
-				params.reason, params.main_group === 'custom') + " ~~~~";
+		if( messageData.heading ) {
+			text += "== " + messageData.heading + " ==\n";
+		} else if( !dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex ) {
+			Morebits.status.info( 'Info', 'Will create a new level 2 heading for the date, as none was found for this month' );
+			text += "== " + date.getUTCMonthName() + " " + date.getUTCFullYear() + " ==\n";
 		}
+		text += Twinkle.warn.callbacks.getWarningWikitext(params.sub_group, params.article,
+			params.reason, params.main_group === 'custom') + " ~~~~";
 
 		if ( Twinkle.getPref('showSharedIPNotice') && Morebits.isIPAddress( mw.config.get('wgTitle') ) ) {
 			Morebits.status.info( 'Info', 'Adding a shared IP notice' );
@@ -1805,11 +1456,10 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 
 	// Then, grab all the values provided by the form
 	var params = {
-		reason: e.target.block_reason ? e.target.block_reason.value : e.target.reason.value,
+		reason: e.target.reason.value,
 		main_group: e.target.main_group.value,
 		sub_group: e.target.sub_group.value,
 		article: e.target.article.value,  // .replace( /^(Image|Category):/i, ':$1:' ),  -- apparently no longer needed...
-		block_timer: e.target.block_timer ? e.target.block_timer.value : null,
 		messageData: selectedEl.data("messageData")
 	};
 


### PR DESCRIPTION
Twinkle block module. Blocks, reblocks, issues block templates, but unblocking not yet supported.

The data for block templates was moved from the warn module to the block module, but the warn module is used to actually issue the warning, and also previewing the templates. Also cleaned up some of the code in the warn module, most of it solely for block module integration.

The templates are now grouped together, grouped by popularity / type and sorted alphabetically. Also updated warn module with the durationless blocking templates, and although they are not uw- prefixed or conform to the user warnings wikiproject, they are essential for the blocking module.