### PR TITLE
Block modue bug fixes/requests from feedback, update config

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -350,6 +350,11 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		Morebits.status.warn(relevantUserName + ' is already blocked', 'Submit query to reblock with supplied options');
 		Twinkle.block.callback.update_form(e, Twinkle.block.currentBlockInfo);
 	}
+
+	if ($form.find('[name=actiontype][value=template]').is(':checked')) {
+		// make sure right fields are hidden based on default template
+		Twinkle.block.callback.change_template(e);
+	}
 };
 
 /*
@@ -797,7 +802,7 @@ Twinkle.block.blockGroups = [
 			{ label: 'Inappropriate use of user talk page while blocked', value: 'blocked talk-revoked-notice' },
 			{ label: 'Legal threats', value: 'uw-lblock' },
 			{ label: 'Personal attacks or harassment', value: 'uw-aoablock' },
-			{ label: 'Possible comprimised account', value: 'uw-compblock' },
+			{ label: 'Possible compromised account', value: 'uw-compblock' },
 			{ label: 'Removal of content', value: 'uw-dblock' },
 			{ label: 'Sockpuppetry', value: 'uw-spoablock' },
 			{ label: 'Social networking', value: 'uw-myblock' },
@@ -976,7 +981,6 @@ Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
 Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 	var $form = $(e.target),
 		toBlock = $form.find('[name=actiontype][value=block]').is(':checked'),
-
 		toWarn = $form.find('[name=actiontype][value=template]').is(':checked'),
 		blockoptions = {}, templateoptions = {};
 
@@ -986,6 +990,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 	blockoptions = Twinkle.block.field_block_options;
 
 	templateoptions = Twinkle.block.field_template_options;
+	templateoptions.disabletalk = !!(templateoptions.disabletalk || blockoptions.disabletalk);
 	delete blockoptions.expiry_preset; // remove extraneous
 
 	// use block settings as warn options where not supplied
@@ -1050,9 +1055,10 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 };
 
 Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
-	var text = '{{subst:' + params.template, settings = Twinkle.block.blockPresetsInfo[params.template];
+	var text = '{{', settings = Twinkle.block.blockPresetsInfo[params.template];
 
 	if (!settings.nonstandard) {
+		text += 'subst:'+params.template;
 		if (params.article && settings.pageParam) text += '|page=' + params.article;
 
 		if (!/te?mp|^\s*$|min/.exec(params.expiry)) {
@@ -1065,6 +1071,8 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 
 		if (params.reason) text += '|reason=' + params.reason;
 		if (params.disabletalk) text += '|notalk=yes';
+	} else {
+		text += params.template;
 	}
 
 	if (settings.sig) text += '|sig=' + settings.sig;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -281,6 +281,33 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			tooltip: 'An optional reason, to replace the default generic reason. Only available for the generic block templates.',
 			value: Twinkle.block.field_template_options.block_reason
 		} );
+
+		if ($form.find('[name=actiontype][value=block]').is(':checked')) {
+			field_template_options.append( {
+				type: 'checkbox',
+				name: 'blank_duration',
+				list: [
+					{
+						label: 'Do not include expiry in template',
+						checked: Twinkle.block.field_template_options.blank_duration,
+						tooltip: 'Instead of including the duration, make the block template read \"You have been blocked from editing temporarily for...\"'
+					}
+				]
+			} );
+		} else {
+			field_template_options.append( {
+				type: 'checkbox',
+				name: 'notalk',
+				list: [
+					{
+						label: 'Talk page access disabled',
+						checked: Twinkle.block.field_template_options.notalk,
+						tooltip: 'Use this to make the block template state that the user\'s talk page access has been removed'
+					}
+				]
+			} );
+		}
+
 		var $previewlink = $( '<a id="twinkleblock-preivew-link">Preview</a>' );
 		$previewlink.off('click').on('click', function(){
 			Twinkle.block.callback.preview($form[0]);
@@ -881,16 +908,16 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 };
 
 Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
-	var form = e.target.form, value = form.template.value;
+	var form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
 
 	if (!$(form).find('[name=actiontype][value=block]').is(':checked')) {
-		if( Twinkle.block.blockPresetsInfo[value].indefinite ) {
-			if(Twinkle.block.prev_template_expiry === null) {
+		if (settings.indefinite) {
+			if (Twinkle.block.prev_template_expiry === null) {
 				Twinkle.block.prev_template_expiry = form.template_expiry.value || '';
 			}
 			form.template_expiry.parentNode.style.display = 'none';
 			form.template_expiry.value = 'indefinite';
-		} else if( form.template_expiry.parentNode.style.display === 'none' ) {
+		} else if ( form.template_expiry.parentNode.style.display === 'none' ) {
 			if(Twinkle.block.prev_template_expiry !== null) {
 				form.template_expiry.value = Twinkle.block.prev_template_expiry;
 				Twinkle.block.prev_template_expiry = null;
@@ -898,12 +925,14 @@ Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemp
 			form.template_expiry.parentNode.style.display = 'block';
 		}
 		if (Twinkle.block.prev_template_expiry) form.expiry.value = Twinkle.block.prev_template_expiry;
-	}
+	} else {
+		Morebits.quickForm.setElementVisibility(form.blank_duration.parentNode, !settings.indefinite);
+ 	}
 
-	Morebits.quickForm.setElementVisibility(form.article.parentNode, !!Twinkle.block.blockPresetsInfo[value].pageParam);
-	Morebits.quickForm.setElementVisibility(form.block_reason.parentNode, !!Twinkle.block.blockPresetsInfo[value].reasonParam);
+	Morebits.quickForm.setElementVisibility(form.article.parentNode, !!settings.pageParam);
+	Morebits.quickForm.setElementVisibility(form.block_reason.parentNode, !!settings.reasonParam);
 
-	e.target.form.root.previewer.closePreview();
+	form.root.previewer.closePreview();
 };
 Twinkle.block.prev_template_expiry = null;
 Twinkle.block.prev_block_reason = null;
@@ -911,12 +940,17 @@ Twinkle.block.prev_article = null;
 Twinkle.block.prev_reason = null;
 
 Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
-	var templatename = form.template.value,
-		linkedarticle = form.article.value,
-		expiry = form.template_expiry ? form.template_expiry.value : form.expiry.value,
-		isIndefinite = !!(/indef|infinity|never|\*|max/).exec( expiry );
+	var params = {
+			template: form.template.value,
+			article: form.article.value,
+			expiry: form.template_expiry ? form.template_expiry.value : form.expiry.value,
+			indefinite: !!(/indef|infinity|never|\*|max/).exec( form.template_expiry ? form.template_expiry.value : form.expiry.value ),
+			blank_duration: form.blank_duration ? form.blank_duration.checked : false,
+			disabletalk: form.disabletalk.checked || (form.notalk ? form.notalk.checked : false),
+			reason: form.block_reason.value
+		};
 
-	var templatetext = Twinkle.block.callback.getBlockNoticeWikitext(templatename, linkedarticle, expiry, form.block_reason.value, isIndefinite);
+	var templatetext = Twinkle.block.callback.getBlockNoticeWikitext(params);
 
 	form.previewer.beginRender(templatetext);
 };
@@ -963,7 +997,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			blockoptions.token = token;
 			var mbApi = new Morebits.wiki.api( 'Executing block', blockoptions, function(data) {
 				statusElement.info('Completed');
-				if (toWarn) Twinkle.block.callback.warn_user(templateoptions);
+				if (toWarn) Twinkle.block.callback.issue_template(templateoptions);
 			});
 			mbApi.post();
 		}, function() {
@@ -973,17 +1007,20 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		Morebits.simpleWindow.setButtonsEnabled( false );
 
 		Morebits.status.init( e.target );
-		Twinkle.block.callback.warn_user(templateoptions);
+		Twinkle.block.callback.issue_template(templateoptions);
 	} else {
 		return alert('Please give Twinkle something to do!');
 	}
 };
 
-Twinkle.block.callback.warn_user = function twinkleblockCallbackWarnUser(formData) {
+Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTemplate(formData) {
 	var userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
 	var params = $.extend(formData, {
-		messageData: Twinkle.block.blockPresetsInfo[formData.template]
+		messageData: Twinkle.block.blockPresetsInfo[formData.template],
+		messageData: Twinkle.block.blockPresetsInfo[formData.template],
+		reason: Twinkle.block.field_template_options.block_reason,
+		disabletalk: Twinkle.block.field_template_options.notalk
 	});
 
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
@@ -995,21 +1032,21 @@ Twinkle.block.callback.warn_user = function twinkleblockCallbackWarnUser(formDat
 	wikipedia_page.load( Twinkle.block.callback.main );
 };
 
-Twinkle.block.callback.getBlockNoticeWikitext = function(templateName, article, blockTime, blockReason, isIndefinite) {
-	var text = '{{subst:' + templateName, settings = Twinkle.block.blockPresetsInfo[templateName];
+Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
+	var text = '{{subst:' + params.template, settings = Twinkle.block.blockPresetsInfo[params.template];
 
-	if (article && settings.pageParam) text += '|page=' + article;
+	if (params.article && settings.pageParam) text += '|page=' + params.article;
 
-	if (!/te?mp|^\s*$|min/.exec(blockTime)) {
-		if (isIndefinite) {
+	if (!/te?mp|^\s*$|min/.exec(params.expiry)) {
+		if (params.indefinite) {
 			text += '|indef=yes';
-		} else {
-			text += '|time=' + blockTime;
+		} else if(!params.blank_duration) {
+			text += '|time=' + params.expiry;
 		}
 	}
 
-	if (blockReason) text += '|reason=' + blockReason;
-	if (settings.sig) text += '|sig=' + settings.sig;
+	if (params.reason) text += '|reason=' + params.reason;
+	if (params.disabletalk) text += '|notalk=yes';
 
 	return text + '}}';
 };
@@ -1031,13 +1068,13 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain( pageobj ) {
 	// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
 	var lastHeaderIndex = text.lastIndexOf( '\n==' ) + 1;
 
-	if( text.length > 0 ) {
+	if ( text.length > 0 ) {
 		text += '\n\n';
 	}
 
-	var isIndefinite = !!(/indef|infinity|never|\*|max/).exec( params.expiry );
+	params.indefinite = !!(/indef|infinity|never|\*|max/).exec( params.expiry );
 
-	if( Twinkle.getPref('blankTalkpageOnIndefBlock') && params.template !== 'uw-lblock' && isIndefinite ) {
+	if ( Twinkle.getPref('blankTalkpageOnIndefBlock') && params.template !== 'uw-lblock' && params.indefinite ) {
 		Morebits.status.info( 'Info', 'Blanking talk page per preferences and creating a new level 2 heading for the date' );
 		text = '== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ==\n';
 	} else if( !dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex ) {
@@ -1045,7 +1082,9 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain( pageobj ) {
 		text += '== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ==\n';
 	}
 
-	text += Twinkle.block.callback.getBlockNoticeWikitext(params.template, params.article, params.expiry, params.block_reason, isIndefinite);
+	params.expiry = typeof params.template_expiry !== "undefined" ? params.template_expiry : params.expiry;
+
+	text += Twinkle.block.callback.getBlockNoticeWikitext(params);
 
 	// build the edit summary
 	var summary = messageData.summary;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -260,7 +260,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				name: 'article',
 				display: 'none',
 				label: 'Linked article',
-				value: Twinkle.block.field_template_options.article || ( Morebits.queryString.exists( 'vanarticle' ) ? Morebits.queryString.get( 'vanarticle' ) : '' ),
+				value: '',
 				tooltip: 'An article can be linked within the notice, perhaps if it was the primary target of disruption. Leave empty for no article to be linked.'
 			} );
 		if (!$form.find('[name=actiontype][value=block]').is(':checked')) {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -269,7 +269,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				name: 'template_expiry',
 				display: 'none',
 				label: 'Period of blocking: ',
-				value: Twinkle.block.field_template_options.template_expiry || Twinkle.block.field_block_options.expiry || $form.find('[name=template_expiry]').val() || '',
+				value: '',
 				tooltip: 'The period the blocking is due for, for example 24 hours, 2 weeks, indefinite etc...'
 			} );
 		}

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -625,7 +625,7 @@ Twinkle.config.sections = [
 				"5": "Level 4im",
 				"6": "Single-issue notices",
 				"7": "Single-issue warnings",
-				"8": "Custom warnings"
+				"9": "Custom warnings"
 			}
 		},
 

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -625,8 +625,7 @@ Twinkle.config.sections = [
 				"5": "Level 4im",
 				"6": "Single-issue notices",
 				"7": "Single-issue warnings",
-				"9": "Custom warnings",
-				"8": "Block (admin only)"
+				"8": "Custom warnings"
 			}
 		},
 


### PR DESCRIPTION
This is in response to feedback given at [WP:AN](https://en.wikipedia.org/wiki/Wikipedia:Administrators%27_noticeboard#New_Twinkle_block_module.21). Changes include:

* Don't autofill the article field with the value of the `vanarticle` URL parameter, as this may be less relevant for a block than when issuing a normal warning
* Do not show fields for duration, article, etc. for templates such as `{{anonblock}}` that do not conform to standards outlined by WikiProject User Warnings (as these params will likely not work)
* When issuing only a template, Leave the duration field blank and not supplied with expiry of an existing block
* When issuing only a template, add option to add `notalk=yes` to template
* When blocking and templating, add option to exclude the duration from the template altogether so that it reads "you have been blocked from editing temporarily..."
* When blocking and templating, make it so that `notalk=yes` is added to the block template if "Prevent this user from editing their own talk page while blocked" is checked
* Remove one last remaining reference to the block option in the Warn module from twinkleconfig.js