### PR TITLE
protect: fix bug using stabilizeValues that prevented salting of pages

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -141,11 +141,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				name: 'preset',
 				label: 'Choose a preset:',
 				event: Twinkle.block.callback.change_preset,
-				list: [{
-					label: '',
-					value: '',
-					type: 'option'
-				}].concat(Twinkle.block.callback.filtered_block_groups())
+				list: Twinkle.block.callback.filtered_block_groups()
 			});
 
 		field_block_options = new Morebits.quickForm.element({ type: 'field', label: 'Block options', name: 'field_block_options' });
@@ -352,8 +348,12 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	}
 
 	if ($form.find('[name=actiontype][value=template]').is(':checked')) {
-		// make sure right fields are hidden based on default template
-		Twinkle.block.callback.change_template(e);
+		// make sure all the fields are correct based on defaults
+		if ($form.find('[name=actiontype][value=block]').is(':checked')) {
+			Twinkle.block.callback.change_preset(e);
+		} else {
+			Twinkle.block.callback.change_template(e);
+		}
 	}
 };
 
@@ -516,7 +516,7 @@ Twinkle.block.blockPresetsInfo = {
 		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '[[WP:No personal attacks|Personal attacks]] or [[WP:Harassment|harassment]]',
-		summary: 'You have been block from editing for making [[WP:NPA|personal attacks]] toward other users'
+		summary: 'You have been blocked from editing for making [[WP:NPA|personal attacks]] toward other users'
 	},
 	'uw-bioblock' : {
 		autoblock: true,
@@ -609,6 +609,7 @@ Twinkle.block.blockPresetsInfo = {
 		autoblock: true,
 		expiry: '24 hours',
 		nocreate: true,
+		pageParam: true,
 		reason: '[[WP:Edit warring|Edit warring]]',
 		summary: 'You have been blocked from editing to prevent further [[WP:DE|disruption]] caused by your engagement in an [[WP:EW|edit war]]'
 	},
@@ -770,6 +771,9 @@ Twinkle.block.transformBlockPresets = function twinkleblockTransformBlockPresets
 	});
 };
 
+// These are the groups of presets and defines the order in which they appear. For each list item:
+//   label: <string, the description that will be visible in the dropdown>
+//   value: <string, the key of a preset in blockPresetsInfo>
 Twinkle.block.blockGroups = [
 	{
 		label: 'Common block reasons',
@@ -777,9 +781,10 @@ Twinkle.block.blockGroups = [
 			{ label: 'anonblock', value: 'anonblock' },
 			{ label: 'anonblock - likely a school', value: 'anonblock - school' },
 			{ label: 'school block', value: 'school block' },
-			{ label: 'Generic block (custom reason)', value: 'uw-block' },
-			{ label: 'Generic block (custom reason) – IP', value: 'uw-ablock' },
+			{ label: 'Generic block (custom reason)', value: 'uw-block' }, // ends up being default for registered users
+			{ label: 'Generic block (custom reason) – IP', value: 'uw-ablock', selected: true }, // set only when blocking IP
 			{ label: 'Generic block (custom reason) – indefinite', value: 'uw-blockindef' },
+			{ label: 'Disruptive editing', value: 'uw-disruptblock' },
 			{ label: 'Not here to contribute to the encyclopedia', value: 'uw-nothereblock' },
 			{ label: 'Vandalism', value: 'uw-vblock' },
 			{ label: 'Vandalism-only account', value: 'uw-voablock' }
@@ -794,7 +799,6 @@ Twinkle.block.blockGroups = [
 			{ label: 'BLP violations', value: 'uw-bioblock' },
 			{ label: 'Copyright violations', value: 'uw-copyrightblock' },
 			{ label: 'Creating inappropriate pages', value: 'uw-npblock' },
-			{ label: 'Disruptive editing', value: 'uw-disruptblock' },
 			{ label: 'Edit filter-related', value: 'uw-efblock' },
 			{ label: 'Edit warring', value: 'uw-ewblock' },
 			{ label: 'Generic block with talk page access revoked', value: 'uw-blocknotalk' },
@@ -857,7 +861,8 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 						data: [{
 							name: 'template-name',
 							value: templateName
-						}]
+						}],
+						selected: !!blockPreset.selected
 					};
 				}
 			});


### PR DESCRIPTION
Looks like `form.pclevel` doesn't exist outside `stabalizeIt` when attempting to salt a page. It errors out at `form.pclevel.value`. Since `stablizeValues` is only used within `stabalizeIt` I just moved it there and all seems to work fine. I don't know why this bug affected only salting of pages (protecting nonexistent/deleted pages), and not protecting of existing pages.