### PR TITLE
protect: force default-enabled <noinclude> wrapping of prot template …

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -929,7 +929,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			if( /template/.test( form.category.value ) ) {
 				form.noinclude.checked = true;
 				form.editexpiry.value = form.moveexpiry.value = form.pcexpiry.value = "indefinite";
-			} else {
+			} else if( mw.config.get('wgNamespaceNumber') !== 10 ) {
 				form.noinclude.checked = false;
 			}
 		}


### PR DESCRIPTION
When protecting a template, make sure the option to wrap the protection template with `<noinclude>` is always checked by default, and not just when performing template-protection.

We semi-protect templates a lot, and many of us, including myself (sad face) forget to tick the `<noinclude>` checkbox, and then bad things happen.

The `checked: (mw.config.get('wgNamespaceNumber') === 10)` on line 500 gets overridden in the `changePreset` event handler on line 933