### PR TITLE
Prevent jumping to next section when target section is empty

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1403,9 +1403,9 @@ Twinkle.protect.callbacks = {
 
 		var reg;
 		if ( increase ) {
-			reg = /(\n==\s*Current requests for increase in protection level\s*==\s*\n\s*\{\{[^\}\}]+\}\}\s*\n)([\s\S]*?)\s*(\n==[^=])/;
+			reg = /(\n==\s*Current requests for increase in protection level\s*==\s*\n\s*\{\{[^\}\}]+\}\}\s*?\n)([\s\S]*?)\s*(\n==[^=])/;
 		} else {
-			reg = /(\n==\s*Current requests for reduction in protection level\s*==\s*\n\s*\{\{[^\}\}]+\}\}\s*\n)([\s\S]*?)\s*(\n==[^=])/;
+			reg = /(\n==\s*Current requests for reduction in protection level\s*==\s*\n\s*\{\{[^\}\}]+\}\}\s*?\n)([\s\S]*?)\s*(\n==[^=])/;
 		}
 		var originalTextLength = text.length;
 		text = text.replace( reg, "$1$2\n\n" + newtag + "\n$3");


### PR DESCRIPTION
Multiple reports have been made to WT:TW regarding protection requests being posted in the wrong section. The common thread between all reported cases is that the target section was empty at the time.

According to testing I did on a copy of the RFPP page in Notepad++, the problem was that the regex was consuming both the target section and the following section when the target section was empty. I'm honestly not sure how this fixes the problem, but Notepad++ testing says that it does. I'll just call it black magic and not argue with it. :P