### PR TITLE
Reporting if page has been protected before! And minor morebits.css change

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -151,24 +151,30 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 };
 
 Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectCallbackShowLogAndCurrentProtectInfo() {
+	var currentlyProtected = !$.isEmptyObject(Twinkle.protect.currentProtectionLevels);
+
 	if (Twinkle.protect.hasProtectLog || Twinkle.protect.hasStableLog) {
 		var $linkMarkup = $("<span>");
 
 		if (Twinkle.protect.hasProtectLog)
-			$linkMarkup.append($( '<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'protect'}) + '">protection log</a>' ), '&nbsp;&nbsp;');
+			$linkMarkup.append(
+				$( '<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'protect'}) + '">protection log</a>' ),
+				Twinkle.protect.hasStableLog ? $("<span> &bull; </span>") : null
+			);
 		if (Twinkle.protect.hasStableLog)
-			$linkMarkup.append($( '<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'stable'}) + '">pending changes log</a>)' ), '&nbsp;&nbsp;');
+			$linkMarkup.append($( '<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'stable'}) + '">pending changes log</a>)' ));
 
 		Morebits.status.init($('div[name="hasprotectlog"] span')[0]);
-		Morebits.status.warn('This page has been protected in the past', $linkMarkup[0]);
+		Morebits.status.warn(
+			currentlyProtected ? 'Previous protections' : 'This page has been protected in the past',
+			$linkMarkup[0]
+		);
 	}
 
 	Morebits.status.init($('div[name="currentprot"] span')[0]);
 	var protectionNode = [], statusLevel = 'info';
 
-	if ($.isEmptyObject(Twinkle.protect.currentProtectionLevels)) {
-		protectionNode.push($("<b>no protection</b>")[0]);
-	} else {
+	if (currentlyProtected) {
 		$.each(Twinkle.protect.currentProtectionLevels, function(type, settings) {
 			var label = type === 'stabilize' ? 'Pending Changes' : Morebits.string.toUpperCaseFirstChar(type);
 			protectionNode.push($("<b>" + label + ": " + settings.level + "</b>")[0]);
@@ -180,8 +186,10 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 			if (settings.cascade) {
 				protectionNode.push("(cascading) ");
 			}
-			statusLevel = 'warn';
 		});
+		statusLevel = 'warn';
+	} else {
+		protectionNode.push($("<b>no protection</b>")[0]);
 	}
 
 	Morebits.status[statusLevel]("Current protection level", protectionNode);

--- a/morebits.css
+++ b/morebits.css
@@ -40,7 +40,6 @@ form.quickform
 form.quickform *
 {
 	font-family: sans-serif;
-	vertical-align: middle;
 }
 
 form.quickform fieldset
@@ -283,6 +282,10 @@ body .ui-dialog.morebits-dialog .morebits-dialog-footerlinks a {
 
 .ui-dialog.morebits-dialog a, .ui-dialog.morebits-dialog .ui-widget-content a {
 	color: #0645AD;  /* jQuery imposes a ridiculous nearly-black colour on <a> tags... I don't understand it */
+}
+
+.ui-icon {
+	vertical-align: middle;
 }
 
 .ui-icon-inline {

--- a/morebits.css
+++ b/morebits.css
@@ -65,6 +65,20 @@ form.quickform select
 	margin-left: .2em;
 }
 
+form.quickform input[type=checkbox],
+form.quickform input[type=radio] {
+	height: 13px;
+	margin-bottom: 2px;
+	margin-top: 2px;
+	padding: 0;
+	width: 13px;
+	vertical-align: top;
+}
+
+form.quickform div {
+	line-height: 18px;
+}
+
 form.quickform h5
 {
 	margin: .5em 0 0;
@@ -285,7 +299,7 @@ body .ui-dialog.morebits-dialog .morebits-dialog-footerlinks a {
 }
 
 .ui-icon {
-	vertical-align: middle;
+	vertical-align: -3px;
 }
 
 .ui-icon-inline {


### PR DESCRIPTION
Fairly sizable update to the protect module that could use another set of eyes.

When protecting a page, admins must first check the protection log to make an informed decision on the duration. Just as with the block module, I've made it report if there were prior protection periods, and link to the protection log if there were. Here we also have to do a separate API call to fetch the pending changes log.

Next, I've included the log notice and current protection notice to be visible for all users, not just admins. We often get requests for semi-protection when the page is semi-protected, and the log info is useful for them to decide what duration to request and to explain their rationale. We also want to use meaningful colours to grab the user's attention. For instance, here again, if a page is already protected we want that to be clear so they don't request the same level of protection. So "no protection" appears as green and if there is a current protection the message will appear in red. The log messages are also in red as that is crucial information for the admins. This puts the log/current state colours in line with the block module.

Finally, a minor CSS change. To conditionally include one or two links to the logs (protect or pending changes), I need to use a `<span>` wrapper so I could pass it to Morebits.status. There might be a better way of doing this, not sure, but I noticed with each child span the alignment gets increasingly off. Turns out we've got a `vertical-align:middle` on the text, which I think we only need for inline images which appears to only include the ui-icon. I tested on various modules and multiple browsers and everything looks good.

@atlight mind taking a look? Or any other Twinkle followers? :)