### PR TITLE
Ask if user has contacted protecting admin before requesting unprotection

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,6 +4,7 @@
 	"unused": true,
 	"smarttabs": true,
 	"eqeqeq": true,
+	"curly": true,
 	"noarg": true,
 	"globals": {
 		"mw": false,

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -160,10 +160,10 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 			}
 		});
 
+		Twinkle.protect.hasStableLog = !!stableData[0].query.logevents.length;
+
 		if (page.flagged) {
 			// note that stable settings aren't logged when page is moved, so we don't need to use fetchProtectingAdmin
-			Twinkle.protect.hasStableLog = !!stableData[0].query.logevents.length;
-
 			current.stabilize = {
 				level: page.flagged.protection_level,
 				expiry: page.flagged.protection_expiry,


### PR DESCRIPTION
It is procedural that users ask the protecting admin about unprotection before requesting it at [[WP:RFPP]]. More often than not this does not happen, so per request we're going to try to have Twinkle remind them.

In short: When the protection module is opened, you'll see the current protections as you do normally, but with the name of the protecting admin next to each entry, which links to their talk page. When you attempt to request unprotection you are prompted (with `confirm`) "Have you attempted to contact the protecting admins (MusikAnimal, NeilN) first?"

Some notes:
- If an admin changes _any_ protection settings they appear in the log as the admin responsible for all protection settings. E.g. if NeilN move-protects the page and I semi-protect it, it is not feasible to infer that NeilN did the move protection and not me. I don't think this is a big concern, as the re-protecting admin will have enough insight into why the other protections are there.
- Protection settings can be _moved_ when the page is moved. If the script detects the current protection was moved from a previous page, it will recursively go through the logs to find the original protecting admin. ~~I believe there to be a rock-solid base case and graceful handling of failures so that the recursion won't lock up.~~ Still working on this! Fixed... it now won't check logs that have already been checked. Otherwise it could go into an infinite loop when you protect a page, move it somewhere, then move it back to the original location.
- Pending changes protection have their own log entry, but if moved from a previous page, it does _not_ appear in the logs. This is a MediaWiki bug as far as I can tell, and the workaround to recurse through the page moves to find a pending changes log entry seems initially not worth the effort, but we may revisit it.
- The interface shows the admin who applied the protections, as with "Current protections: Move: (sysop) ... by [link to MusikAnimal's talk page]". We have the sysop name next to each edit/move/create protect entry, even though they will be the same. This is purely for aesthetics, since it looks weird to have it just at the end. I also separated the entries by a bullet for better readability
  - A side note: What about a separate line for each entry, to make it even more readable? Or one line for edit/move/create protections and another for pending changes?
- You are only prompted if you contacted the protecting admin if the script successfully figured out who the protecting admin was

Thoughts? I think this change is less than perfect but still effective, and will be well-received.
