### PR TITLE
Admins delete under multiple rationale, use template-generated delete reasons

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -110,6 +110,9 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 							// enable/disable delete multiple
 							cForm.delmultiple.disabled = cChecked;
 							cForm.delmultiple.checked = false;
+							// enable/disable open talk page checkbox
+							cForm.openusertalk.disabled = cChecked;
+							cForm.openusertalk.checked = false;
 
 							// enable/disable notify checkbox
 							cForm.notify.disabled = !cChecked;
@@ -175,6 +178,18 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 				}
 			]
 		} );
+		form.append( {
+				type: 'checkbox',
+				list: [
+					{
+						label: 'Open user talk page on submit',
+						value: 'openusertalk',
+						name: 'openusertalk',
+						tooltip: 'Use this is override your preferences for the selected rationale',
+						checked : false
+					}
+				]
+			} );
 		form.append( { type: 'header', label: 'Tag-related options' } );
 	}
 
@@ -432,8 +447,21 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 					}
 				];
 			}
+			// FIXME: does this do anything?
 			criterion.event = openSubgroupHandler;
 		}
+
+		criterion.event = function(e) {
+			if (multiple) return;
+			if( isSysop ) {
+				var normalizedCriterion = Twinkle.speedy.normalizeHash[e.target.value];
+				$('[name=openusertalk]').prop('checked',
+						Twinkle.getPref('openUserTalkPageOnSpeedyDelete').indexOf(normalizedCriterion) !== -1
+					);
+			} else {
+				$('[name=openusertalk]').prop('checked', false);
+			}
+		};
 
 		return criterion;
 	});
@@ -1133,7 +1161,7 @@ Twinkle.speedy.callbacks = {
 
 			// look up initial contributor. If prompting user for deletion reason, just display a link.
 			// Otherwise open the talk page directly
-			if( params.openusertalk ) {
+			if( params.openUserTalk ) {
 				thispage.setCallbackParameters( params );
 				thispage.lookupCreator( Twinkle.speedy.callbacks.sysop.openUserTalkPage );
 			}
@@ -1816,7 +1844,7 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 	});
 
 	// analyse each criterion to determine whether to watch the page, prompt for summary, or open user talk page
-	var watchPage, promptForSummary, openUserTalk;
+	var watchPage, promptForSummary;
 	normalizeds.forEach(function(norm) {
 		if (Twinkle.getPref("watchSpeedyPages").indexOf(norm) !== -1) {
 			watchPage = true;
@@ -1824,18 +1852,15 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		if (Twinkle.getPref("promptForSpeedyDeletionSummary").indexOf(norm) !== -1) {
 			promptForSummary = true;
 		}
-		if (Twinkle.getPref('openUserTalkPageOnSpeedyDelete').indexOf(norm) !== -1) {
-			openUserTalk = true;
-		}
 	});
 
 	var params = {
 		values: values,
 		normalizeds: normalizeds,
 		watch: watchPage,
-		openusertalk: openUserTalk,
 		deleteTalkPage: form.talkpage && form.talkpage.checked,
 		deleteRedirects: form.redirects.checked,
+		openUserTalk: form.openusertalk.checked,
 		promptForSummary: promptForSummary,
 		templateParams: Twinkle.speedy.getParameters( form, values )
 	};

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -185,7 +185,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 						label: 'Open user talk page on submit',
 						value: 'openusertalk',
 						name: 'openusertalk',
-						tooltip: 'Use this is override your preferences for the selected rationale',
+						tooltip: 'This defaults to your open-talk-page preferences when deleting pages under the currently selected rationale. It is left unchanged if you choose to delete under multiple criteria.',
 						checked : false
 					}
 				]
@@ -1120,7 +1120,7 @@ Twinkle.speedy.callbacks = {
 		};
 
 		var statusIndicator = new Morebits.status( 'Building deletion summary' );
-		var api = new Morebits.wiki.api( 'Fetching parsing deletion template', query, function(apiObj) {
+		var api = new Morebits.wiki.api( 'Parsing deletion template', query, function(apiObj) {
 				statusIndicator.info( 'complete' );
 				callback(apiObj);
 			},  statusIndicator);
@@ -1864,6 +1864,9 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		promptForSummary: promptForSummary,
 		templateParams: Twinkle.speedy.getParameters( form, values )
 	};
+	if(!params.templateParams) {
+		return;
+	}
 
 	Morebits.simpleWindow.setButtonsEnabled( false );
 	Morebits.status.init( form );

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -451,17 +451,18 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 			criterion.event = openSubgroupHandler;
 		}
 
-		criterion.event = function(e) {
-			if (multiple) return;
-			if( isSysop ) {
+		if ( isSysop ) {
+			var originalEvent = criterion.event;
+			criterion.event = function(e) {
+				if (multiple) return originalEvent(e);
+
 				var normalizedCriterion = Twinkle.speedy.normalizeHash[e.target.value];
 				$('[name=openusertalk]').prop('checked',
 						Twinkle.getPref('openUserTalkPageOnSpeedyDelete').indexOf(normalizedCriterion) !== -1
 					);
-			} else {
-				$('[name=openusertalk]').prop('checked', false);
-			}
-		};
+				return originalEvent(e);
+			};
+		}
 
 		return criterion;
 	});

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -460,7 +460,9 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 				$('[name=openusertalk]').prop('checked',
 						Twinkle.getPref('openUserTalkPageOnSpeedyDelete').indexOf(normalizedCriterion) !== -1
 					);
-				return originalEvent(e);
+				if ( originalEvent ) {
+					return originalEvent(e);
+				}
 			};
 		}
 
@@ -820,7 +822,8 @@ Twinkle.speedy.generalList = [
 			label: 'Page where the deletion discussion took place: ',
 			tooltip: 'Must start with "Wikipedia:"',
 			size: 60
-		}
+		},
+		hideSubgroupWhenMultiple: true
 	},
 	{
 		label: 'G5: Banned or blocked user',
@@ -920,7 +923,8 @@ Twinkle.speedy.generalList = [
 			label: 'Optional explanation: ',
 			tooltip: 'Perhaps linking to where the author requested this deletion.',
 			size: 60
-		}
+		},
+		hideSubgroupWhenSysop: true
 	},
 	{
 		label: 'G8: Pages dependent on a non-existent or deleted page',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1121,9 +1121,14 @@ Twinkle.speedy.callbacks = {
 
 		var statusIndicator = new Morebits.status( 'Building deletion summary' );
 		var api = new Morebits.wiki.api( 'Parsing deletion template', query, function(apiObj) {
-				statusIndicator.info( 'complete' );
-				callback(apiObj);
-			},  statusIndicator);
+				var reason = decodeURIComponent($(apiObj.getXML().querySelector('text').childNodes[0].nodeValue).find('#delete-reason').text()).replace(/\+/g, ' ');
+				if (!reason) {
+					statusIndicator.warn( 'Unable to generate summary from deletion template' );
+				} else {
+					statusIndicator.info( 'complete' );
+				}
+				callback(reason);
+			}, statusIndicator);
 		api.post();
 	},
 
@@ -1136,8 +1141,7 @@ Twinkle.speedy.callbacks = {
 				Twinkle.speedy.callbacks.sysop.deletePage( reason, params );
 			} else {
 				var code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
-				Twinkle.speedy.callbacks.parseWikitext(code, function(apiobj) {
-					reason = decodeURIComponent($(apiobj.getXML().querySelector('text').childNodes[0].nodeValue).find('#delete-reason').text()).replace(/\+/g, ' ');
+				Twinkle.speedy.callbacks.parseWikitext(code, function(reason) {
 					if (params.promptForSummary) {
 						reason = prompt("Enter the deletion summary to use, or press OK to accept the automatically generated one.", reason);
 					}

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -40,22 +40,28 @@ Twinkle.speedy.dialog = null;
 
 // The speedy criteria list can be in one of several modes
 Twinkle.speedy.mode = {
-	sysopSubmit: 1,  // radio buttons, no subgroups, submit when "Submit" button is clicked
+	sysopSingleSubmit: 1,  // radio buttons, no subgroups, submit when "Submit" button is clicked
 	sysopRadioClick: 2,  // radio buttons, no subgroups, submit when a radio button is clicked
-	userMultipleSubmit: 3,  // check boxes, subgroups, "Submit" button already pressent
-	userMultipleRadioClick: 4,  // check boxes, subgroups, need to add a "Submit" button
-	userSingleSubmit: 5,  // radio buttons, subgroups, submit when "Submit" button is clicked
-	userSingleRadioClick: 6,  // radio buttons, subgroups, submit when a radio button is clicked
+	sysopMultipleSubmit: 3, // check boxes, subgroups, "Submit" button already present
+	sysopMultipleRadioClick: 4, // check boxes, subgroups, need to add a "Submit" button
+	userMultipleSubmit: 5,  // check boxes, subgroups, "Submit" button already pressent
+	userMultipleRadioClick: 6,  // check boxes, subgroups, need to add a "Submit" button
+	userSingleSubmit: 7,  // radio buttons, subgroups, submit when "Submit" button is clicked
+	userSingleRadioClick: 8,  // radio buttons, subgroups, submit when a radio button is clicked
 
 	// are we in "delete page" mode?
 	// (sysops can access both "delete page" [sysop] and "tag page only" [user] modes)
 	isSysop: function twinklespeedyModeIsSysop(mode) {
-		return mode === Twinkle.speedy.mode.sysopSubmit ||
-			mode === Twinkle.speedy.mode.sysopRadioClick;
+		return mode === Twinkle.speedy.mode.sysopSingleSubmit ||
+			mode === Twinkle.speedy.mode.sysopMultipleSubmit ||
+			mode === Twinkle.speedy.mode.sysopRadioClick ||
+			mode === Twinkle.speedy.mode.sysopMultipleRadioClick;
 	},
 	// do we have a "Submit" button once the form is created?
 	hasSubmitButton: function twinklespeedyModeHasSubmitButton(mode) {
-		return mode === Twinkle.speedy.mode.sysopSubmit ||
+		return mode === Twinkle.speedy.mode.sysopSingleSubmit ||
+			mode === Twinkle.speedy.mode.sysopMultipleSubmit ||
+			mode === Twinkle.speedy.mode.sysopMultipleRadioClick ||
 			mode === Twinkle.speedy.mode.userMultipleSubmit ||
 			mode === Twinkle.speedy.mode.userMultipleRadioClick ||
 			mode === Twinkle.speedy.mode.userSingleSubmit;
@@ -63,12 +69,10 @@ Twinkle.speedy.mode = {
 	// is db-multiple the outcome here?
 	isMultiple: function twinklespeedyModeIsMultiple(mode) {
 		return mode === Twinkle.speedy.mode.userMultipleSubmit ||
-			mode === Twinkle.speedy.mode.userMultipleRadioClick;
+			mode === Twinkle.speedy.mode.sysopMultipleSubmit ||
+			mode === Twinkle.speedy.mode.userMultipleRadioClick ||
+			mode === Twinkle.speedy.mode.sysopMultipleRadioClick;
 	},
-	// do we want subgroups? (if not we have to use prompt())
-	wantSubgroups: function twinklespeedyModeWantSubgroups(mode) {
-		return !Twinkle.speedy.mode.isSysop(mode);
-	}
 };
 
 // Prepares the speedy deletion dialog and displays it
@@ -103,6 +107,9 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 							// enable/disable redirects checkbox
 							cForm.redirects.disabled = cChecked;
 							cForm.redirects.checked = !cChecked;
+							// enable/disable delete multiple
+							cForm.delmultiple.disabled = cChecked;
+							cForm.delmultiple.checked = false;
 
 							// enable/disable notify checkbox
 							cForm.notify.disabled = !cChecked;
@@ -153,6 +160,21 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 					}
 				]
 			} );
+		form.append( {
+			type: 'checkbox',
+			list: [
+				{
+					label: 'Delete under multiple criteria',
+					value: 'delmultiple',
+					name: 'delmultiple',
+					tooltip: "When selected, you can select several criteria that apply to the page. For example, G11 and A7 are a common combination for articles.",
+					event: function( event ) {
+						Twinkle.speedy.callback.modeChanged( event.target.form );
+						event.stopPropagation();
+					}
+				}
+			]
+		} );
 		form.append( { type: 'header', label: 'Tag-related options' } );
 	}
 
@@ -205,6 +227,19 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 	dialog.display();
 
 	Twinkle.speedy.callback.modeChanged( result );
+
+	// if sysop, check if CSD is already on the page and fill in custom rationale
+	if (Morebits.userIsInGroup('sysop') && $("#delete-reason").length) {
+		var customOption = $("input[name=csd][value=reason]")[0];
+
+		if (Twinkle.getPref('speedySelectionStyle') !== 'radioClick') {
+			// force listeners to re-init
+			customOption.click();
+			customOption.parentNode.appendChild(customOption.subgroup);
+		}
+
+		customOption.subgroup.querySelector('input').value = decodeURIComponent($("#delete-reason").text()).replace(/\+/g, ' ');
+	}
 };
 
 Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(form) {
@@ -213,7 +248,11 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 	// first figure out what mode we're in
 	var mode = Twinkle.speedy.mode.userSingleSubmit;
 	if (form.tag_only && !form.tag_only.checked) {
-		mode = Twinkle.speedy.mode.sysopSubmit;
+		if (form.delmultiple.checked) {
+			mode = Twinkle.speedy.mode.sysopMultipleSubmit;
+		} else {
+			mode = Twinkle.speedy.mode.sysopSingleSubmit;
+		}
 	} else {
 		if (form.multiple.checked) {
 			mode = Twinkle.speedy.mode.userMultipleSubmit;
@@ -230,7 +269,9 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 			name: 'work_area'
 		} );
 
-	if (mode === Twinkle.speedy.mode.userMultipleRadioClick) {
+	if (mode === Twinkle.speedy.mode.userMultipleRadioClick || mode === Twinkle.speedy.mode.sysopMultipleRadioClick) {
+		var evaluateType = Twinkle.speedy.mode.isSysop(mode) ? 'evaluateSysop' : 'evaluateUser';
+
 		work_area.append( {
 				type: 'div',
 				label: 'When finished choosing criteria, click:'
@@ -240,13 +281,18 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 				name: 'submit-multiple',
 				label: 'Submit Query',
 				event: function( event ) {
-					Twinkle.speedy.callback.evaluateUser( event );
+					Twinkle.speedy.callback[evaluateType]( event );
 					event.stopPropagation();
 				}
 			} );
 	}
 
 	var radioOrCheckbox = (Twinkle.speedy.mode.isMultiple(mode) ? 'checkbox' : 'radio');
+
+	if (Twinkle.speedy.mode.isSysop(mode) && !Twinkle.speedy.mode.isMultiple(mode)) {
+		work_area.append( { type: 'header', label: 'Custom rationale' } );
+		work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.customRationale, mode) } );
+	}
 
 	if (namespace % 2 === 1 && namespace !== 3) {
 		// show db-talk on talk pages, but not user talk pages
@@ -298,8 +344,13 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 			break;
 	}
 
+	// custom rationale lives under general criteria when tagging
+	var generalCriteria = Twinkle.speedy.generalList;
+	if(!Twinkle.speedy.mode.isSysop(mode)) {
+		generalCriteria = Twinkle.speedy.customRationale.concat(generalCriteria);
+	}
 	work_area.append( { type: 'header', label: 'General criteria' } );
-	work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.generalList, mode) });
+	work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(generalCriteria, mode) });
 
 	work_area.append( { type: 'header', label: 'Redirects' } );
 	work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList, mode) } );
@@ -312,7 +363,6 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 	// mode switches
 	var isSysop = Twinkle.speedy.mode.isSysop(mode);
 	var multiple = Twinkle.speedy.mode.isMultiple(mode);
-	var wantSubgroups = Twinkle.speedy.mode.wantSubgroups(mode);
 	var hasSubmitButton = Twinkle.speedy.mode.hasSubmitButton(mode);
 
 	var openSubgroupHandler = function(e) {
@@ -323,16 +373,13 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 		e.stopPropagation();
 	};
 	var submitSubgroupHandler = function(e) {
-		Twinkle.speedy.callback.evaluateUser(e);
+		var evaluateType = Twinkle.speedy.mode.isSysop(mode) ? 'evaluateSysop' : 'evaluateUser';
+		Twinkle.speedy.callback[evaluateType](e);
 		e.stopPropagation();
 	};
 
 	return $.map(list, function(critElement) {
 		var criterion = $.extend({}, critElement);
-
-		if (!wantSubgroups) {
-			criterion.subgroup = null;
-		}
 
 		if (multiple) {
 			if (criterion.hideWhenMultiple) {
@@ -391,6 +438,21 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 		return criterion;
 	});
 };
+
+Twinkle.speedy.customRationale = [
+	{
+		label: 'Custom rationale' + (Morebits.userIsInGroup('sysop') ? ' (custom deletion reason)' : ' using {{db}} template'),
+		value: 'reason',
+		tooltip: '{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can\'t find any criteria that fit.',
+		subgroup: {
+			name: 'reason_1',
+			type: 'input',
+			label: 'Rationale: ',
+			size: 60
+		},
+		hideWhenMultiple: true
+	}
+];
 
 Twinkle.speedy.talkList = [
 	{
@@ -699,19 +761,6 @@ Twinkle.speedy.portalList = [
 
 Twinkle.speedy.generalList = [
 	{
-		label: 'Custom rationale' + (Morebits.userIsInGroup('sysop') ? ' (custom deletion reason)' : ' using {{db}} template'),
-		value: 'reason',
-		tooltip: '{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can\'t find any criteria that fit.',
-		subgroup: {
-			name: 'reason_1',
-			type: 'input',
-			label: 'Rationale: ',
-			size: 60
-		},
-		hideWhenMultiple: true,
-		hideSubgroupWhenSysop: true
-	},
-	{
 		label: 'G1: Patent nonsense. Pages consisting purely of incoherent text or gibberish with no meaningful content or history.',
 		value: 'nonsense',
 		tooltip: 'This does not include poor writing, partisan screeds, obscene remarks, vandalism, fictional material, material not in English, poorly translated material, implausible theories, or hoaxes. In short, if you can understand it, G1 does not apply.'
@@ -998,126 +1047,96 @@ Twinkle.speedy.normalizeHash = {
 	'emptyportal': 'p2'
 };
 
-// keep this synched with [[MediaWiki:Deletereason-dropdown]]
-Twinkle.speedy.reasonHash = {
-	'reason': '',
-// General
-	'nonsense': '[[WP:PN|Patent nonsense]], meaningless, or incomprehensible',
-	'test': 'Test page',
-	'vandalism': '[[WP:Vandalism|Vandalism]]',
-	'hoax': 'Blatant [[WP:Do not create hoaxes|hoax]]',
-	'repost': 'Recreation of a page that was [[WP:DEL|deleted]] per a [[WP:XFD|deletion discussion]]',
-	'banned': 'Creation by a [[WP:BLOCK|blocked]] or [[WP:BAN|banned]] user in violation of block or ban',
-	'histmerge': 'Temporary deletion in order to merge page histories',
-	'move': 'Making way for a non-controversial move',
-	'xfd': 'Deleting page per result of [[WP:XfD|deletion discussion]]',
-	'disambig': 'Unnecessary disambiguation page',
-	'movedab': 'Redirect to [[WP:MALPLACED|malplaced disambiguation page]]',
-	'copypaste': '[[WP:CPMV|Copy-and-paste]] page move',
-	'g6': 'Housekeeping and routine (non-controversial) cleanup',
-	'author': 'One author who has requested deletion or blanked the page',
-	'g8': 'Page dependent on a deleted or nonexistent page',
-	'talk': '[[Help:Talk page|Talk page]] of a deleted or nonexistent page',
-	'subpage': '[[WP:Subpages|Subpage]] of a deleted or nonexistent page',
-	'redirnone': '[[Wikipedia:Redirect|redirect]] to a deleted or nonexistent page',
-	'templatecat': 'Populated by deleted or retargeted templates',
-	'imagepage': 'File description page for a file that does not exist',
-	'attack': '[[WP:ATP|Attack page]] or negative unsourced [[WP:BLP|BLP]]',
-	'negublp': 'Negative unsourced [[WP:BLP|BLP]]',
-	'spam': 'Unambiguous [[WP:NOTADVERTISING|advertising]] or promotion',
-	'copyvio': 'Unambiguous [[WP:CV|copyright infringement]]',
-	'afc': 'Abandoned [[WP:AFC|Article for creation]] – to retrieve it, see [[WP:REFUND/G13]]',
-// Articles
-	'nocontext': 'Short article without enough context to identify the subject',
-	'foreign': 'Article in a foreign language that exists on another project',
-	'nocontent': 'Article that has no meaningful, substantive content',
-	'transwiki': 'Article that has been transwikied to another project',
-	'a7': 'No credible indication of importance (individuals, animals, organizations, web content, events)',
-	'person' : 'No credible indication of importance (real person)',
-	'web': 'No credible indication of importance (web content)',
-	'corp': 'No credible indication of importance (organization)',
-	'club': 'No credible indication of importance (organization)',
-	'band': 'No credible indication of importance (band/musician)',
-	'animal': 'No credible indication of importance (individual animal)',
-	'event': 'No credible indication of importance (event)',
-	'a9': 'Music recording by redlinked artist and no indication of importance or significance',
-	'a10': 'Recently created article that duplicates an existing topic',
-	'madeup': 'Made up by article creator or an associate, and no indication of importance/significance',
-// Images and media
-// Keep synched with [[MediaWiki:Filedelete-reason-dropdown]]
-	'redundantimage': 'Redundant copy of non-Commons file in the same file format',
-	'noimage': 'Corrupt or empty file',
-	'fpcfail': 'Unneeded file description page for a file on Commons',
-	'noncom': 'Invalid licence, eg. "for non-commercial use only" or "for Wikipedia use only"',
-	'unksource': 'Lack of licensing information',
-	'unfree': 'Unused non-free media',
-	'norat': 'Non-free file with no [[WP:RAT|non-free use rationale]]',
-	'badfairuse': 'Violates [[WP:F|non-free use policy]]',
-	'nowcommons': 'Media file available on Commons',
-	'imgcopyvio': 'Unambiguous [[WP:COPYVIO|copyright violation]]',
-	'badfiletype': 'Useless media file (not an image, audio or video)',
-	'nopermission': 'No evidence of permission',
-// Categories
-	'catempty': 'Empty category',
-// User pages
-	'userreq': 'User request to delete page in own userspace',
-	'nouser': 'Userpage or subpage of a nonexistent user',
-	'gallery': '[[WP:NFC|Non-free]] [[Help:Gallery|gallery]]',
-	'notwebhost': '[[WP:NOTWEBHOST|Misuse of Wikipedia as a web host]]',
-// Templates
-	'policy': 'Template that unambiguously misrepresents established policy',
-	'duplicatetemplate': 'Unused, redundant template',
-// Portals
-	'p1': '[[WP:P|Portal]] page that would be subject to speedy deletion as an article',
-	'emptyportal': '[[WP:P|Portal]] without a substantial topic base',
-// Redirects
-	'rediruser': 'Cross-[[WP:NS|namespace]] [[WP:R|redirect]] from mainspace',
-	'redirtypo': 'Recently created, implausible [[WP:R|redirect]]'
-};
-
 Twinkle.speedy.callbacks = {
-	sysop: {
-		main: function( params ) {
-			var thispage;
-
-			Morebits.wiki.addCheckpoint();  // prevent actionCompleted from kicking in until user interaction is done
-
-			// look up initial contributor. If prompting user for deletion reason, just display a link.
-			// Otherwise open the talk page directly
-			if( params.openusertalk ) {
-				thispage = new Morebits.wiki.page( mw.config.get('wgPageName') );  // a necessary evil, in order to clear incorrect status text
-				thispage.setCallbackParameters( params );
-				thispage.lookupCreator( Twinkle.speedy.callbacks.sysop.openUserTalkPage );
-			}
-
-			// delete page
-			var reason;
-			thispage = new Morebits.wiki.page( mw.config.get('wgPageName'), "Deleting page" );
-			if (params.normalized === 'db') {
-				reason = prompt("Enter the deletion summary to use, which will be entered into the deletion log:", "");
-			} else {
-				var presetReason = "[[WP:CSD#" + params.normalized.toUpperCase() + "|" + params.normalized.toUpperCase() + "]]: " + params.reason;
-				if (Twinkle.getPref("promptForSpeedyDeletionSummary").indexOf(params.normalized) !== -1) {
-					reason = prompt("Enter the deletion summary to use, or press OK to accept the automatically generated one.", presetReason);
-				} else {
-					reason = presetReason;
+	getTemplateCodeAndParams: function(params) {
+		var code, parameters, i;
+		if (params.normalizeds.length > 1) {
+			code = "{{db-multiple";
+			params.utparams = {};
+			$.each(params.normalizeds, function(index, norm) {
+				code += "|" + norm.toUpperCase();
+				parameters = params.templateParams[index] || [];
+				for (var i in parameters) {
+					if (typeof parameters[i] === 'string' && !parseInt(i, 10)) {  // skip numeric parameters - {{db-multiple}} doesn't understand them
+						code += "|" + i + "=" + parameters[i];
+					}
+				}
+				$.extend(params.utparams, Twinkle.speedy.getUserTalkParameters(norm, parameters));
+			});
+			code += "}}";
+		} else {
+			parameters = params.templateParams[0] || [];
+			code = "{{db-" + params.values[0];
+			for (i in parameters) {
+				if (typeof parameters[i] === 'string') {
+					code += "|" + i + "=" + parameters[i];
 				}
 			}
+			if (params.usertalk) {
+				code += "|help=off";
+			}
+			code += "}}";
+			params.utparams = Twinkle.speedy.getUserTalkParameters(params.normalizeds[0], parameters);
+		}
+
+		return [code, params.utparams];
+	},
+
+	parseWikitext: function(wikitext, callback) {
+		var query = {
+			action: "parse",
+			prop: "text",
+			pst: "true",
+			text: wikitext,
+			title: mw.config.get("wgPageName")
+		};
+
+		var statusIndicator = new Morebits.status( 'Building deletion summary' );
+		var api = new Morebits.wiki.api( 'Fetching parsing deletion template', query, function(apiObj) {
+				statusIndicator.info( 'complete' );
+				callback(apiObj);
+			},  statusIndicator);
+		api.post();
+	},
+
+	sysop: {
+		main: function( params ) {
+			var reason;
+
+			if (!params.normalizeds.length && params.normalizeds[0] === 'db') {
+				reason = prompt("Enter the deletion summary to use, which will be entered into the deletion log:", "");
+				Twinkle.speedy.callbacks.sysop.deletePage( reason, params );
+			} else {
+				var code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
+				Twinkle.speedy.callbacks.parseWikitext(code, function(apiobj) {
+					reason = decodeURIComponent($(apiobj.getXML().querySelector('text').childNodes[0].nodeValue).find('#delete-reason').text()).replace(/\+/g, ' ');
+					if (params.promptForSummary) {
+						reason = prompt("Enter the deletion summary to use, or press OK to accept the automatically generated one.", reason);
+					}
+					Twinkle.speedy.callbacks.sysop.deletePage( reason, params );
+				});
+			}
+		},
+		deletePage: function( reason, params ) {
+			var thispage = new Morebits.wiki.page( mw.config.get('wgPageName'), "Deleting page" );
+
 			if (reason === null) {
-				Morebits.status.error("Asking for reason", "User cancelled");
-				Morebits.wiki.removeCheckpoint();
-				return;
+				return Morebits.status.error("Asking for reason", "User cancelled");
 			} else if (!reason || !reason.replace(/^\s*/, "").replace(/\s*$/, "")) {
-				Morebits.status.error("Asking for reason", "you didn't give one.  I don't know... what with admins and their apathetic antics... I give up...");
-				Morebits.wiki.removeCheckpoint();
-				return;
+				return Morebits.status.error("Asking for reason", "you didn't give one.  I don't know... what with admins and their apathetic antics... I give up...");
 			}
 			thispage.setEditSummary( reason + Twinkle.getPref('deletionSummaryAd') );
 			thispage.deletePage(function() {
 				thispage.getStatusElement().info("done");
 				Twinkle.speedy.callbacks.sysop.deleteTalk( params );
 			});
-			Morebits.wiki.removeCheckpoint();
+
+			// look up initial contributor. If prompting user for deletion reason, just display a link.
+			// Otherwise open the talk page directly
+			if( params.openusertalk ) {
+				thispage.setCallbackParameters( params );
+				thispage.lookupCreator( Twinkle.speedy.callbacks.sysop.openUserTalkPage );
+			}
 		},
 		deleteTalk: function( params ) {
 			// delete talk page
@@ -1295,35 +1314,11 @@ Twinkle.speedy.callbacks = {
 				return;
 			}
 
-			var code, parameters, i;
-			if (params.normalizeds.length > 1) {
-				code = "{{db-multiple";
-				params.utparams = {};
-				$.each(params.normalizeds, function(index, norm) {
-					code += "|" + norm.toUpperCase();
-					parameters = params.templateParams[index] || [];
-					for (var i in parameters) {
-						if (typeof parameters[i] === 'string' && !parseInt(i, 10)) {  // skip numeric parameters - {{db-multiple}} doesn't understand them
-							code += "|" + i + "=" + parameters[i];
-						}
-					}
-					$.extend(params.utparams, Twinkle.speedy.getUserTalkParameters(norm, parameters));
-				});
-				code += "}}";
-			} else {
-				parameters = params.templateParams[0] || [];
-				code = "{{db-" + params.values[0];
-				for (i in parameters) {
-					if (typeof parameters[i] === 'string') {
-						code += "|" + i + "=" + parameters[i];
-					}
-				}
-				if (params.usertalk) {
-					code += "|help=off";
-				}
-				code += "}}";
-				params.utparams = Twinkle.speedy.getUserTalkParameters(params.normalizeds[0], parameters);
-			}
+			// given the params, builds the template and also adds the user talk page parameters to the params that were passed in
+			// returns => [<string> wikitext, <object> utparams]
+			var buildData = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params),
+				code = buildData[0];
+			params.utparams = buildData[1];
 
 			var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			// patrol the page, if reached from Special:NewPages
@@ -1354,9 +1349,9 @@ Twinkle.speedy.callbacks = {
 				editsummary = editsummary.substr(0, editsummary.length - 2); // remove trailing comma
 				editsummary += ').';
 			} else if (params.normalizeds[0] === "db") {
-				editsummary = 'Requesting [[WP:CSD|speedy deletion]] with rationale \"' + parameters["1"] + '\".';
+				editsummary = 'Requesting [[WP:CSD|speedy deletion]] with rationale \"' + params["1"] + '\".';
 			} else if (params.values[0] === "histmerge") {
-				editsummary = "Requesting history merge with [[" + parameters["1"] + "]] ([[WP:CSD#G6|CSD G6]]).";
+				editsummary = "Requesting history merge with [[" + params["1"] + "]] ([[WP:CSD#G6|CSD G6]]).";
 			} else {
 				editsummary = "Requesting speedy deletion ([[WP:CSD#" + params.normalizeds[0].toUpperCase() + "|CSD " + params.normalizeds[0].toUpperCase() + "]]).";
 			}
@@ -1800,26 +1795,49 @@ Twinkle.speedy.resolveCsdValues = function twinklespeedyResolveCsdValues(e) {
 Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSysop(e) {
 	var form = (e.target.form ? e.target.form : e.target);
 
+	if (e.target.type === "checkbox" || e.target.type === "text" ||
+			e.target.type === "select") {
+		return;
+	}
+
 	var tag_only = form.tag_only;
 	if( tag_only && tag_only.checked ) {
 		Twinkle.speedy.callback.evaluateUser(e);
 		return;
 	}
 
-	var value = Twinkle.speedy.resolveCsdValues(e)[0];
-	if (!value) {
+	var values = Twinkle.speedy.resolveCsdValues(e);
+	if (!values) {
 		return;
 	}
-	var normalized = Twinkle.speedy.normalizeHash[ value ];
+
+	var normalizeds = values.map(function(value) {
+		return Twinkle.speedy.normalizeHash[ value ];
+	});
+
+	// analyse each criterion to determine whether to watch the page, prompt for summary, or open user talk page
+	var watchPage, promptForSummary, openUserTalk;
+	normalizeds.forEach(function(norm) {
+		if (Twinkle.getPref("watchSpeedyPages").indexOf(norm) !== -1) {
+			watchPage = true;
+		}
+		if (Twinkle.getPref("promptForSpeedyDeletionSummary").indexOf(norm) !== -1) {
+			promptForSummary = true;
+		}
+		if (Twinkle.getPref('openUserTalkPageOnSpeedyDelete').indexOf(norm) !== -1) {
+			openUserTalk = true;
+		}
+	});
 
 	var params = {
-		value: value,
-		normalized: normalized,
-		watch: Twinkle.getPref('watchSpeedyPages').indexOf( normalized ) !== -1,
-		reason: Twinkle.speedy.reasonHash[ value ],
-		openusertalk: Twinkle.getPref('openUserTalkPageOnSpeedyDelete').indexOf( normalized ) !== -1,
+		values: values,
+		normalizeds: normalizeds,
+		watch: watchPage,
+		openusertalk: openUserTalk,
 		deleteTalkPage: form.talkpage && form.talkpage.checked,
-		deleteRedirects: form.redirects.checked
+		deleteRedirects: form.redirects.checked,
+		promptForSummary: promptForSummary,
+		templateParams: Twinkle.speedy.getParameters( form, values )
 	};
 
 	Morebits.simpleWindow.setButtonsEnabled( false );

--- a/twinkle.js
+++ b/twinkle.js
@@ -47,7 +47,7 @@ Twinkle.defaultConfig.twinkle = {
 	summaryAd: " ([[WP:TW|TW]])",
 	deletionSummaryAd: " ([[WP:TW|TW]])",
 	protectionSummaryAd: " ([[WP:TW|TW]])",
-	userTalkPageMode: "window",
+	userTalkPageMode: "tab",
 	dialogLargeFont: false,
 	 // ARV
 	spiWatchReport: "yes",
@@ -77,9 +77,9 @@ Twinkle.defaultConfig.twinkle = {
 	// these next two should probably be identical by default
 	notifyUserOnSpeedyDeletionNomination:    [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],
 	welcomeUserOnSpeedyDeletionNotification: [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],
-	promptForSpeedyDeletionSummary: [ "db", "g1", "g2", "g3", "g4", "g6", "g7", "g8", "g10", "g11", "g12", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f2", "f4", "f7", "f8", "f10", "u5", "t2", "t3", "p1", "p2" ],
+	promptForSpeedyDeletionSummary: [],
 	openUserTalkPageOnSpeedyDelete: [ "db", "g1", "g2", "g3", "g4", "g5", "g10", "g11", "g12", "a1", "a3", "a7", "a9", "a10", "a11", "f3", "f7", "f9", "u3", "u5", "t2", "p1" ],
-	deleteTalkPageOnDelete: false,
+	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,
 	deleteSysopDefaultToTag: false,
 	speedyWindowHeight: 500,


### PR DESCRIPTION
This is **incomplete**. Still needs testing, and there's at least one bug I haven't been able to fix

* Allow admins to delete under multiple rationale
* Allow admins to use the subgroups to enter in values such as the URL for G12 deletions
* Use the corresponding template to generate a deletion summary
* Move custom rationale to top with it's own section, and supply the rationale generated by the CSD template already on the page, if it exists