### PR TITLE
MoreBits.js: always assert the user is logged in when making a POST

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1398,6 +1398,7 @@ Morebits.wiki.api = function( currentAction, query, onSuccess, statusElement, on
 	this.currentAction = currentAction;
 	this.query = query;
 	this.query.format = 'xml';
+	this.query.assert = 'user';
 	this.onSuccess = onSuccess;
 	this.onError = onError;
 	if( statusElement ) {


### PR DESCRIPTION
I think this will do it. There might be a better way, I'm not familiar with how Morebits.js works