### PR TITLE
speedy: Fix delete reason fetching on non-wikitext pages

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1172,6 +1172,7 @@ Twinkle.speedy.callbacks = {
 			prop: "text",
 			pst: "true",
 			text: wikitext,
+			contentmodel: "wikitext",
 			title: mw.config.get("wgPageName")
 		};
 


### PR DESCRIPTION
Currently `parseWikitext()` would bork on `.js`/`.css` pages for that `parse`'d give out something like `<pre>{{db-spam}}</pre>` instead of expanding the template.