### PR TITLE
Adjust {{uw-3rr}} description

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1012,8 +1012,8 @@ Twinkle.warn.messages = {
 
 	singlewarn: {
 		"uw-3rr": {
-			label: "Violating the three-revert rule; see also uw-ew",
-			summary: "Warning: Violating the three-revert rule"
+			label: "Potential three-revert rule violation; see also uw-ew",
+			summary: "Warning: Three-revert rule"
 		},
 		"uw-affiliate": {
 			label: "Affiliate marketing",


### PR DESCRIPTION
A discussion on [WT:TWINKLE](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#.22Violating.22_the_three_revert_rule) has resulted in a consensus that the edit summary left by Twinkle shouldn't imply the user has broken the 3RR. The warning itself {{[uw-3rr](https://en.wikipedia.org/wiki/Template:Uw-3rr)}} doesn't say the user has broken 3RR, so neither should the edit summary.