### PR TITLE
Change {{TWA invite}} template

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -589,7 +589,7 @@ Twinkle.welcome.templates = {
 	"TWA invite": {
 		description: "invite the user to The Wikipedia Adventure (not a welcome template)",
 		linkedArticle: false,
-		syntax: "{{WP:TWA/Invite|signature=~~~~}}"
+		syntax: "{{WP:TWA/InviteTW|signature=~~~~}}"
 	},
 
 	// NON-ENGLISH WELCOMES


### PR DESCRIPTION
Change TWA invite syntax to "{{WP:TWA/InviteTW|signature=~~~~}}" - using the Twinkle-specific TWA invite template. This template is the same as TWA/Invite but adds a header

Template: https://en.wikipedia.org/wiki/Wikipedia:TWA/InviteTW