### PR TITLE
prod: Remove superfluous "move to Commons" tags

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -185,7 +185,11 @@ Twinkle.prod.callbacks = {
 
 		// Remove tags that become superfluous with this action
 		text = text.replace(/\{\{\s*([Nn]ew unreviewed article|[Uu]nreviewed|[Uu]serspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, "");
-
+		if (mw.config.get('wgNamespaceNumber') === 6) {
+			// remove "move to Commons" tag - deletion-tagged files cannot be moved to Commons
+			text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, "");
+		}
+		
 		var prod_re = /\{\{\s*(?:dated prod|dated files|dated prod blp|Prod blp\/dated|Proposed deletion\/dated)\s*\|(?:\{\{[^\{\}]*\}\}|[^\}\{])*\}\}/i;
 		var summaryText;
 		if( !prod_re.test( text ) ) {

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -184,8 +184,7 @@ Twinkle.prod.callbacks = {
 		}
 
 		// Remove tags that become superfluous with this action
-		text = text.replace(/\{\{\s*(new unreviewed article|unreviewed|userspace draft|mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/gi, "");
-				
+		text = text.replace(/\{\{\s*(new unreviewed article|unreviewed|userspace draft|mtc|(copy|move) to wikimedia commons|(copy |move )?to ?commons)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/gi, "");
 		var prod_re = /\{\{\s*(?:dated prod|dated files|dated prod blp|Prod blp\/dated|Proposed deletion\/dated)\s*\|(?:\{\{[^\{\}]*\}\}|[^\}\{])*\}\}/i;
 		var summaryText;
 		if( !prod_re.test( text ) ) {

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -184,12 +184,8 @@ Twinkle.prod.callbacks = {
 		}
 
 		// Remove tags that become superfluous with this action
-		text = text.replace(/\{\{\s*([Nn]ew unreviewed article|[Uu]nreviewed|[Uu]serspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, "");
-		if (mw.config.get('wgNamespaceNumber') === 6) {
-			// remove "move to Commons" tag - deletion-tagged files cannot be moved to Commons
-			text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, "");
-		}
-		
+		text = text.replace(/\{\{\s*(new unreviewed article|unreviewed|userspace draft|mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/gi, "");
+				
 		var prod_re = /\{\{\s*(?:dated prod|dated files|dated prod blp|Prod blp\/dated|Proposed deletion\/dated)\s*\|(?:\{\{[^\{\}]*\}\}|[^\}\{])*\}\}/i;
 		var summaryText;
 		if( !prod_re.test( text ) ) {


### PR DESCRIPTION
Remove superfluous "move to Commons" tags when PRODing files. Deletion-tagged files cannot be moved to Commons