### PR TITLE
Update {{uw-spam1}} label and edit summary

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -243,8 +243,8 @@ Twinkle.warn.messages = {
 				summary: "General note: Not adhering to neutral point of view"
 			},
 			"uw-spam1": {
-				label: "Adding spam links",
-				summary: "General note: Adding spam links"
+				label: "Adding inappropriate external links",
+				summary: "General note: Adding inappropriate external links"
 			}
 		},
 		"Behavior towards other editors": {


### PR DESCRIPTION
"spam links" → "inappropriate external links"
Requested at [Wikipedia talk:Twinkle#Edit summary for uw-spam1](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=796122026#Edit_summary_for_uw-spam1)