### PR TITLE
Reload Twinklefluff interface when diff view changes

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -19,7 +19,7 @@
 
 //<nowiki>
 
-( function ( window, document, $, undefined ) { // Wrap with anonymous function
+( function ( window, document, $, mw, undefined ) { // Wrap with anonymous function
 
 var Twinkle = {};
 window.Twinkle = Twinkle;  // allow global access
@@ -441,7 +441,9 @@ Twinkle.load = function () {
 	Twinkle.diff();
 	Twinkle.unlink();
 	Twinkle.config.init();
-	Twinkle.fluff.init();
+	mw.hook( 'wikipage.diff' ).add( function () {
+		Twinkle.fluff.init();
+	} );
 	if ( Morebits.userIsInGroup('sysop') ) {
 		Twinkle.deprod();
 		Twinkle.batchdelete();
@@ -459,6 +461,6 @@ Twinkle.load = function () {
 	}
 };
 
-} ( window, document, jQuery )); // End wrap with anonymous function
+} ( window, document, jQuery, mediaWiki )); // End wrap with anonymous function
 
 // </nowiki>


### PR DESCRIPTION
This patch will hook Twinklefluff initialization to the mw.hook responsible for pages containing diff view.

Now for example the RevisionSlider extension that fires that hook will re-initiate the Twinkle links added to the page when moving through the revisions. This should fix https://github.com/azatoth/twinkle/issues/360

The hook gets fired everytime a diff page loads / reloads. To avoid having the links twice the original call got replaced.

Further modules that might need to be re-initiated by hook could be added in a follow up.