### PR TITLE
protect - A few fixes for tagging redirect pages

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1382,10 +1382,16 @@ Twinkle.protect.callbacks = {
 		if( params.tag === 'none' ) {
 			summary = 'Removing protection template' + Twinkle.getPref('summaryAd');
 		} else {
-			if( params.noinclude ) {
+			if( Morebits.wiki.isPageRedirect() ) {
+				//Only tag if no {{rcat shell}} is found
+				if (!text.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
+					text = text.replace(/#REDIRECT ?(\[\[.*?\]\])(.*)/i, "#REDIRECT $1$2\n\n{{" + tag + "}}");
+				} else {
+					Morebits.status.info("Redirect category shell present", "nothing to do");
+					return;
+				}
+			} else if( params.noinclude ) {
 				text = "<noinclude>{{" + tag + "}}</noinclude>" + text;
-			} else if( Morebits.wiki.isPageRedirect() ) {
-				text = text + "\n{{" + tag + "}}";
 			} else {
 				text = "{{" + tag + "}}\n" + text;
 			}


### PR DESCRIPTION
- Place tag underneath the #REDIRECT header (don't break the redirect, remove need for `<noinclude>`)
- Detect {{Rcat shell (and sundry redirects) and do nothing if present

Closes #408 