### PR TITLE
speedy: A few tweaks to CSD logging

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1470,14 +1470,17 @@ Twinkle.speedy.callbacks = {
 					// disallow warning yourself
 					if (initialContrib === mw.config.get('wgUserName')) {
 						Morebits.status.warn("You (" + initialContrib + ") created this page; skipping user notification");
+						initialContrib = null;
 
 					// don't notify users when their user talk page is nominated
 					} else if (initialContrib === mw.config.get('wgTitle') && mw.config.get('wgNamespaceNumber') === 3) {
 						Morebits.status.warn("Notifying initial contributor: this user created their own user talk page; skipping notification");
+						initialContrib = null;
 
 					// quick hack to prevent excessive unwanted notifications, per request. Should actually be configurable on recipient page...
 					} else if ((initialContrib === "Cyberbot I" || initialContrib === "SoxBot") && params.normalizeds[0] === "f2") {
 						Morebits.status.warn("Notifying initial contributor: page created procedurally by bot; skipping notification");
+						initialContrib = null;
 
 					} else {
 						var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, "Notifying initial contributor (" + initialContrib + ")"),

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1507,7 +1507,7 @@ Twinkle.speedy.callbacks = {
 						notifytext += (params.welcomeuser ? "" : "|nowelcome=yes") + "}} ~~~~";
 
 						var editsummary = "Notification: speedy deletion nomination";
-						if (params.normalizeds.indexOf("g10") === -1) {  // no article name in summary for G10 deletions
+						if (params.normalizeds.indexOf("g10") === -1) {  // no article name in summary for G10 taggings
 							editsummary += " of [[:" + Morebits.pageNameNorm + "]].";
 						} else {
 							editsummary += " of an attack page.";
@@ -1569,7 +1569,12 @@ Twinkle.speedy.callbacks = {
 				appendText += "\n\n=== " + date.getUTCMonthName() + " " + date.getUTCFullYear() + " ===";
 			}
 
-			appendText += "\n# [[:" + Morebits.pageNameNorm + "]]: ";
+			appendText += "\n# [[:" + Morebits.pageNameNorm;
+			if (params.normalizeds.indexOf("g10") === -1) {  // no article name in log for G10 taggings
+				appendText += "]]: ";
+			} else {
+				appendText += "|This]] attack page: ";
+			}
 			if (params.fromDI) {
 				appendText += "DI [[WP:CSD#" + params.normalized.toUpperCase() + "|CSD " + params.normalized.toUpperCase() + "]] ({{tl|di-" + params.templatename + "}})";
 			} else {
@@ -1593,7 +1598,15 @@ Twinkle.speedy.callbacks = {
 			appendText += " ~~~~~\n";
 
 			pageobj.setAppendText(appendText);
-			pageobj.setEditSummary("Logging speedy deletion nomination of [[:" + Morebits.pageNameNorm + "]]." + Twinkle.getPref('summaryAd'));
+
+			var editsummary = "Logging speedy deletion nomination";
+			if (params.normalizeds.indexOf("g10") === -1) {  // no article name in summary for G10 taggings
+				editsummary += " of [[:" + Morebits.pageNameNorm + "]].";
+			} else {
+				editsummary += " of an attack page.";
+			}
+			editsummary += Twinkle.getPref('summaryAd');
+			pageobj.setEditSummary(editsummary);
 			pageobj.setCreateOption("recreate");
 			pageobj.append();
 		}


### PR DESCRIPTION
Two different behaviors fixed:
- A few edge cases exist where twinkle won't notify the original creator, but it would still erroneously say you had notified the user in your log.
- Avoid using the title of a page nominated for G10.  The name of G10 noms was removed from the notification edit summary in e296afc roughly six years ago but it was still present in the edit summary for the log.  That's been fixed.  This also removes the title from displaying in the log itself, hiding it behind a piped wikilink.