### PR TITLE
speedy: Correct language for G6 db-disambig

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -936,7 +936,7 @@ Twinkle.speedy.generalList = [
 	{
 		label: 'G6: Unnecessary disambiguation page',
 		value: 'disambig',
-		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate two or fewer existing Wikipedia pages and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguates no (zero) existing Wikipedia pages, regardless of its title.',
+		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.',
 		hideWhenMultiple: true,
 		hideWhenRedirect: true
 	},


### PR DESCRIPTION
As requested on [WT:TW](https://en.wikipedia.org/w/index.php?oldid=857841491#Db-disambig), this corrects the db-disambig tooltip to say that it applies to a page that dabs one page, not two or fewer.

Original text was introduced in f92641ebf02c60a8d635fa1e80edb93dca43389b, which was [correct at the time](https://en.wikipedia.org/w/index.php?title=Template:Db-disambig&oldid=353013319).