### PR TITLE
friendlytag: Group old and new redirect tags within Rcat shell

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1071,7 +1071,24 @@ Twinkle.tag.callbacks = {
 		$.each(tags, addTag);
 
 		if( Twinkle.tag.mode === 'redirect' ) {
-			pageText += tagText;
+			// Check for all Rcat shell redirects (from #433)
+			if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
+				// Regex courtesy [[User:Kephir/gadgets/sagittarius.js]] at [[Special:PermaLink/831402893]]
+				var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|)((?:[^|{}]*|{{[^|}]*}})+)(}})\s*/i);
+				pageText = pageText.replace(oldTags[0], oldTags[1]+tagText+oldTags[2]+oldTags[3]);
+			} else {
+				// Fold any pre-existing Rcats into taglist and under Rcatshell
+				var pageTags = pageText.match(/\n{{R(?:edirect)? .*?}}/img);
+				var oldPageTags ='';
+				if (pageTags) {
+					pageTags.forEach(function(pageTag) {
+						var pageRe = new RegExp(pageTag, 'img');
+						pageText = pageText.replace(pageRe,'');
+						oldPageTags = oldPageTags.concat(pageTag);
+					});
+				}
+				pageText += '\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
+			}
 		} else {
 			// smartly insert the new tags after any hatnotes. Regex is a bit more
 			// complicated than it'd need to be, to allow templates as parameters,


### PR DESCRIPTION
Closes #444.  While processing new tags on a redirect page, check the page for
already-existing redirect categories.  If they exist, whether within or
without an Rcat shell, fold them and the new tags into an Rcat shell.

There is some double-processing, as the already-existing method to check for
duplication remains, but the intent of this is not to affect 'tags' so as not
to affect the edit summary.  Moreover, the old tags remain unsorted, mainly to
avoid creating a broader-scope-than-necessary variable, but is probably a good
idea anyway, to avoid the perception that those tags were added by the user.

Rcat regex courtesy of [[User:Kephir/gadgets/sagittarius.js]] and #433