### PR TITLE
protect: Use numbered parameter in pagelinks

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1419,7 +1419,7 @@ Twinkle.protect.callbacks = {
 			statusElement.error( [ 'There is already a protection request for this page at ', rppLink, ', aborting.' ] );
 			return;
 		}
-		newtag += '* {{pagelinks|' + Morebits.pageNameNorm + '}}\n\n';
+		newtag += '* {{pagelinks|1=' + Morebits.pageNameNorm + '}}\n\n';
 
 		var words;
 		switch( params.expiry ) {


### PR DESCRIPTION
Prevent issues if page name has = in it
[[[Special:Permalink/865529421#RPP function bug]]](https://en.wikipedia.org/wiki/Special:Permalink/865529421#RPP_function_bug)