### PR TITLE
twinkleprotect: Remove references to PC2, use PC instead of PC1

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -401,14 +401,9 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					});
 				pclevel.append({
 						type: 'option',
-						label: 'Level 1',
+						label: 'Pending changes',
 						value: 'autoconfirmed',
 						selected: true
-					});
-				pclevel.append({
-						type: 'option',
-						label: 'Level 2 (do not use)',
-						value: 'review'
 					});
 				field2.append({
 						type: 'select',
@@ -740,14 +735,13 @@ Twinkle.protect.protectionTypesCreate = [
 ];
 
 // A page with both regular and PC protection will be assigned its regular
-// protection weight plus 2 (for PC1) or 7 (for PC2)
+// protection weight plus 2
 Twinkle.protect.protectionWeight = {
 	sysop: 40,
 	templateeditor: 30,
 	extendedconfirmed: 20,
-	flaggedrevs_review: 15,  // Pending Changes level 2 protection alone
 	autoconfirmed: 10,
-	flaggedrevs_autoconfirmed: 5,  // Pending Changes level 1 protection alone
+	flaggedrevs_autoconfirmed: 5,  // Pending Changes protection alone
 	all: 0,
 	flaggedrevs_none: 0  // just in case
 };
@@ -855,27 +849,27 @@ Twinkle.protect.protectionPresetsInfo = {
 	'pp-pc-vandalism': {
 		stabilize: 'autoconfirmed',  // stabilize = Pending Changes
 		reason: 'Persistent [[WP:Vandalism|vandalism]]',
-		template: 'pp-pc1'
+		template: 'pp-pc'
 	},
 	'pp-pc-disruptive': {
 		stabilize: 'autoconfirmed',
 		reason: 'Persistent [[WP:Disruptive editing|disruptive editing]]',
-		template: 'pp-pc1'
+		template: 'pp-pc'
 	},
 	'pp-pc-unsourced': {
 		stabilize: 'autoconfirmed',
 		reason: 'Persistent addition of [[WP:INTREF|unsourced or poorly sourced content]]',
-		template: 'pp-pc1'
+		template: 'pp-pc'
 	},
 	'pp-pc-blp': {
 		stabilize: 'autoconfirmed',
 		reason: 'Violations of the [[WP:BLP|biographies of living persons policy]]',
-		template: 'pp-pc1'
+		template: 'pp-pc'
 	},
 	'pp-pc-protected': {
 		stabilize: 'autoconfirmed',
 		reason: null,
-		template: 'pp-pc1'
+		template: 'pp-pc'
 	},
 	'pp-move': {
 		move: 'sysop',
@@ -945,7 +939,7 @@ Twinkle.protect.protectionTags = [
 	{
 		label: 'Pending changes templates',
 		list: [
-			{ label: '{{pp-pc1}}: pending changes level 1', value: 'pp-pc1' }
+			{ label: '{{pp-pc}}: pending changes', value: 'pp-pc' }
 		]
 	},
 	{
@@ -1451,8 +1445,6 @@ Twinkle.protect.callbacks = {
 				if (result) {
 					if (stabilizeLevel.level === "autoconfirmed") {
 						result += 2;
-					} else if (stabilizeLevel.level === "review") {
-						result += 7;
 					}
 				} else {
 					result = Twinkle.protect.protectionWeight["flaggedrevs_" + stabilizeLevel];


### PR DESCRIPTION
Pending Changes level 2 was officially turned off in Jan 2017 after the conclusion of a series of RFCs
(See https://en.wikipedia.org/wiki/Wikipedia:Pending_changes#Timeline but most prominently
https://en.wikipedia.org/wiki/Wikipedia:Pending_changes/Request_for_Comment_2016#Summary_of_previous_discussions and
https://en.wikipedia.org/wiki/Wikipedia:Village_pump_(proposals)/Archive_137#Make_PC2_no_longer_available_to_admins).
The code has remained here since its introduction in e97c9b05 but is now just cluttering the dropdown with a grayed-out "do not use."
I've kept the weights for PC1 the same.

While I don't believe there has been a broad discussion about explicitly referring to PC1 as just PC, it has been endorsed several times:
- The final discussion turning PC2 off
- Template:Pp-pc2 and the PC2 category were deleted at TfD: https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2017_February_18#Template:Pp-pc2
- The PC1 category was renamed to PC at CfD: https://en.wikipedia.org/wiki/Wikipedia:Categories_for_discussion/Log/2017_December_10#Category:Wikipedia_pending_changes_protected_pages_(level_1)
- Template:Pp-pc1 was recently moved to Template:Pp-pc after an (admittedly poorly attended) RM: https://en.wikipedia.org/wiki/Template_talk:Pp-pc#Requested_move_5_October_2018

I've removed references to PC2 and changed those of PC1 to PC in
Module:Protection banner: https://en.wikipedia.org/wiki/Module:Protection_banner/config