### PR TITLE
protect: Remove autoconfirmed from dropdowns when inappropriate

### DIFF
--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -134,11 +134,6 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		});
 	movelevel.append({
 			type: 'option',
-			label: 'Autoconfirmed',
-			value: 'autoconfirmed'
-		});
-	movelevel.append({
-			type: 'option',
 			label: 'Extended confirmed',
 			value: 'extendedconfirmed'
 		});

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -324,11 +324,6 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					});
 				movelevel.append({
 						type: 'option',
-						label: 'Autoconfirmed',
-						value: 'autoconfirmed'
-					});
-				movelevel.append({
-						type: 'option',
 						label: 'Extended confirmed',
 						value: 'extendedconfirmed'
 					});
@@ -446,11 +441,13 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						label: 'All',
 						value: 'all'
 					});
-				createlevel.append({
-						type: 'option',
-						label: 'Autoconfirmed',
-						value: 'autoconfirmed'
-					});
+				if (mw.config.get("wgNamespaceNumber") !== 0) {
+					createlevel.append({
+							type: 'option',
+							label: 'Autoconfirmed',
+							value: 'autoconfirmed'
+						});
+				}
 				if (isTemplate) {
 					createlevel.append({
 							type: 'option',


### PR DESCRIPTION
1. (auto)confirmed is needed to move any page, even in your own userspace
2. After WP:ACPERM, (auto)confirmed is needed to create an article in mainspace
3. Removed AC move protection option from batchdelete