### PR TITLE
twinkle: Tweak default CSD pref to not mark as patrolled

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -80,7 +80,7 @@ Twinkle.defaultConfig.twinkle = {
 	// CSD
 	speedySelectionStyle: "buttonClick",
 	watchSpeedyPages: [ "g3", "g5", "g10", "g11", "g12" ],
-	markSpeedyPagesAsPatrolled: true,
+	markSpeedyPagesAsPatrolled: false,
 
 	// these next two should probably be identical by default
 	notifyUserOnSpeedyDeletionNomination:    [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],


### PR DESCRIPTION
Per issue #452 