### PR TITLE
tag: |reason= and |talk= fields for {{Expert needed}}, edit summary fix for custom tags with parameter

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -195,13 +195,26 @@ Twinkle.tag.updateSortOrder = function(e) {
 				};
 				break;
 			case "expert needed":
-				checkbox.subgroup = {
+				checkbox.subgroup = [ {
 					name: 'expertNeeded',
 					type: 'input',
 					label: 'Name of relevant WikiProject: ',
 					tooltip: 'Optionally, enter the name of a WikiProject which might be able to help recruit an expert. Don\'t include the "WikiProject" prefix.'
-				};
-				break;
+				}, 
+				{
+					name: 'expertNeededReason',
+					type: 'input',
+					label: 'Reason: ',
+					tooltip: 'Short explanation describing the issue. Either Reason or Talk link is required.'
+				}, 
+				{
+					name: 'expertNeededTalk',
+					type: 'input',
+					label: 'Talk discussion: ',
+					tooltip: 'Name of the section of this article\'s talk page where the issue is being discussed. Do not give a link, just the name of the section. Either Reason or Talk link is required.'
+				}
+				];
+				break; 
 			case "globalize":
 				checkbox.subgroup = {
 					name: 'globalize',
@@ -408,8 +421,11 @@ Twinkle.tag.updateSortOrder = function(e) {
 		var $checkbox = $(checkbox);
 		var link = Morebits.htmlNode("a", ">");
 		link.setAttribute("class", "tag-template-link");
-		link.setAttribute("href", mw.util.getUrl("Template:" +
-			Morebits.string.toUpperCaseFirstChar(checkbox.values)));
+		var linkto = Morebits.string.toUpperCaseFirstChar(checkbox.values);
+		link.setAttribute("href", mw.util.getUrl(
+			(linkto.indexOf(":") === -1 ? "Template:" : "") +
+			(linkto.indexOf("|") === -1 ? linkto : linkto.slice(0,linkto.indexOf("|")))
+		));
 		link.setAttribute("target", "_blank");
 		$checkbox.parent().append(["\u00A0", link]);
 	});
@@ -925,8 +941,14 @@ Twinkle.tag.callbacks = {
 						}
 						break;
 					case 'expert needed':
-						if (params.tagParameters.expertNeeded) {
-							currentTag += '|1=' + params.tagParameters.expertNeeded;
+						if (params.expertNeeded) {
+							currentTag += '|1=' + params.expertNeeded;
+						}
+						if(params.expertNeededTalk) {
+							currentTag += '|talk=' + params.expertNeededTalk;
+						}
+						if(params.expertNeededReason) {
+							currentTag += '|reason=' + params.expertNeededReason;
 						}
 						break;
 					case 'news release':
@@ -982,8 +1004,18 @@ Twinkle.tag.callbacks = {
 			summaryText += ' {{[[:';
 			if( tagName === 'globalize' ) {
 				summaryText += "Template:" + params.tagParameters.globalize + '|' + params.tagParameters.globalize;
+			} else if( tagName.indexOf("|") !== -1 ) {
+				//if it is a custom tag with a parameter
+				var slicedTagName = tagName.slice(0,tagName.indexOf("|"));
+				if( tagName.indexOf(":") !== -1 ) {
+					summaryText += slicedTagName;
+				} else {
+					summaryText += "Template:" + slicedTagName + "|" + slicedTagName;
+				}
+			} else if( tagName.indexOf(":") !== -1 ) {
+				summaryText += tagName;
 			} else {
-				summaryText += (tagName.indexOf(":") !== -1 ? tagName : ("Template:" + tagName + "|" + tagName));
+				summaryText += "Template:" + tagName + "|" + tagName;
 			}
 			summaryText += ']]}}';
 		};
@@ -1361,6 +1393,9 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 				globalize: form["articleTags.globalize"] ? form["articleTags.globalize"].value : null,
 				notability: form["articleTags.notability"] ? form["articleTags.notability"].value : null
 			};
+			params.expertNeeded = form["articleTags.expertNeeded"] ? form["articleTags.expertNeeded"].value : null,
+			params.expertNeededTalk = form["articleTags.expertNeededTalk"] ? form["articleTags.expertNeededTalk"].value : null,
+			params.expertNeededReason = form["articleTags.expertNeededReason"] ? form["articleTags.expertNeededReason"].value : null,
 			// common to {{merge}}, {{merge from}}, {{merge to}}
 			params.mergeTarget = form["articleTags.mergeTarget"] ? form["articleTags.mergeTarget"].value : null;
 			params.mergeReason = form["articleTags.mergeReason"] ? form["articleTags.mergeReason"].value : null;

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -195,7 +195,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 				};
 				break;
 			case "expert needed":
-				checkbox.subgroup = [ {
+				checkbox.subgroup = [
+					{
 					name: 'expertNeeded',
 					type: 'input',
 					label: 'Name of relevant WikiProject: ',

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -200,7 +200,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 					type: 'input',
 					label: 'Name of relevant WikiProject: ',
 					tooltip: 'Optionally, enter the name of a WikiProject which might be able to help recruit an expert. Don\'t include the "WikiProject" prefix.'
-				}, 
+				},
 				{
 					name: 'expertNeededReason',
 					type: 'input',

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -206,7 +206,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 					type: 'input',
 					label: 'Reason: ',
 					tooltip: 'Short explanation describing the issue. Either Reason or Talk link is required.'
-				}, 
+				},
 				{
 					name: 'expertNeededTalk',
 					type: 'input',

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1390,10 +1390,10 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 				cleanup: form["articleTags.cleanup"] ? form["articleTags.cleanup"].value : null,
 				copyEdit: form["articleTags.copyEdit"] ? form["articleTags.copyEdit"].value : null,
 				copypaste: form["articleTags.copypaste"] ? form["articleTags.copypaste"].value : null,
-				expertNeeded: form["articleTags.expertNeeded"] ? form["articleTags.expertNeeded"].value : null,
 				globalize: form["articleTags.globalize"] ? form["articleTags.globalize"].value : null,
 				notability: form["articleTags.notability"] ? form["articleTags.notability"].value : null
 			};
+			// {{expert needed}} parameters:
 			params.expertNeeded = form["articleTags.expertNeeded"] ? form["articleTags.expertNeeded"].value : null,
 			params.expertNeededTalk = form["articleTags.expertNeededTalk"] ? form["articleTags.expertNeededTalk"].value : null,
 			params.expertNeededReason = form["articleTags.expertNeededReason"] ? form["articleTags.expertNeededReason"].value : null,

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -215,7 +215,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 					tooltip: 'Name of the section of this article\'s talk page where the issue is being discussed. Do not give a link, just the name of the section. Either Reason or Talk link is required.'
 				}
 				];
-				break; 
+				break;
 			case "globalize":
 				checkbox.subgroup = {
 					name: 'globalize',


### PR DESCRIPTION
1.  Added |reason= and |talk= fields to {{[Expert needed](https://en.wikipedia.org/wiki/Template:Expert_needed)}} as requested at [Wikipedia:Twinkle/to_do](https://en.wikipedia.org/wiki/Wikipedia:Twinkle/to_do) . Either of these two fields is compulsory per documentation. (Though this isn't enforced here) 

2. Per Issue #353, edit summary is buggy when a custom tag with parameter is added. Also handled this issue for the case that the tag isn't in template namespace.

