### PR TITLE
prod: add alert if BLPPROD is applied but article is not in Category:Living people

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -177,10 +177,21 @@ Twinkle.prod.callbacks = {
 		var text = pageobj.getPageText();
 		var params = pageobj.getCallbackParameters();
 
+		// Check for already existing deletion tags
 		var tag_re = /({{(?:db-?|delete|[aitcmrs]fd|md1)[^{}]*?\|?[^{}]*?}})/i;
 		if( tag_re.test( text ) ) {
 			statelem.warn( 'Page already tagged with a deletion template, aborting procedure' );
 			return;
+		}
+
+		// Alert if article is not in Category:Living people and BLPPROD is selected
+		if( params.blp ) {
+			var blpcheck_re = /\[\[Category:Living people\]\]/i;
+			if( !blpcheck_re.test( text ) ) {
+				if( ! confirm("Please note that the article is not in Category:Living people and hence may be ineligible for BLPPROD. Are you sure you want to continue? \n\nYou may wish to add the category if you proceed, unless the article is about a recently deceased person." ) ) {
+					return;
+				}
+			}
 		}
 
 		// Remove tags that become superfluous with this action


### PR DESCRIPTION
If page is being nominated for BLPPROD, a check is done to see if article has [[Category:Living people]]. If not, user is warned about it and they can choose to either continue or abort the action.  If they choose to continue, [[Category:Living people]] is added to the article along with the prod tag. 

This feature makes TW smarter and helps prevent bios of deceased people (and non-bios) from being mistakenly tagged for blp-prod. 