### PR TITLE
twinkle: improve TW menu button in vector skin

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -290,7 +290,19 @@ Twinkle.addPortlet = function( navigation, id, text, type, nextnodeid )
 		root.appendChild( outerDiv );
 	}
 
+	if( outerDivClass === "vectorMenu" ) {	
+		// add invisible checkbox to make menu keyboard accessible
+		// similar to the p-cactions ("More") menu
+		var chkbox = document.createElement( "input" );
+		chkbox.className = "vectorMenuCheckbox";
+		chkbox.setAttribute( "type","checkbox" );
+		chkbox.setAttribute( "aria-labelledby", "p-twinkle-label" );
+		outerDiv.appendChild( chkbox );
+	}
 	var h5 = document.createElement( "h3" );
+	if(outerDivClass === "vectorMenu") { 
+		h5.id = "p-twinkle-label";
+	}
 	if ( type === "menu" ) {
 		var span = document.createElement( "span" );
 		span.appendChild( document.createTextNode( text ) );


### PR DESCRIPTION
Per https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=868832371&diffmode=source#Twinkle_dropdown_in_Vector, added a `<input type="checkbox" class="vectorMenuCheckBox" aria-labelledby="p-twinkle-label">` to the relevant div element. And added `id="p-twinkle-label"` to the "TW" heading text. 

This provides TW button with the same special effects of the More button. 

I have been unable to test this by any of the usual methods. Pasting code to console or loading it from userspace js page lead to a bizarre "Twinkle.arv() is not a function" error. Looks like the only way to test would be to apply these changes to https://test.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.js .