### PR TITLE
Fix rollback link on contribs page

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -61,7 +61,7 @@ Twinkle.fluff = {
 				revVandNode.appendChild(revVandLink);
 
 				list.each(function(key, current) {
-					var href = $(current).children("a:eq(1)").attr("href");
+					var href = $(current).find(".mw-changeslist-diff").attr("href");
 					current.appendChild( document.createTextNode(' ') );
 					var tmpNode = revNode.cloneNode( true );
 					tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'norm' } ) );


### PR DESCRIPTION
Fix rollback link on contribs page
    
Previous discussion: https://github.com/azatoth/twinkle/commit/9b61d36a364cd1a9fce2e72b0b7ed13aa291fc00#comments
    
Starting around Nov 10, there were multiple reports of failed rollbacks from the contribs page at WT:TW: [here](https://en.wikipedia.org/w/index.php?oldid=872508505#Problem_when_clicking_on_%22vandalism%22_link_while_examining_user_contributions) and [here](https://en.wikipedia.org/w/index.php?oldid=872508505#Rollback_malfunction)
    
[T205581](https://phabricator.wikimedia.org/T205581) introduced a number of css changes to allow for full skinnability.  [One of these changes](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/461237) put the diff and hist links into their own span, thus hiding the a elements as children of that span rather than span.mw-uctop.  This finds the link with .mw-changeslist-diff directly, on the off chance the order is changed.