### PR TITLE
speedy: add R4, merge db-blankdraft to G13

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -36,7 +36,7 @@ Twinkle.config.commonSets = {
 		f1: "F1", f2: "F2", f3: "F3", f7: "F7", f8: "F8", f9: "F9", f10: "F10",
 		c1: "C1",
 		t2: "T2", t3: "T3",
-		r2: "R2", r3: "R3",
+		r2: "R2", r3: "R3", r4: "R4",
 		p1: "P1", p2: "P2"
 	},
 	csdCriteriaDisplayOrder: [
@@ -47,7 +47,7 @@ Twinkle.config.commonSets = {
 		"f1", "f2", "f3", "f7", "f8", "f9", "f10",
 		"c1",
 		"t2", "t3",
-		"r2", "r3",
+		"r2", "r3", "r4",
 		"p1", "p2"
 	],
 	csdCriteriaNotification: {
@@ -59,7 +59,7 @@ Twinkle.config.commonSets = {
 		f1: "F1", f2: "F2", f3: "F3", f7: "F7", f8: "F8", f9: "F9", f10: "F10",
 		c1: "C1",
 		t2: "T2", t3: "T3",
-		r2: "R2", r3: "R3",
+		r2: "R2", r3: "R3", r4: "R4",
 		p1: "P1", p2: "P2"
 	},
 	csdCriteriaNotificationDisplayOrder: [
@@ -70,7 +70,7 @@ Twinkle.config.commonSets = {
 		"f1", "f2", "f3", "f7", "f9", "f10",
 		"c1",
 		"t2", "t3",
-		"r2", "r3",
+		"r2", "r3", "r4",
 		"p1", "p2"
 	],
 	csdAndDICriteria: {
@@ -81,7 +81,7 @@ Twinkle.config.commonSets = {
 		f1: "F1", f2: "F2", f3: "F3", f4: "F4", f5: "F5", f6: "F6", f7: "F7", f8: "F8", f9: "F9", f10: "F10", f11: "F11",
 		c1: "C1",
 		t2: "T2", t3: "T3",
-		r2: "R2", r3: "R3",
+		r2: "R2", r3: "R3", r4: "R4",
 		p1: "P1", p2: "P2"
 	},
 	csdAndDICriteriaDisplayOrder: [
@@ -92,7 +92,7 @@ Twinkle.config.commonSets = {
 		"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11",
 		"c1",
 		"t2", "t3",
-		"r2", "r3",
+		"r2", "r3", "r4",
 		"p1", "p2"
 	],
 	namespacesNoSpecial: {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -797,9 +797,9 @@ Twinkle.speedy.userNonRedirectList = [
 		hideWhenMultiple: true
 	},
 	{
-		label: 'G13: Old, abandoned AfC submission or blank draft',
+		label: 'G13: AfC draft submission or a blank draft, stale by over 6 months',
 		value: 'afc',
-		tooltip: 'Any rejected or unsubmitted AfC submission, or a blank draft, unedited in over 6 months,',
+		tooltip: 'Any rejected or unsubmitted AfC draft submission or a blank draft, that has not been edited in over 6 months (excluding bot edits).',
 		hideWhenMultiple: true
 	}
 ];
@@ -1037,9 +1037,9 @@ Twinkle.speedy.generalList = [
 		]
 	},
 	{
-		label: 'G13: Old, abandoned Articles for Creation submissions',
+		label: 'G13: Page in draft namespace or userspace AfC submission, stale by over 6 months',
 		value: 'afc',
-		tooltip: 'Any rejected or unsubmitted AfC submission that has not been edited for more than 6 months.',
+		tooltip: 'Any rejected or unsubmitted AfC submission in userspace or any page in draft namespace, that has not been edited for more than 6 months. Blank drafts in either namespace are also included.',
 		hideWhenRedirect: true
 	}
 ];
@@ -1088,7 +1088,6 @@ Twinkle.speedy.normalizeHash = {
 	'disambig': 'g6',
 	'movedab': 'g6',
 	'copypaste': 'g6',
-	'blankdraft': 'g6',
 	'g6': 'g6',
 	'author': 'g7',
 	'g8': 'g8',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -644,7 +644,7 @@ Twinkle.speedy.fileList = [
 	{
 		label: 'G8: File description page with no corresponding file',
 		value: 'imagepage',
-		tooltip: 'This is only for use when the file doesn\'t exist at all. Corrupt files, and local description pages for files on Commons, should use F2; implausible redirects should use R3; and broken Commons redirects should use G6.'
+		tooltip: 'This is only for use when the file doesn\'t exist at all. Corrupt files, and local description pages for files on Commons, should use F2; implausible redirects should use R3; and broken Commons redirects should use R4.'
 	}
 ];
 
@@ -791,15 +791,15 @@ Twinkle.speedy.userNonRedirectList = [
 		tooltip: 'Pages in userspace consisting of writings, information, discussions, and/or activities not closely related to Wikipedia\'s goals, where the owner has made few or no edits outside of userspace, with the exception of plausible drafts, pages adhering to WP:UPYES, and résumé-style pages.'
 	},
 	{
-		label: 'G6: Blank draft',
-		value: 'blankdraft',
-		tooltip: 'Userspace drafts containing only the default Article Wizard text, where the author of the page has been inactive for at least one year.',
-		hideWhenMultiple: true
-	},
-	{
 		label: 'G11: Promotional user page under a promotional user name',
 		value: 'spamuser',
 		tooltip: 'A promotional user page, with a username that promotes or implies affiliation with the thing being promoted. Note that simply having a page on a company or product in one\'s userspace does not qualify it for deletion. If a user page is spammy but the username is not, then consider tagging with regular G11 instead.',
+		hideWhenMultiple: true
+	},
+	{
+		label: 'G13: Old, abandoned AfC submission or blank draft',
+		value: 'afc',
+		tooltip: 'Any rejected or unsubmitted AfC submission, or a blank draft, unedited in over 6 months,',
 		hideWhenMultiple: true
 	}
 ];
@@ -1056,6 +1056,11 @@ Twinkle.speedy.redirectList = [
 		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
 	},
 	{
+		label: 'R4: File namespace redirect with name that matches a Commons page',
+		value: 'redircom',
+		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).'
+	},
+	{
 		label: 'G6: Redirect to malplaced disambiguation page',
 		value: 'movedab',
 		tooltip: 'This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.',
@@ -1115,6 +1120,7 @@ Twinkle.speedy.normalizeHash = {
 	'madeup': 'a11',
 	'rediruser': 'r2',
 	'redirtypo': 'r3',
+	'redircom' : 'r4',
 	'redundantimage': 'f1',
 	'noimage': 'f2',
 	'fpcfail': 'f2',


### PR DESCRIPTION
Added newly-introduced CSD R4 per [discussion](https://en.wikipedia.org/wiki/Special:PermanentLink/872246394#Redirects_in_the_File:_namespace_G6_%E2%86%92_R4). Merged db-blankdraft to db-g13 per [discussion](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Criteria_for_speedy_deletion&oldid=872669362#Proposal_to_merge_db-blankdraft_into_G13)

Closes #466. 