### PR TITLE
tag: add more parameters

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -368,6 +368,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 						{ label: "{{notability|Numbers}}: notability guideline for numbers", value: "Numbers" },
 						{ label: "{{notability|Products}}: notability guideline for products and services", value: "Products" },
 						{ label: "{{notability|Sport}}: notability guideline for sports and athletics", value: "Sport" },
+						{ label: "{{notability|Television}}: notability guideline for television shows", value: "Television" },
 						{ label: "{{notability|Web}}: notability guideline for web content", value: "Web" }
 					]
 				};
@@ -1492,12 +1493,11 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 		alert( 'Tagging multiple articles in a merge, and starting a discussion for multiple articles, is not supported at the moment. Please turn off "tag other article", and/or clear out the "reason" box, and try again.' );
 		return;
 	}
-	if( params.tags.indexOf('cleanup') !== -1 && params.tagParameters.cleanup.trim && params.tagParameters.cleanup.trim() === "") {
+	if( params.tags.indexOf('cleanup') !== -1 && params.tagParameters.cleanup.trim() === '') {
 		alert( 'You must specify a reason for the {{cleanup}} tag.' );
 		return;
 	}
-
-	if(params.tags.indexOf('expand language') !== -1 && params.tagParameters.expandLanguageLangCode == null) {
+	if( params.tags.indexOf('expand language') !== -1 && params.tagParameters.expandLanguageLangCode.trim() === '') {
 		alert('You must specify language code for the {{expand language}} tag.');
 		return;
 	}

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -100,7 +100,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label: 'License and sourcing problem tags' });
 			form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.tag.file.licenseList } );
-
+		
 			form.append({ type: 'header', label: 'Wikimedia Commons-related tags' });
 			form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.tag.file.commonsList } );
 
@@ -119,7 +119,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label:'Spelling, misspelling, tense and capitalization templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.spellingList });
-
+			
 			form.append({ type: 'header', label:'Alternative name templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.alternativeList });
 
@@ -696,9 +696,28 @@ Twinkle.tag.spellingList = [
 ];
 
 Twinkle.tag.alternativeList = [
-	{
+	{ 
 		label: '{{R from alternative language}}: redirect from an English name to a name in another language, or vice-versa',
-		value: 'R from alternative language'
+		value: 'R from alternative language',
+		subgroup : [ 
+			{
+				name: 'altLangFrom',
+				type: 'input',
+				label: 'From language (two-letter code): ',
+				tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German'
+			},
+			{
+				name: 'altLangTo',
+				type: 'input',
+				label: 'To language (two-letter code): ',
+				tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German'
+			},
+			{
+				name: 'altLangInfo',
+				type: 'div',
+				label: $.parseHTML('<p>For a list of language codes, see <a href="/wiki/Wp:Template_messages/Redirect_language_codes">Wikipedia:Template messages/Redirect language codes</a></p>')
+			} 
+		]
 	},
 	{
 		label: '{{R from alternative name}}: redirect from a title that is another name, a pseudonym, a nickname, or a synonym',
@@ -888,8 +907,7 @@ Twinkle.tag.callbacks = {
 		var addTag = function friendlytagAddTag( tagIndex, tagName ) {
 			var currentTag = "";
 			if( tagName === 'uncategorized' || tagName === 'improve categories' ) {
-				pageText += '\n\n{{' + tagName +
-					'|date={{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}}}';
+				pageText += '\n\n{{' + tagName + '|date={{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}}}';
 			} else {
 				if( tagName === 'globalize' ) {
 					currentTag += '{{' + params.tagParameters.globalize;
@@ -980,6 +998,14 @@ Twinkle.tag.callbacks = {
 								}
 								currentTag += '|discuss=Talk:' + params.discussArticle + '#' + params.talkDiscussionTitle;
 							}
+						}
+						break;
+					case 'R from alternative language':
+						if(params.altLangFrom) {
+							currentTag += '|from=' + params.altLangFrom;
+						}
+						if(params.altLangTo) {
+							currentTag += '|to=' + params.altLangTo;
 						}
 						break;
 					default:
@@ -1426,6 +1452,8 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			break;
 		case 'redirect':
 			params.tags = form.getChecked( 'redirectTags' );
+			params.altLangFrom = form["redirectTags.altLangFrom"] ? form["redirectTags.altLangFrom"].value : null;
+			params.altLangTo = form["redirectTags.altLangTo"] ? form["redirectTags.altLangTo"].value : null;
 			break;
 		default:
 			alert("Twinkle.tag: unknown mode " + Twinkle.tag.mode);
@@ -1482,5 +1510,5 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 };
 })(jQuery);
 
-
 //</nowiki>
+	

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -174,6 +174,14 @@ Twinkle.tag.updateSortOrder = function(e) {
 					size: 35
 				};
 				break;
+			case "close paraphrasing":
+				checkbox.subgroup = {
+					name: 'closeParaphrasing',
+					type: 'input',
+					label: 'Source: ',
+					tooltip: 'Source that has been closely paraphrased'
+				};
+				break;
 			case "copy edit":
 				checkbox.subgroup = {
 					name: 'copyEdit',
@@ -938,6 +946,9 @@ Twinkle.tag.callbacks = {
 					case 'cleanup':
 						currentTag += '|reason=' + params.tagParameters.cleanup;
 						break;
+					case 'close paraphrasing':
+						currentTag += '|source=' + params.tagParameters.closeParaphrasing;
+						break;
 					case 'copy edit':
 						if (params.tagParameters.copyEdit) {
 							currentTag += '|for=' + params.tagParameters.copyEdit;
@@ -1427,6 +1438,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			params.group = form.group.checked;
 			params.tagParameters = {
 				cleanup: form["articleTags.cleanup"] ? form["articleTags.cleanup"].value : null,
+				closeParaphrasing: form["articleTags.closeParaphrasing"] ? form["articleTags.closeParaphrasing"].value : null,
 				copyEdit: form["articleTags.copyEdit"] ? form["articleTags.copyEdit"].value : null,
 				copypaste: form["articleTags.copypaste"] ? form["articleTags.copypaste"].value : null,
 				expandLanguageLangCode: form["articleTags.expandLanguageLangCode"] ? form["articleTags.expandLanguageLangCode"].value : null,

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -100,7 +100,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label: 'License and sourcing problem tags' });
 			form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.tag.file.licenseList } );
-		
+
 			form.append({ type: 'header', label: 'Wikimedia Commons-related tags' });
 			form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.tag.file.commonsList } );
 
@@ -119,7 +119,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label:'Spelling, misspelling, tense and capitalization templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.spellingList });
-			
+
 			form.append({ type: 'header', label:'Alternative name templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.alternativeList });
 
@@ -191,6 +191,20 @@ Twinkle.tag.updateSortOrder = function(e) {
 					tooltip: 'If known.',
 					size: 50
 				};
+				break;
+			case "expand language":
+				checkbox.subgroup = [ {
+						name: 'expandLanguageLangCode',
+						type: 'input',
+						label: 'Language code: ',
+						tooltip: 'Language code of the language from which article is to be expanded from'
+					}, {
+						name: 'expandLanguageArticle',
+						type: 'input',
+						label: 'Name of article: ',
+						tooltip: 'Name of article to be expanded from, without the interwiki prefix'
+					},
+				]
 				break;
 			case "expert needed":
 				checkbox.subgroup = [
@@ -583,7 +597,7 @@ Twinkle.tag.article.tagCategories = {
 		],
 		"Timeliness": [
 			"current",
-			"update"			
+			"update"
 		],
 		"Neutrality, bias, and factual accuracy": [
 			"autobiography",
@@ -696,10 +710,10 @@ Twinkle.tag.spellingList = [
 ];
 
 Twinkle.tag.alternativeList = [
-	{ 
+	{
 		label: '{{R from alternative language}}: redirect from an English name to a name in another language, or vice-versa',
 		value: 'R from alternative language',
-		subgroup : [ 
+		subgroup : [
 			{
 				name: 'altLangFrom',
 				type: 'input',
@@ -716,7 +730,7 @@ Twinkle.tag.alternativeList = [
 				name: 'altLangInfo',
 				type: 'div',
 				label: $.parseHTML('<p>For a list of language codes, see <a href="/wiki/Wp:Template_messages/Redirect_language_codes">Wikipedia:Template messages/Redirect language codes</a></p>')
-			} 
+			}
 		]
 	},
 	{
@@ -922,9 +936,7 @@ Twinkle.tag.callbacks = {
 				// prompt for other parameters, based on the tag
 				switch( tagName ) {
 					case 'cleanup':
-						if (params.tagParameters.cleanup) {
-							currentTag += '|reason=' + params.tagParameters.cleanup;
-						}
+						currentTag += '|reason=' + params.tagParameters.cleanup;
 						break;
 					case 'copy edit':
 						if (params.tagParameters.copyEdit) {
@@ -938,21 +950,9 @@ Twinkle.tag.callbacks = {
 						break;
 					case 'expand language':
 						currentTag += '|topic=';
-						var langcode = prompt('Please enter the language code of the other wiki (e.g. "fr", "roa-rup").  \n' +
-							"This information is required.  To skip the {{expand language}} tag, click Cancel.", "");
-						if (langcode === null || langcode === "") {
-							Morebits.status.warn("Notice", "{{expand language}} tag skipped by user");
-							return true;  // continue to next tag
-						} else {
-							currentTag += '|langcode=' + langcode;
-						}
-						var otherart = prompt('Please enter the name of the article in the other wiki (without interwiki prefix).  \n' +
-							"This information is optional.  To skip the {{expand language}} tag, click Cancel.", "");
-						if (otherart === null) {
-							Morebits.status.warn("Notice", "{{expand language}} tag skipped by user");
-							return true;  // continue to next tag
-						} else {
-							currentTag += '|otherarticle=' + otherart;
+						currentTag += '|langcode=' + params.tagParameters.expandLanguageLangCode;
+						if (params.tagParameters.expandLanguageArticle !== null) {
+							currentTag += '|otherarticle=' + params.tagParameters.expandLanguageArticle;
 						}
 						break;
 					case 'expert needed':
@@ -1429,6 +1429,8 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 				cleanup: form["articleTags.cleanup"] ? form["articleTags.cleanup"].value : null,
 				copyEdit: form["articleTags.copyEdit"] ? form["articleTags.copyEdit"].value : null,
 				copypaste: form["articleTags.copypaste"] ? form["articleTags.copypaste"].value : null,
+				expandLanguageLangCode: form["articleTags.expandLanguageLangCode"] ? form["articleTags.expandLanguageLangCode"].value : null,
+				expandLanguageArticle: form["articleTags.expandLanguageArticle"] ? form["articleTags.expandLanguageArticle"].value : null,
 				globalize: form["articleTags.globalize"] ? form["articleTags.globalize"].value : null,
 				notability: form["articleTags.notability"] ? form["articleTags.notability"].value : null
 			};
@@ -1483,6 +1485,11 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 		return;
 	}
 
+	if(params.tags.indexOf('expand language') !== -1 && params.tagParameters.expandLanguageLangCode == null) {
+		alert('You must specify language code for the {{expand language}} tag.');
+		return;
+	}
+
 	Morebits.simpleWindow.setButtonsEnabled( false );
 	Morebits.status.init( form );
 
@@ -1511,4 +1518,3 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 })(jQuery);
 
 //</nowiki>
-	

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -9,10 +9,8 @@
  *** friendlytag.js: Tag module
  ****************************************
  * Mode of invocation:     Tab ("Tag")
- * Active on:              Existing articles; file pages with a corresponding file
- *                         which is local (not on Commons); existing subpages of
- *                         {Wikipedia|Wikipedia talk}:Articles for creation;
- *                         all redirects
+ * Active on:              Existing articles and drafts; file pages with a corresponding file
+ *                         which is local (not on Commons); all redirects
  * Config directives in:   FriendlyConfig
  */
 
@@ -28,7 +26,7 @@ Twinkle.tag = function friendlytag() {
 		Twinkle.addPortletLink( Twinkle.tag.callback, "Tag", "friendly-tag", "Add maintenance tags to file" );
 	}
 	// article/draft article tagging
-	else if( ( mw.config.get('wgNamespaceNumber') === 0 || mw.config.get('wgNamespaceNumber') === 118 || /^Wikipedia( talk)?:Articles for creation\//.exec(Morebits.pageNameNorm) ) && mw.config.get('wgCurRevisionId') ) {
+	else if( ( [0, 118].indexOf(mw.config.get('wgNamespaceNumber')) !== -1 ) && mw.config.get('wgCurRevisionId') ) {
 		Twinkle.tag.mode = 'article';
 		Twinkle.addPortletLink( Twinkle.tag.callback, "Tag", "friendly-tag", "Add maintenance tags to article" );
 	}


### PR DESCRIPTION
Closes #250. 

~~I have no idea how to link the help pointer to [[Wikipedia:Template messages/Redirect language codes]],~~ as quickForm input labels don't allow links (or any kind of HTML) in them. This is due to use of `node.appendChild( document.createTextNode( data.label ) );` kinda code in morebits.js; it would have been better if morebits had simply used `node.innerHTML = data.label`. UPDATE: Done now, $.parseHTML was the answer.

~~As an aside, I made `var makeCheckbox = function(tag, description)` from Twinkle.tag.updateSortOrder (where it was used only for articles) global, as Twinkle.tag.makeCheckbox, as this function could potentially be used elsewhere. This would've made the diff look messy. Sorry for that :(~~ Reverted, in hindsight, it was never necessary. It's easier to make a checkbox elsewhere, w/o running through the whole switch.

As a separate commit, I removed WP/WT:AFC subpages from the tag's activation areas, as these locations are no longer used to host drafts. 