### PR TITLE
fluff: show rollback/vandalism links for IP ranges

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -38,7 +38,10 @@ Twinkle.fluff = {
 			return span;
 		};
 
-		if( mw.config.get('wgCanonicalSpecialPageName') === "Contributions" && mw.config.exists('wgRelevantUserName') ) {
+		// $('sp-contributions-footer-anon-range') relies on the fmbox
+		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
+		// is used to show rollback/vandalism links for IP ranges
+		if( mw.config.get('wgCanonicalSpecialPageName') === "Contributions" && (mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0])) {
 			//Get the username these contributions are for
 			var username = mw.config.get('wgRelevantUserName');
 			if( Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||


### PR DESCRIPTION
Follow-up to https://github.com/azatoth/twinkle/pull/439#issuecomment-436102516

Relies upon the id in `MediaWiki:Sp-contributions-footer-anon-range` to discover if we're viewing a range's contributions.  This is required because while using wgRelevantUserName (#439) avoids the previous iteration's console error, it isn't (reliably) refined for IP range, and doesn't exist when viewing their contributions (see https://phabricator.wikimedia.org/T206954).

Incidentally, this doesn't break for ranges outside the CIDR limit (/16 on enWiki) because mediawiki incorrectly shows `MediaWiki:Sp-contributions-footer-anon` in that case. Depending on how (or if) https://phabricator.wikimedia.org/T211910 is resolved, this may or may not need updating.