### PR TITLE
 tag: add custom tags for files and redirects as well

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -98,8 +98,6 @@ Twinkle.tag.callback = function friendlytagCallback() {
 		case 'file':
 			Window.setTitle( "File maintenance tagging" );
 
-			// TODO: perhaps add custom tags TO list of checkboxes
-
 			form.append({ type: 'header', label: 'License and sourcing problem tags' });
 			form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.tag.file.licenseList } );
 
@@ -114,6 +112,11 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label: 'Replacement tags' });
 			form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.tag.file.replacementList } );
+
+			if (Twinkle.getFriendlyPref('customFileTagList').length) {
+				form.append({ type: 'header', label: 'Custom tags' });
+				form.append({ type: 'checkbox', name: 'imageTags', list: Twinkle.getFriendlyPref('customFileTagList') });
+			}
 			break;
 
 		case 'redirect':
@@ -127,6 +130,11 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label:'Miscellaneous and administrative redirect templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.administrativeList });
+
+			if (Twinkle.getFriendlyPref('customRedirectTagList').length) {
+				form.append({ type: 'header', label: 'Custom tags' });
+				form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.getFriendlyPref('customRedirectTagList') });
+			}
 			break;
 
 		default:
@@ -569,7 +577,7 @@ Twinkle.tag.article.tagCategories = {
 		],
 		"Timeliness": [
 			"current",
-			"update"			
+			"update"
 		],
 		"Neutrality, bias, and factual accuracy": [
 			"autobiography",

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -555,6 +555,22 @@ Twinkle.config.sections = [
 			type: "customList",
 			customListValueTitle: "Template name (no curly brackets)",
 			customListLabelTitle: "Text to show in Tag dialog"
+		},
+		{
+			name: "customFileTagList",
+			label: "Custom file maintenance tags to display",
+			helptip: "Additional tags that you wish to add for files.",
+			type: "customList",
+			customListValueTitle: "Template name (no curly brackets)",
+			customListLabelTitle: "Text to show in Tag dialog"
+		},
+		{
+			name: "customRedirectTagList",
+			label: "Custom redirect category tags to display",
+			helptip: "Additional tags that you wish to add for redirects.",
+			type: "customList",
+			customListValueTitle: "Template name (no curly brackets)",
+			customListLabelTitle: "Text to show in Tag dialog"
 		}
 	]
 },

--- a/twinkle.js
+++ b/twinkle.js
@@ -145,6 +145,8 @@ Twinkle.defaultConfig.friendly = {
 	markTaggedPagesAsPatrolled: true,
 	tagArticleSortOrder: "cat",
 	customTagList: [],
+	customFileTagList: [],
+	customRedirectTagList: [],
 
 	// Welcome
 	topWelcomes: false,


### PR DESCRIPTION
Added custom tags support for files per request at [Wikipedia_talk:Twinkle#Custom_tags_for_non-article_namespace](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Custom_tags_for_non-article_namespace). Then realised that now only redirects are being left out, so added it to that too.