### PR TITLE
Morebits: add documentation

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -855,7 +855,9 @@ HTMLFormElement.prototype.getChecked = function( name, type ) {
 /**
  * **************** RegExp ****************
  *
- * RegExp.escape: Will escape a string to be used in a RegExp
+ * Escapes a string to be used in a RegExp
+ * @param {string} text - string to be escaped
+ * @param {boolean} [space_fix] - Set this true to replace spaces and underscore with `[ _]` as they are often equivalent
  */
 
 RegExp.escape = function( text, space_fix ) {
@@ -977,7 +979,6 @@ if (!String.prototype.trim) {
 	String.prototype.trim = function stringPrototypeTrim( ) {
 		return this.trimRight().trimLeft();
 	};
-	Morebits.string.splitWeightedByKeys()
 }
 
 Morebits.string = {
@@ -992,9 +993,12 @@ Morebits.string = {
 	},
 
 	/**
-	 * Gives an array of substrings of `str` starting with `start` and 
+	 * Gives an array of substrings of `str` starting with `start` and
 	 * ending with `end`, which is not in `skiplist`
-	 * @param {string} str  @param {string} start @param {string} end @param {(array|string)} skiplist 
+	 * @param {string} str
+	 * @param {string} start
+	 * @param {string} end
+	 * @param {(array|string)} [skiplist]
 	 */
 	splitWeightedByKeys: function( str, start, end, skiplist ) {
 		if( start.length !== end.length ) {
@@ -1039,9 +1043,9 @@ Morebits.string = {
 	},
 
 	/**
-	 * Formats freeform "reason" (from a textarea) for deletion/other templates 
+	 * Formats freeform "reason" (from a textarea) for deletion/other templates
 	 * that are going to be substituted, (e.g. PROD, XFD, RPP)
-	 * @param {string} str 
+	 * @param {string} str
 	 */
 	formatReasonText: function( str ) {
 		var result = str.toString().trimRight();
@@ -1052,13 +1056,13 @@ Morebits.string = {
 	},
 
 	/**
-	 * a replacement for `String.prototype.replace()` when the second parameter 
-	 * (the replacement string) is arbitrary, such as a username or freeform user input, 
+	 * a replacement for `String.prototype.replace()` when the second parameter
+	 * (the replacement string) is arbitrary, such as a username or freeform user input,
 	 * and may contain dollar signs
 	 */
 	safeReplace: function morebitsStringSafeReplace(string, pattern, replacement) {
 		return string.replace(pattern, replacement.replace(/\$/g, "$$$$"));
-	} 
+	}
 };
 
 
@@ -1068,7 +1072,7 @@ Morebits.string = {
 
 Morebits.array = {
 	/**
-	 * returns a copy of the array with duplicates removed 
+	 * @returns a copy of the array with duplicates removed
 	 */
 	uniq: function(arr) {
 		if ( ! Array.isArray( arr ) ) {
@@ -1085,7 +1089,7 @@ Morebits.array = {
 	},
 
 	/**
-	 * returns a copy of the array with the first instance of each value 
+	 * @returns a copy of the array with the first instance of each value
 	 * removed; subsequent instances of those values (duplicates) remain
 	 */
 	dups: function(arr) {
@@ -1108,9 +1112,9 @@ Morebits.array = {
 
 	/**
 	 * breaks up `arr` into smaller arrays of length `size`, and
-	 * returns an array of these "chunked" arrays
-	 * @param {array} arr 
-	 * @param {number} size 
+	 * @returns an array of these "chunked" arrays
+	 * @param {array} arr
+	 * @param {number} size
 	 */
 	chunk: function( arr, size ) {
 		if ( ! Array.isArray( arr ) ) {
@@ -1198,7 +1202,7 @@ Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
  * is fairly unlikely that anyone will iterate over a Date object.
  */
 
-Date.monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 
+Date.monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
 	'July', 'August', 'September', 'October', 'November','December' ];
 
 Date.monthNamesAbbrev = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -1298,14 +1302,12 @@ Morebits.wikipedia.namespacesFriendly = {
  * **************** Morebits.wiki ****************
  * Various objects for wiki editing and API access
  */
-
 Morebits.wiki = {};
 
 /**
  * Determines whether the current page is a redirect or soft redirect
  * (fails to detect soft redirects on edit, history, etc. pages)
  */
-
 Morebits.wiki.isPageRedirect = function wikipediaIsPageRedirect() {
 	return !!(mw.config.get("wgIsRedirect") || document.getElementById("softredirect"));
 };
@@ -1546,12 +1548,12 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  *
  * onSuccess and onFailure are callback functions called when the operation is a success or failure
  * if enclosed in [brackets], it indicates that it is optional
- * 
+ *
  * load(onSuccess, [onFailure]): Loads the text for the page
- * 
+ *
  * getPageText(): returns a string containing the text of the page after a successful load()
  *
- * save([onSuccess], [onFailure]):  Saves the text set via setPageText() for the page. 
+ * save([onSuccess], [onFailure]):  Saves the text set via setPageText() for the page.
  * 									Must be preceded by calling load().
  *    Warning: Calling save() can result in additional calls to the previous load() callbacks to
  *             recover from edit conflicts!
@@ -1563,15 +1565,15 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  *
  * prepend([onSuccess], [onFailure]): Adds the text provided via setPrependText() to the start of the page.
  *                                Does not require calling load() first.
- * 
+ *
  * move(onSuccess, [onFailure]): Moves a page to another title
  *
  * deletePage(onSuccess, [onFailure]): Deletes a page (for admins only)
- * 
+ *
  * protect(onSuccess, [onFailure]): Protects a page
  *
  * getPageName(): returns a string containing the name of the loaded page, including the namespace
- * 
+ *
  * setPageText(pageText) sets the updated page text that will be saved when save() is called
  *
  * setAppendText(appendText) sets the text that will be appended to the page when append() is called
@@ -1594,7 +1596,7 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  * exists(): returns true if the page existed on the wiki when it was last loaded
  *
  * getCurrentID(): returns a string containing the current revision ID of the page
- * 
+ *
  * lookupCreator(onSuccess): Retrieves the username of the user who created the page
  *    onSuccess - callback function which is called when the username is found
  *                within the callback, the username can be retrieved using the getCreator() function
@@ -1632,7 +1634,7 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  */
 
  /**
-  * @constructor 
+  * @constructor
   * @param {string} pageName The name of the page, prefixed by the namespace (if any)
   * For the current page, use mw.config.get('wgPageName')
   * @param {string} [currentAction] A string describing the action about to be undertaken (optional)
@@ -1736,8 +1738,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 	/**
 	 * Loads the text for the page
-	 *   @param {Function} onSuccess - callback function which is called when the load has succeeded
-	 *   @param {Function} onFailure - callback function which is called when the load fails (optional)
+	 * @param {Function} onSuccess - callback function which is called when the load has succeeded
+	 * @param {Function} onFailure - callback function which is called when the load fails (optional)
 	 */
 	this.load = function(onSuccess, onFailure) {
 		ctx.onLoadSuccess = onSuccess;
@@ -1784,13 +1786,13 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	/**
 	 * Saves the text for the page to Wikipedia
 	 * Must be preceded by successfully calling load().
-	 *    
+	 *
 	 * Warning: Calling save() can result in additional calls to the previous load() callbacks to
 	 *             recover from edit conflicts!
 	 *             In this case, callers must make the same edit to the new pageText and reinvoke save().
 	 *             This behavior can be disabled with setMaxConflictRetries(0).
-	 *  @param {Function} onSuccess - callback function which is called when the save has succeeded (optional)
-	 *  @param {Function} onFailure - callback function which is called when the save fails (optional)
+	 * @param {Function} onSuccess - callback function which is called when the save has succeeded (optional)
+	 * @param {Function} onFailure - callback function which is called when the save fails (optional)
 	 *
 	 */
 	this.save = function(onSuccess, onFailure) {
@@ -1887,8 +1889,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	/**
 	 * Adds the text provided via setAppendText() to the end of the page.
 	 * Does not require calling load() first.
-	 *    @param {Function} onSuccess - callback function which is called when the method has succeeded (optional)
-	 *    @param {Function} onFailure - callback function which is called when the method fails (optional)
+	 * @param {Function} onSuccess - callback function which is called when the method has succeeded (optional)
+	 * @param {Function} onFailure - callback function which is called when the method fails (optional)
 	 */
 	this.append = function(onSuccess, onFailure) {
 		ctx.editMode = 'append';
@@ -1905,8 +1907,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	/**
 	 * Adds the text provided via setPrependText() to the start of the page.
 	 * Does not require calling load() first.
-	 *  @param {Function}  onSuccess - callback function which is called when the method has succeeded (optional)
-	 *  @param {Function}  onFailure - callback function which is called when the method fails (optional)
+	 * @param {Function}  onSuccess - callback function which is called when the method has succeeded (optional)
+	 * @param {Function}  onFailure - callback function which is called when the method fails (optional)
 	 */
 	this.prepend = function(onSuccess, onFailure) {
 		ctx.editMode = 'prepend';
@@ -1921,14 +1923,14 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
-	 * returns a string containing the name of the loaded page, including the namespace
+	 * @returns a string containing the name of the loaded page, including the namespace
 	 */
 	this.getPageName = function() {
 		return ctx.pageName;
 	};
 
 	/**
-	 * returns a string containing the text of the page after a successful load()
+	 * @returns a string containing the text of the page after a successful load()
 	 */
 	this.getPageText = function() {
 		return ctx.pageText;
@@ -1976,7 +1978,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	 *       'nocreate'   - don't create the page, only edit it if it already exists
 	 *       null         - create the page if it does not exist, unless it was deleted in the moment
 	 *                      between retrieving the edit token and saving the edit (default)
-	 * 
+	 *
 	 */
 	this.setCreateOption = function(createOption) {
 		ctx.createOption = createOption;
@@ -1984,7 +1986,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 	/**
 	 * `minorEdit` - boolean value:
-	 * True  - When save is called, the resulting edit will be marked as "minor". 
+	 * True  - When save is called, the resulting edit will be marked as "minor".
 	 * False - When save is called, the resulting edit will not be marked as "minor". (default)
 	 */
 	this.setMinorEdit = function(minorEdit) {
@@ -1993,16 +1995,16 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 	/**
 	 * `botEdit` is a boolean value:
-	 *       True  - When save is called, the resulting edit will be marked as "bot".
-	 *       False - When save is called, the resulting edit will not be marked as "bot". (default)
+	 *  True  - When save is called, the resulting edit will be marked as "bot".
+	 *  False - When save is called, the resulting edit will not be marked as "bot". (default)
 	 */
 	this.setBotEdit = function(botEdit) {
 		ctx.botEdit = botEdit;
 	};
 
 	/**
-	 * `pageSection` - integer specifying the section number to load or save. The default is `null`, which means 
-	 * that the entire page will be retrieved.
+	 * `pageSection` - integer specifying the section number to load or save.
+	 * The default is `null`, which means that the entire page will be retrieved.
 	 */
 	this.setPageSection = function(pageSection) {
 		ctx.pageSection = pageSection;
@@ -2016,8 +2018,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
-	 * maxRetries - number of retries for save errors not involving an edit conflict or loss of edit token
-	 * Default:2
+	 * `maxRetries` - number of retries for save errors not involving an edit conflict or loss of edit token
+	 * Default: 2
 	 */
 	this.setMaxRetries = function(maxRetries) {
 		ctx.maxRetries = maxRetries;
@@ -2115,7 +2117,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
-	 *  returns a string containing the current revision ID of the page
+	 *  @returns a string containing the current revision ID of the page
 	 */
 	this.getCurrentID = function() {
 		return ctx.revertCurID;
@@ -2129,11 +2131,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 	/**
 	 * `callbackParameters` - an object for use in a callback function
-	 * 
-	 * Callback notes: callbackParameters is for use by the caller only. The parameters 
-	 * allow a caller to pass the proper context into its callback function. 
-	 * Callers must ensure that any changes to the callbackParameters object 
-	 * within a load() callback still permit a proper re-entry into the 
+	 *
+	 * Callback notes: callbackParameters is for use by the caller only. The parameters
+	 * allow a caller to pass the proper context into its callback function.
+	 * Callers must ensure that any changes to the callbackParameters object
+	 * within a load() callback still permit a proper re-entry into the
 	 * load() callback if an edit conflict is detected upon calling save().
 	 */
 	this.setCallbackParameters = function(callbackParameters) {
@@ -2141,33 +2143,33 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
-	 * returns the object previous set by setCallbackParameters()
+	 * @returns the object previous set by setCallbackParameters()
 	 */
 	this.getCallbackParameters = function() {
 		return ctx.callbackParameters;
 	};
 
 	/**
-	 * returns the Status element created by the constructor
+	 * @returns the Status element created by the constructor
 	 */
 	this.getStatusElement = function() {
 		return ctx.statusElement;
 	};
-	
+
 
 	this.setFlaggedRevs = function(level, expiry) {
 		ctx.flaggedRevs = { level: level, expiry: expiry };
 	};
 
 	/**
-	 * returns true if the page existed on the wiki when it was last loaded
+	 * @returns true if the page existed on the wiki when it was last loaded
 	 */
 	this.exists = function() {
 		return ctx.pageExists;
 	};
 
 	/**
-	 * returns the user who created the page following lookupCreator()
+	 * @returns the user who created the page following lookupCreator()
 	 */
 	this.getCreator = function() {
 		return ctx.creator;
@@ -2175,8 +2177,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 	/**
 	 * Retrieves the username of the user who created the page
-	 *    @param {Function} onSuccess - callback function (required) which is called when the username is found 
-	 *    within the callback, the username can be retrieved using the getCreator() function
+	 * @param {Function} onSuccess - callback function (required) which is
+	 * called when the username is found within the callback, the username
+	 * can be retrieved using the getCreator() function
 	 */
 	this.lookupCreator = function(onSuccess) {
 		if (!onSuccess) {
@@ -2968,9 +2971,9 @@ Morebits.wiki.preview = function(previewbox) {
 
 	/**
 	 * Displays the preview box, and begins an asynchronous attempt
-	 * to render the specified wikitext. 
+	 * to render the specified wikitext.
 	 * @param {string} wikitext - wikitext to render; most things should work, including subst: and ~~~~
-	 * @param {string} pageTitle - optional parameter for the page this should be rendered as being on
+	 * @param {string} [pageTitle] - optional parameter for the page this should be rendered as being on
 	 */
 	this.beginRender = function(wikitext, pageTitle) {
 		$(previewbox).show();
@@ -3052,7 +3055,7 @@ Morebits.wikitext.template = {
 				continue;
 			}
 			if( test2 === ']]' ) {
-				current += test2;
+				current += ']]';
 				++i;
 				--level;
 				continue;
@@ -3110,12 +3113,20 @@ Morebits.wikitext.template = {
 	}
 };
 
+/**
+ * @param {string} text
+ */
 Morebits.wikitext.page = function mediawikiPage( text ) {
 	this.text = text;
 };
 
 Morebits.wikitext.page.prototype = {
 	text: '',
+
+	/**
+	 * Removes links to `link_target` from the page text.
+	 * @param {string} link_target
+	 */
 	removeLink: function( link_target ) {
 		var first_char = link_target.substr( 0, 1 );
 		var link_re_string = "[" + first_char.toUpperCase() + first_char.toLowerCase() + ']' + RegExp.escape( link_target.substr( 1 ), true );
@@ -3129,6 +3140,13 @@ Morebits.wikitext.page.prototype = {
 		var link_named_re = new RegExp( "\\[\\[" + colon + link_re_string + "\\|(.+?)\\]\\]", 'g' );
 		this.text = this.text.replace( link_simple_re, "$1" ).replace( link_named_re, "$1" );
 	},
+
+	/**
+	 * Comments out images from page text. If used in a gallery, deletes the whole line.
+	 * If used as a template argument (not necessarily with File: prefix), the template parameter is commented out.
+	 * @param {string} image - Image name without File: prefix
+	 * @param {string} reason - Reason to be included in comment, alongside the commented-out image
+	 */
 	commentOutImage: function( image, reason ) {
 		var unbinder = new Morebits.unbinder( this.text );
 		unbinder.unbind( '<!--', '-->' );
@@ -3137,10 +3155,8 @@ Morebits.wikitext.page.prototype = {
 		var first_char = image.substr( 0, 1 );
 		var image_re_string = "[" + first_char.toUpperCase() + first_char.toLowerCase() + ']' + RegExp.escape( image.substr( 1 ), true );
 
-		/*
-		 * Check for normal image links, i.e. [[Image:Foobar.png|...]]
-		 * Will eat the whole link
-		 */
+		// Check for normal image links, i.e. [[File:Foobar.png|...]]
+		// Will eat the whole link
 		var links_re = new RegExp( "\\[\\[(?:[Ii]mage|[Ff]ile):\\s*" + image_re_string );
 		var allLinks = Morebits.array.uniq(Morebits.string.splitWeightedByKeys( unbinder.content, '[[', ']]' ));
 		for( var i = 0; i < allLinks.length; ++i ) {
@@ -3152,25 +3168,28 @@ Morebits.wikitext.page.prototype = {
 		// unbind the newly created comments
 		unbinder.unbind( '<!--', '-->' );
 
-		/*
-		 * Check for gallery images, i.e. instances that must start on a new line, eventually preceded with some space, and must include Image: prefix
-		 * Will eat the whole line.
-		 */
+		// Check for gallery images, i.e. instances that must start on a new line,
+		// eventually preceded with some space, and must include File: prefix
+		// Will eat the whole line.
 		var gallery_image_re = new RegExp( "(^\\s*(?:[Ii]mage|[Ff]ile):\\s*" + image_re_string + ".*?$)", 'mg' );
 		unbinder.content = unbinder.content.replace( gallery_image_re, "<!-- " + reason + "$1 -->" );
 
 		// unbind the newly created comments
 		unbinder.unbind( '<!--', '-->' );
-		/*
-		 * Check free image usages, for example as template arguments, might have the Image: prefix excluded, but must be preceeded by an |
-		 * Will only eat the image name and the preceeding bar and an eventual named parameter
-		 */
+
+		// Check free image usages, for example as template arguments, might have the File: prefix excluded, but must be preceeded by an |
+		// Will only eat the image name and the preceeding bar and an eventual named parameter
 		var free_image_re = new RegExp( "(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:(?:[Ii]mage|[Ff]ile):\\s*)?" + image_re_string + ")", 'mg' );
 		unbinder.content = unbinder.content.replace( free_image_re, "<!-- " + reason + "$1 -->" );
-
 		// Rebind the content now, we are done!
 		this.text = unbinder.rebind();
 	},
+
+	/**
+	 * Converts first usage of [[File:`image`]] to [[File:`image`|`data`]]
+	 * @param {string} image - Image name without File: prefix
+	 * @param {string} data
+	 */
 	addToImageComment: function( image, data ) {
 		var first_char = image.substr( 0, 1 );
 		var first_char_regex = RegExp.escape( first_char, true );
@@ -3192,6 +3211,11 @@ Morebits.wikitext.page.prototype = {
 		var newtext = "$1|$2 " + data;
 		this.text = this.text.replace( gallery_re, newtext );
 	},
+
+	/**
+	 * Removes transclusions of template from page text
+	 * @param {string} template - Page name whose transclusions are to be removed, include namespace prefix only if not in template namespace
+	 */
 	removeTemplate: function( template ) {
 		var first_char = template.substr( 0, 1 );
 		var template_re_string = "(?:[Tt]emplate:)?\\s*[" + first_char.toUpperCase() + first_char.toLowerCase() + ']' + RegExp.escape( template.substr( 1 ), true );
@@ -3203,6 +3227,7 @@ Morebits.wikitext.page.prototype = {
 			}
 		}
 	},
+
 	getText: function() {
 		return this.text;
 	}

--- a/morebits.js
+++ b/morebits.js
@@ -1387,11 +1387,11 @@ Morebits.wiki.removeCheckpoint = function() {
 
  /**
   * @constructor
-  * @param {*} currentAction - The current action (required)
-  * @param {*} query - The query object. (required)
-  * @param {*} onSuccess - The function to call when request gotten
-  * @param {*} [statusElement] - A Morebits.status object to use for status messages (optional)
-  * @param {*} [onError] - The function to call if an error occurs (optional)
+  * @param {string} currentAction - The current action (required)
+  * @param {Object} query - The querys (required)
+  * @param {Function} onSuccess - The function to call when request gotten
+  * @param {Object} [statusElement] - A Morebits.status object to use for status messages (optional)
+  * @param {Function} [onError] - The function to call if an error occurs (optional)
   */
 Morebits.wiki.api = function( currentAction, query, onSuccess, statusElement, onError ) {
 	this.currentAction = currentAction;
@@ -2939,7 +2939,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 }; // end Morebits.wiki.page
 
-/** Morebits.wiki.page TODO: (XXX)
+/* Morebits.wiki.page TODO: (XXX)
  * - Should we retry loads also?
  * - Need to reset current action before the save?
  * - Deal with action.completed stuff
@@ -2952,26 +2952,26 @@ Morebits.wiki.page = function(pageName, currentAction) {
  * **************** Morebits.wiki.preview ****************
  * Uses the API to parse a fragment of wikitext and render it as HTML.
  *
- * Constructor: Morebits.wiki.preview(previewbox, currentAction)
- *    previewbox - the <div> element that will contain the rendered HTML
- *
- * beginRender(wikitext): Displays the preview box, and begins an asynchronous attempt
- *                        to render the specified wikitext.
- *    wikitext - wikitext to render; most things should work, including subst: and ~~~~
- *    pageTitle - optional parameter for the page this should be rendered as being on
- *
- * closePreview(): Hides the preview box and clears it.
- *
  * The suggested implementation pattern (in Morebits.simpleWindow + Morebits.quickForm situations) is to
  * construct a Morebits.wiki.preview object after rendering a Morebits.quickForm, and bind the object
  * to an arbitrary property of the form (e.g. |previewer|).  For an example, see
  * twinklewarn.js.
  */
 
+ /**
+  * @constructor
+  * @param {HTMLDivElement} previewbox - the <div> element that will contain the rendered HTML
+  */
 Morebits.wiki.preview = function(previewbox) {
 	this.previewbox = previewbox;
 	$(previewbox).addClass("morebits-previewbox").hide();
 
+	/**
+	 * Displays the preview box, and begins an asynchronous attempt
+	 * to render the specified wikitext. 
+	 * @param {string} wikitext - wikitext to render; most things should work, including subst: and ~~~~
+	 * @param {string} pageTitle - optional parameter for the page this should be rendered as being on
+	 */
 	this.beginRender = function(wikitext, pageTitle) {
 		$(previewbox).show();
 
@@ -2998,9 +2998,12 @@ Morebits.wiki.preview = function(previewbox) {
 			return;
 		}
 		previewbox.innerHTML = html;
-		$(previewbox).find("a").attr("target", "_blank");
+		$(previewbox).find("a").attr("target", "_blank");	// this makes links open in new tab
 	};
 
+	/**
+	 * Hides the preview box and clears it.
+	 */
 	this.closePreview = function() {
 		$(previewbox).empty().hide();
 	};

--- a/morebits.js
+++ b/morebits.js
@@ -1537,72 +1537,46 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  * Callback functions may invoke any Morebits.wiki.page prototype method using this reference.
  *
  *
- * NOTE: This list of member functions is incomplete.
+ * HIGHLIGHTS:
  *
  * Constructor: Morebits.wiki.page(pageName, currentAction)
  *    pageName - the name of the page, prefixed by the namespace (if any)
  *               (for the current page, use mw.config.get('wgPageName'))
  *    currentAction - a string describing the action about to be undertaken (optional)
  *
- * load(onSuccess, onFailure): Loads the text for the page
- *    onSuccess - callback function which is called when the load has succeeded
- *    onFailure - callback function which is called when the load fails (optional)
+ * onSuccess and onFailure are callback functions called when the operation is a success or failure
+ * if enclosed in [brackets], it indicates that it is optional
+ * 
+ * load(onSuccess, [onFailure]): Loads the text for the page
+ * 
+ * getPageText(): returns a string containing the text of the page after a successful load()
  *
- * save(onSuccess, onFailure): Saves the text for the page. Must be preceded by calling load().
- *    onSuccess - callback function which is called when the save has succeeded (optional)
- *    onFailure - callback function which is called when the save fails (optional)
+ * save([onSuccess], [onFailure]):  Saves the text set via setPageText() for the page. 
+ * 									Must be preceded by calling load().
  *    Warning: Calling save() can result in additional calls to the previous load() callbacks to
  *             recover from edit conflicts!
  *             In this case, callers must make the same edit to the new pageText and reinvoke save().
  *             This behavior can be disabled with setMaxConflictRetries(0).
  *
- * append(onSuccess, onFailure): Adds the text provided via setAppendText() to the end of the page.
+ * append([onSuccess], [onFailure]): Adds the text provided via setAppendText() to the end of the page.
  *                               Does not require calling load() first.
- *    onSuccess - callback function which is called when the method has succeeded (optional)
- *    onFailure - callback function which is called when the method fails (optional)
  *
- * prepend(onSuccess, onFailure): Adds the text provided via setPrependText() to the start of the page.
+ * prepend([onSuccess], [onFailure]): Adds the text provided via setPrependText() to the start of the page.
  *                                Does not require calling load() first.
- *    onSuccess - callback function which is called when the method has succeeded (optional)
- *    onFailure - callback function which is called when the method fails (optional)
+ * 
+ * move(onSuccess, [onFailure]): Moves a page to another title
+ *
+ * deletePage(onSuccess, [onFailure]): Deletes a page (for admins only)
+ * 
+ * protect(onSuccess, [onFailure]): Protects a page
  *
  * getPageName(): returns a string containing the name of the loaded page, including the namespace
+ * 
+ * setPageText(pageText) sets the updated page text that will be saved when save() is called
  *
- * getPageText(): returns a string containing the text of the page after a successful load()
+ * setAppendText(appendText) sets the text that will be appended to the page when append() is called
  *
- * setPageText(pageText)
- *    pageText - string containing the updated page text that will be saved when save() is called
- *
- * setAppendText(appendText)
- *    appendText - string containing the text that will be appended to the page when append() is called
- *
- * setPrependText(prependText)
- *    prependText - string containing the text that will be prepended to the page when prepend() is called
- *
- * setEditSummary(summary)
- *    summary - string containing the text of the edit summary that will be used when save() is called
- *
- * setMinorEdit(minorEdit)
- *    minorEdit is a boolean value:
- *       true  - When save is called, the resulting edit will be marked as "minor".
- *       false - When save is called, the resulting edit will not be marked as "minor". (default)
- *
- * setBotEdit(botEdit)
- *    botEdit is a boolean value:
- *       true  - When save is called, the resulting edit will be marked as "bot".
- *       false - When save is called, the resulting edit will not be marked as "bot". (default)
- *
- * setPageSection(pageSection)
- *    pageSection - integer specifying the section number to load or save. The default is |null|, which means
- *                  that the entire page will be retrieved.
- *
- * setMaxConflictRetries(maxRetries)
- *    maxRetries - number of retries for save errors involving an edit conflict or loss of edit token
- *    default: 2
- *
- * setMaxRetries(maxRetries)
- *    maxRetries - number of retries for save errors not involving an edit conflict or loss of edit token
- *    default: 2
+ * setPrependText(prependText) sets the text that will be prepended to the page when prepend() is called
  *
  * setCallbackParameters(callbackParameters)
  *    callbackParameters - an object for use in a callback function
@@ -1617,58 +1591,15 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  *
  * getStatusElement(): returns the Status element created by the constructor
  *
- * setFollowRedirect(followRedirect)
- *    followRedirect is a boolean value:
- *       true  - a maximum of one redirect will be followed.
- *               In the event of a redirect, a message is displayed to the user and
- *               the redirect target can be retrieved with getPageName().
- *       false - the requested pageName will be used without regard to any redirect. (default)
- *
- * setWatchlist(watchlistOption)
- *    watchlistOption is a boolean value:
- *       true  - page will be added to the user's watchlist when save() is called
- *       false - watchlist status of the page will not be changed (default)
- *
- * setWatchlistFromPreferences(watchlistOption)
- *    watchlistOption is a boolean value:
- *       true  - page watchlist status will be set based on the user's
- *               preference settings when save() is called
- *       false - watchlist status of the page will not be changed (default)
- *
- *    Watchlist notes:
- *       1. The MediaWiki API value of 'unwatch', which explicitly removes the page from the
- *          user's watchlist, is not used.
- *       2. If both setWatchlist() and setWatchlistFromPreferences() are called,
- *          the last call takes priority.
- *       3. Twinkle modules should use the appropriate preference to set the watchlist options.
- *       4. Most Twinkle modules use setWatchlist().
- *          setWatchlistFromPreferences() is only needed for the few Twinkle watchlist preferences
- *          that accept a string value of 'default'.
- *
- * setCreateOption(createOption)
- *    createOption is a string value:
- *       'recreate'   - create the page if it does not exist, or edit it if it exists
- *       'createonly' - create the page if it does not exist, but return an error if it
- *                      already exists
- *       'nocreate'   - don't create the page, only edit it if it already exists
- *       null         - create the page if it does not exist, unless it was deleted in the moment
- *                      between retrieving the edit token and saving the edit (default)
- *
  * exists(): returns true if the page existed on the wiki when it was last loaded
  *
+ * getCurrentID(): returns a string containing the current revision ID of the page
+ * 
  * lookupCreator(onSuccess): Retrieves the username of the user who created the page
  *    onSuccess - callback function which is called when the username is found
  *                within the callback, the username can be retrieved using the getCreator() function
  *
  * getCreator(): returns the user who created the page following lookupCreator()
- *
- * getCurrentID(): returns a string containing the current revision ID of the page
- *
- * patrol(): marks the page as patrolled, if possible
- *
- * move(onSuccess, onFailure): Moves a page to another title
- *
- * deletePage(onSuccess, onFailure): Deletes a page (for admins only)
  *
  */
 
@@ -1802,258 +1733,6 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	var emptyFunction = function() { };
-{
-	// Public interface accessors :
-
-	/**
-	 * returns a string containing the name of the loaded page, including the namespace
-	 */
-	this.getPageName = function() {
-		return ctx.pageName;
-	};
-
-	/**
-	 * returns a string containing the text of the page after a successful load()
-	 */
-	this.getPageText = function() {
-		return ctx.pageText;
-	};
-
-	/**
-	 * `pageText` - string containing the updated page text that will be saved when save() is called
-	 */
-	this.setPageText = function(pageText) {
-		ctx.editMode = 'all';
-		ctx.pageText = pageText;
-	};
-
-	/**
-	 * `appendText` - string containing the text that will be appended to the page when append() is called
-	 */
-	this.setAppendText = function(appendText) {
-		ctx.editMode = 'append';
-		ctx.appendText = appendText;
-	};
-
-	/**
-	 * `prependText` - string containing the text that will be prepended to the page when prepend() is called
-	 */
-	this.setPrependText = function(prependText) {
-		ctx.editMode = 'prepend';
-		ctx.prependText = prependText;
-	};
-
-	/**
-	 * `summary` - string containing the text of the edit summary that will be used when save() is called
-	 */
-	this.setEditSummary = function(summary) {
-		ctx.editSummary = summary;
-	};
-
-	/**
-	 *    `createOption` is a string value:
-	 *       'recreate'   - create the page if it does not exist, or edit it if it exists
-	 *       'createonly' - create the page if it does not exist, but return an error if it
-	 *                      already exists
-	 *       'nocreate'   - don't create the page, only edit it if it already exists
-	 *       null         - create the page if it does not exist, unless it was deleted in the moment
-	 *                      between retrieving the edit token and saving the edit (default)
-	 * 
-	 */
-	this.setCreateOption = function(createOption) {
-		ctx.createOption = createOption;
-	};
-
-	/**
-	 * `minorEdit` - boolean value:
-	 * True  - When save is called, the resulting edit will be marked as "minor". 
-	 * False - When save is called, the resulting edit will not be marked as "minor". (default)
-	 */
-	this.setMinorEdit = function(minorEdit) {
-		ctx.minorEdit = minorEdit;
-	};
-
-	/**
-	 * `botEdit` is a boolean value:
-	 *       True  - When save is called, the resulting edit will be marked as "bot".
-	 *       False - When save is called, the resulting edit will not be marked as "bot". (default)
-	 */
-	this.setBotEdit = function(botEdit) {
-		ctx.botEdit = botEdit;
-	};
-
-	/**
-	 * `pageSection` - integer specifying the section number to load or save. The default is `null`, which means 
-	 * that the entire page will be retrieved.
-	 */
-	this.setPageSection = function(pageSection) {
-		ctx.pageSection = pageSection;
-	};
-
-	/**
-	 * `maxRetries` - number of retries for save errors involving an edit conflict or loss of edit token.Default: 2
-	 */
-	this.setMaxConflictRetries = function(maxRetries) {
-		ctx.maxConflictRetries = maxRetries;
-	};
-
-	/**
-	 * maxRetries - number of retries for save errors not involving an edit conflict or loss of edit token
-	 * Default:2
-	 */
-	this.setMaxRetries = function(maxRetries) {
-		ctx.maxRetries = maxRetries;
-	};
-
-	/**
-	 * `callbackParameters` - an object for use in a callback function
-	 * 
-	 * Callback notes: callbackParameters is for use by the caller only. The parameters 
-	 * allow a caller to pass the proper context into its callback function. 
-	 * Callers must ensure that any changes to the callbackParameters object 
-	 * within a load() callback still permit a proper re-entry into the 
-	 * load() callback if an edit conflict is detected upon calling save().
-	 */
-	this.setCallbackParameters = function(callbackParameters) {
-		ctx.callbackParameters = callbackParameters;
-	};
-
-	/**
-	 * returns the object previous set by setCallbackParameters()
-	 */
-	this.getCallbackParameters = function() {
-		return ctx.callbackParameters;
-	};
-
-	/**
-	 * returns the user who created the page following lookupCreator()
-	 */
-	this.getCreator = function() {
-		return ctx.creator;
-	};
-
-	this.setOldID = function(oldID) {
-		ctx.revertOldID = oldID;
-	};
-
-	/**
-	 *  returns a string containing the current revision ID of the page
-	 */
-	this.getCurrentID = function() {
-		return ctx.revertCurID;
-	};
-
-	this.getRevisionUser = function() {
-		return ctx.revertUser;
-	};
-
-	this.setMoveDestination = function(destination) {
-		ctx.moveDestination = destination;
-	};
-
-	this.setMoveTalkPage = function(flag) {
-		ctx.moveTalkPage = !!flag;
-	};
-
-	this.setMoveSubpages = function(flag) {
-		ctx.moveSubpages = !!flag;
-	};
-
-	this.setMoveSuppressRedirect = function(flag) {
-		ctx.moveSuppressRedirect = !!flag;
-	};
-
-	this.setEditProtection = function(level, expiry) {
-		ctx.protectEdit = { level: level, expiry: expiry };
-	};
-
-	this.setMoveProtection = function(level, expiry) {
-		ctx.protectMove = { level: level, expiry: expiry };
-	};
-
-	this.setCreateProtection = function(level, expiry) {
-		ctx.protectCreate = { level: level, expiry: expiry };
-	};
-
-	this.setCascadingProtection = function(flag) {
-		ctx.protectCascade = !!flag;
-	};
-
-	this.setFlaggedRevs = function(level, expiry) {
-		ctx.flaggedRevs = { level: level, expiry: expiry };
-	};
-
-	/**
-	 * returns the Status element created by the constructor
-	 */
-	this.getStatusElement = function() {
-		return ctx.statusElement;
-	};
-
-	/**
-	 *    `followRedirect` is a boolean value:
-	 *       True  - a maximum of one redirect will be followed.
-	 *               In the event of a redirect, a message is displayed to the user and
-	 *               the redirect target can be retrieved with getPageName().
-	 *       False - the requested pageName will be used without regard to any redirect. (default)
-	 */
-	this.setFollowRedirect = function(followRedirect) {
-		if (ctx.pageLoaded) {
-			ctx.statusElement.error("Internal error: cannot change redirect setting after the page has been loaded!");
-			return;
-		}
-		ctx.followRedirect = followRedirect;
-	};
-
-	/**
-	 *  `watchlistOption` is a boolean value:
-	 *       True  - page will be added to the user's watchlist when save() is called
- 	 *       False - watchlist status of the page will not be changed (default)
- 	 *
-	 */
-	this.setWatchlist = function(flag) {
-		if (flag) {
-			ctx.watchlistOption = 'watch';
-		} else {
-			ctx.watchlistOption = 'nochange';
-		}
-	};
-
-	/**
-	 *    `watchlistOption` is a boolean value:
-	 *       True  - page watchlist status will be set based on the user's
-	 *               preference settings when save() is called
-	 *       False - watchlist status of the page will not be changed (default)
-	 *
-	 *    Watchlist notes:
-	 *       1. The MediaWiki API value of 'unwatch', which explicitly removes the page from the
-	 *          user's watchlist, is not used.
-	 *       2. If both setWatchlist() and setWatchlistFromPreferences() are called,
-	 *          the last call takes priority.
-	 *       3. Twinkle modules should use the appropriate preference to set the watchlist options.
-	 *       4. Most Twinkle modules use setWatchlist().
-	 *          setWatchlistFromPreferences() is only needed for the few Twinkle watchlist preferences
-	 *          that accept a string value of 'default'.
-	 */
-	this.setWatchlistFromPreferences = function(flag) {
-		if (flag) {
-			ctx.watchlistOption = 'preferences';
-		} else {
-			ctx.watchlistOption = 'nochange';
-		}
-	};
-
-	this.suppressProtectWarning = function() {
-		ctx.suppressProtectWarning = true;
-	};
-
-	/**
-	 * returns true if the page existed on the wiki when it was last loaded
-	 */
-	this.exists = function() {
-		return ctx.pageExists;
-	};
-}
 
 	/**
 	 * Loads the text for the page
@@ -2242,8 +1921,261 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
+	 * returns a string containing the name of the loaded page, including the namespace
+	 */
+	this.getPageName = function() {
+		return ctx.pageName;
+	};
+
+	/**
+	 * returns a string containing the text of the page after a successful load()
+	 */
+	this.getPageText = function() {
+		return ctx.pageText;
+	};
+
+	/**
+	 * `pageText` - string containing the updated page text that will be saved when save() is called
+	 */
+	this.setPageText = function(pageText) {
+		ctx.editMode = 'all';
+		ctx.pageText = pageText;
+	};
+
+	/**
+	 * `appendText` - string containing the text that will be appended to the page when append() is called
+	 */
+	this.setAppendText = function(appendText) {
+		ctx.editMode = 'append';
+		ctx.appendText = appendText;
+	};
+
+	/**
+	 * `prependText` - string containing the text that will be prepended to the page when prepend() is called
+	 */
+	this.setPrependText = function(prependText) {
+		ctx.editMode = 'prepend';
+		ctx.prependText = prependText;
+	};
+
+
+
+	// Edit-related setter methods:
+	/**
+	 * `summary` - string containing the text of the edit summary that will be used when save() is called
+	 */
+	this.setEditSummary = function(summary) {
+		ctx.editSummary = summary;
+	};
+
+	/**
+	 *    `createOption` is a string value:
+	 *       'recreate'   - create the page if it does not exist, or edit it if it exists
+	 *       'createonly' - create the page if it does not exist, but return an error if it
+	 *                      already exists
+	 *       'nocreate'   - don't create the page, only edit it if it already exists
+	 *       null         - create the page if it does not exist, unless it was deleted in the moment
+	 *                      between retrieving the edit token and saving the edit (default)
+	 * 
+	 */
+	this.setCreateOption = function(createOption) {
+		ctx.createOption = createOption;
+	};
+
+	/**
+	 * `minorEdit` - boolean value:
+	 * True  - When save is called, the resulting edit will be marked as "minor". 
+	 * False - When save is called, the resulting edit will not be marked as "minor". (default)
+	 */
+	this.setMinorEdit = function(minorEdit) {
+		ctx.minorEdit = minorEdit;
+	};
+
+	/**
+	 * `botEdit` is a boolean value:
+	 *       True  - When save is called, the resulting edit will be marked as "bot".
+	 *       False - When save is called, the resulting edit will not be marked as "bot". (default)
+	 */
+	this.setBotEdit = function(botEdit) {
+		ctx.botEdit = botEdit;
+	};
+
+	/**
+	 * `pageSection` - integer specifying the section number to load or save. The default is `null`, which means 
+	 * that the entire page will be retrieved.
+	 */
+	this.setPageSection = function(pageSection) {
+		ctx.pageSection = pageSection;
+	};
+
+	/**
+	 * `maxRetries` - number of retries for save errors involving an edit conflict or loss of edit token.Default: 2
+	 */
+	this.setMaxConflictRetries = function(maxRetries) {
+		ctx.maxConflictRetries = maxRetries;
+	};
+
+	/**
+	 * maxRetries - number of retries for save errors not involving an edit conflict or loss of edit token
+	 * Default:2
+	 */
+	this.setMaxRetries = function(maxRetries) {
+		ctx.maxRetries = maxRetries;
+	};
+
+	/**
+	 *  `watchlistOption` is a boolean value:
+	 *       True  - page will be added to the user's watchlist when save() is called
+ 	 *       False - watchlist status of the page will not be changed (default)
+	 */
+	this.setWatchlist = function(watchlistOption) {
+		if (watchlistOption) {
+			ctx.watchlistOption = 'watch';
+		} else {
+			ctx.watchlistOption = 'nochange';
+		}
+	};
+
+	/**
+	 *    `watchlistOption` is a boolean value:
+	 *       True  - page watchlist status will be set based on the user's
+	 *               preference settings when save() is called
+	 *       False - watchlist status of the page will not be changed (default)
+	 *
+	 *    Watchlist notes:
+	 *       1. The MediaWiki API value of 'unwatch', which explicitly removes the page from the
+	 *          user's watchlist, is not used.
+	 *       2. If both setWatchlist() and setWatchlistFromPreferences() are called,
+	 *          the last call takes priority.
+	 *       3. Twinkle modules should use the appropriate preference to set the watchlist options.
+	 *       4. Most Twinkle modules use setWatchlist().
+	 *          setWatchlistFromPreferences() is only needed for the few Twinkle watchlist preferences
+	 *          that accept a string value of 'default'.
+	 */
+	this.setWatchlistFromPreferences = function(watchlistOption) {
+		if (watchlistOption) {
+			ctx.watchlistOption = 'preferences';
+		} else {
+			ctx.watchlistOption = 'nochange';
+		}
+	};
+
+	/**
+	 *    `followRedirect` is a boolean value:
+	 *       True  - a maximum of one redirect will be followed.
+	 *               In the event of a redirect, a message is displayed to the user and
+	 *               the redirect target can be retrieved with getPageName().
+	 *       False - the requested pageName will be used without regard to any redirect. (default)
+	 */
+	this.setFollowRedirect = function(followRedirect) {
+		if (ctx.pageLoaded) {
+			ctx.statusElement.error("Internal error: cannot change redirect setting after the page has been loaded!");
+			return;
+		}
+		ctx.followRedirect = followRedirect;
+	};
+
+	// Move-related setter functions
+	this.setMoveDestination = function(destination) {
+		ctx.moveDestination = destination;
+	};
+
+	this.setMoveTalkPage = function(flag) {
+		ctx.moveTalkPage = !!flag;
+	};
+
+	this.setMoveSubpages = function(flag) {
+		ctx.moveSubpages = !!flag;
+	};
+
+	this.setMoveSuppressRedirect = function(flag) {
+		ctx.moveSuppressRedirect = !!flag;
+	};
+
+	// Protect-related setter functions
+	this.setEditProtection = function(level, expiry) {
+		ctx.protectEdit = { level: level, expiry: expiry };
+	};
+
+	this.setMoveProtection = function(level, expiry) {
+		ctx.protectMove = { level: level, expiry: expiry };
+	};
+
+	this.setCreateProtection = function(level, expiry) {
+		ctx.protectCreate = { level: level, expiry: expiry };
+	};
+
+	this.setCascadingProtection = function(flag) {
+		ctx.protectCascade = !!flag;
+	};
+
+	// Revert-related getters/setters:
+	this.setOldID = function(oldID) {
+		ctx.revertOldID = oldID;
+	};
+
+	/**
+	 *  returns a string containing the current revision ID of the page
+	 */
+	this.getCurrentID = function() {
+		return ctx.revertCurID;
+	};
+
+	this.getRevisionUser = function() {
+		return ctx.revertUser;
+	};
+
+	// Miscellaneous getters/setters:
+
+	/**
+	 * `callbackParameters` - an object for use in a callback function
+	 * 
+	 * Callback notes: callbackParameters is for use by the caller only. The parameters 
+	 * allow a caller to pass the proper context into its callback function. 
+	 * Callers must ensure that any changes to the callbackParameters object 
+	 * within a load() callback still permit a proper re-entry into the 
+	 * load() callback if an edit conflict is detected upon calling save().
+	 */
+	this.setCallbackParameters = function(callbackParameters) {
+		ctx.callbackParameters = callbackParameters;
+	};
+
+	/**
+	 * returns the object previous set by setCallbackParameters()
+	 */
+	this.getCallbackParameters = function() {
+		return ctx.callbackParameters;
+	};
+
+	/**
+	 * returns the Status element created by the constructor
+	 */
+	this.getStatusElement = function() {
+		return ctx.statusElement;
+	};
+	
+
+	this.setFlaggedRevs = function(level, expiry) {
+		ctx.flaggedRevs = { level: level, expiry: expiry };
+	};
+
+	/**
+	 * returns true if the page existed on the wiki when it was last loaded
+	 */
+	this.exists = function() {
+		return ctx.pageExists;
+	};
+
+	/**
+	 * returns the user who created the page following lookupCreator()
+	 */
+	this.getCreator = function() {
+		return ctx.creator;
+	};
+
+	/**
 	 * Retrieves the username of the user who created the page
-	 *    @param {Function} onSuccess - callback function which is called when the username is found 
+	 *    @param {Function} onSuccess - callback function (required) which is called when the username is found 
 	 *    within the callback, the username can be retrieved using the getCreator() function
 	 */
 	this.lookupCreator = function(onSuccess) {
@@ -2299,6 +2231,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 	};
 
+	/**
+	 * Reverts a page to revertOldID
+	 * @param {Function} onSuccess - callback function to run on success
+	 * @param {Function} onFailure - callback function to run on failure (optional)
+	 */
 	this.revert = function(onSuccess, onFailure) {
 		ctx.onSaveSuccess = onSuccess;
 		ctx.onSaveFailure = onFailure || emptyFunction;

--- a/morebits.js
+++ b/morebits.js
@@ -1305,6 +1305,7 @@ Morebits.wiki = {};
  * Determines whether the current page is a redirect or soft redirect
  * (fails to detect soft redirects on edit, history, etc. pages)
  */
+
 Morebits.wiki.isPageRedirect = function wikipediaIsPageRedirect() {
 	return !!(mw.config.get("wgIsRedirect") || document.getElementById("softredirect"));
 };
@@ -1386,11 +1387,11 @@ Morebits.wiki.removeCheckpoint = function() {
 
  /**
   * @constructor
-  * @param {*} currentAction The current action (required)
-  * @param {*} query The query object. (required)
-  * @param {*} onSuccess The function to call when request gotten
-  * @param {*} [statusElement] A Morebits.status object to use for status messages (optional)
-  * @param {*} [onError] The function to call if an error occurs (optional)
+  * @param {*} currentAction - The current action (required)
+  * @param {*} query - The query object. (required)
+  * @param {*} onSuccess - The function to call when request gotten
+  * @param {*} [statusElement] - A Morebits.status object to use for status messages (optional)
+  * @param {*} [onError] - The function to call if an error occurs (optional)
   */
 Morebits.wiki.api = function( currentAction, query, onSuccess, statusElement, onError ) {
 	this.currentAction = currentAction;
@@ -1699,6 +1700,12 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  *          significant duplication of code for little benefit.
  */
 
+ /**
+  * @constructor 
+  * @param {string} pageName The name of the page, prefixed by the namespace (if any)
+  * For the current page, use mw.config.get('wgPageName')
+  * @param {string} [currentAction] A string describing the action about to be undertaken (optional)
+  */
 Morebits.wiki.page = function(pageName, currentAction) {
 
 	if (!currentAction) {
@@ -1795,69 +1802,132 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	var emptyFunction = function() { };
+{
+	// Public interface accessors :
 
 	/**
-	 * Public interface accessors
+	 * returns a string containing the name of the loaded page, including the namespace
 	 */
 	this.getPageName = function() {
 		return ctx.pageName;
 	};
 
+	/**
+	 * returns a string containing the text of the page after a successful load()
+	 */
 	this.getPageText = function() {
 		return ctx.pageText;
 	};
 
+	/**
+	 * `pageText` - string containing the updated page text that will be saved when save() is called
+	 */
 	this.setPageText = function(pageText) {
 		ctx.editMode = 'all';
 		ctx.pageText = pageText;
 	};
 
+	/**
+	 * `appendText` - string containing the text that will be appended to the page when append() is called
+	 */
 	this.setAppendText = function(appendText) {
 		ctx.editMode = 'append';
 		ctx.appendText = appendText;
 	};
 
+	/**
+	 * `prependText` - string containing the text that will be prepended to the page when prepend() is called
+	 */
 	this.setPrependText = function(prependText) {
 		ctx.editMode = 'prepend';
 		ctx.prependText = prependText;
 	};
 
+	/**
+	 * `summary` - string containing the text of the edit summary that will be used when save() is called
+	 */
 	this.setEditSummary = function(summary) {
 		ctx.editSummary = summary;
 	};
 
+	/**
+	 *    `createOption` is a string value:
+	 *       'recreate'   - create the page if it does not exist, or edit it if it exists
+	 *       'createonly' - create the page if it does not exist, but return an error if it
+	 *                      already exists
+	 *       'nocreate'   - don't create the page, only edit it if it already exists
+	 *       null         - create the page if it does not exist, unless it was deleted in the moment
+	 *                      between retrieving the edit token and saving the edit (default)
+	 * 
+	 */
 	this.setCreateOption = function(createOption) {
 		ctx.createOption = createOption;
 	};
 
+	/**
+	 * `minorEdit` - boolean value:
+	 * True  - When save is called, the resulting edit will be marked as "minor". 
+	 * False - When save is called, the resulting edit will not be marked as "minor". (default)
+	 */
 	this.setMinorEdit = function(minorEdit) {
 		ctx.minorEdit = minorEdit;
 	};
 
+	/**
+	 * `botEdit` is a boolean value:
+	 *       True  - When save is called, the resulting edit will be marked as "bot".
+	 *       False - When save is called, the resulting edit will not be marked as "bot". (default)
+	 */
 	this.setBotEdit = function(botEdit) {
 		ctx.botEdit = botEdit;
 	};
 
+	/**
+	 * `pageSection` - integer specifying the section number to load or save. The default is `null`, which means 
+	 * that the entire page will be retrieved.
+	 */
 	this.setPageSection = function(pageSection) {
 		ctx.pageSection = pageSection;
 	};
 
+	/**
+	 * `maxRetries` - number of retries for save errors involving an edit conflict or loss of edit token.Default: 2
+	 */
 	this.setMaxConflictRetries = function(maxRetries) {
 		ctx.maxConflictRetries = maxRetries;
 	};
 
+	/**
+	 * maxRetries - number of retries for save errors not involving an edit conflict or loss of edit token
+	 * Default:2
+	 */
 	this.setMaxRetries = function(maxRetries) {
 		ctx.maxRetries = maxRetries;
 	};
 
+	/**
+	 * `callbackParameters` - an object for use in a callback function
+	 * 
+	 * Callback notes: callbackParameters is for use by the caller only. The parameters 
+	 * allow a caller to pass the proper context into its callback function. 
+	 * Callers must ensure that any changes to the callbackParameters object 
+	 * within a load() callback still permit a proper re-entry into the 
+	 * load() callback if an edit conflict is detected upon calling save().
+	 */
 	this.setCallbackParameters = function(callbackParameters) {
 		ctx.callbackParameters = callbackParameters;
 	};
 
+	/**
+	 * returns the object previous set by setCallbackParameters()
+	 */
 	this.getCallbackParameters = function() {
 		return ctx.callbackParameters;
 	};
 
+	/**
+	 * returns the user who created the page following lookupCreator()
+	 */
 	this.getCreator = function() {
 		return ctx.creator;
 	};
@@ -1866,6 +1936,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.revertOldID = oldID;
 	};
 
+	/**
+	 *  returns a string containing the current revision ID of the page
+	 */
 	this.getCurrentID = function() {
 		return ctx.revertCurID;
 	};
@@ -1910,10 +1983,20 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.flaggedRevs = { level: level, expiry: expiry };
 	};
 
+	/**
+	 * returns the Status element created by the constructor
+	 */
 	this.getStatusElement = function() {
 		return ctx.statusElement;
 	};
 
+	/**
+	 *    `followRedirect` is a boolean value:
+	 *       True  - a maximum of one redirect will be followed.
+	 *               In the event of a redirect, a message is displayed to the user and
+	 *               the redirect target can be retrieved with getPageName().
+	 *       False - the requested pageName will be used without regard to any redirect. (default)
+	 */
 	this.setFollowRedirect = function(followRedirect) {
 		if (ctx.pageLoaded) {
 			ctx.statusElement.error("Internal error: cannot change redirect setting after the page has been loaded!");
@@ -1922,6 +2005,12 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.followRedirect = followRedirect;
 	};
 
+	/**
+	 *  `watchlistOption` is a boolean value:
+	 *       True  - page will be added to the user's watchlist when save() is called
+ 	 *       False - watchlist status of the page will not be changed (default)
+ 	 *
+	 */
 	this.setWatchlist = function(flag) {
 		if (flag) {
 			ctx.watchlistOption = 'watch';
@@ -1930,6 +2019,22 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 	};
 
+	/**
+	 *    `watchlistOption` is a boolean value:
+	 *       True  - page watchlist status will be set based on the user's
+	 *               preference settings when save() is called
+	 *       False - watchlist status of the page will not be changed (default)
+	 *
+	 *    Watchlist notes:
+	 *       1. The MediaWiki API value of 'unwatch', which explicitly removes the page from the
+	 *          user's watchlist, is not used.
+	 *       2. If both setWatchlist() and setWatchlistFromPreferences() are called,
+	 *          the last call takes priority.
+	 *       3. Twinkle modules should use the appropriate preference to set the watchlist options.
+	 *       4. Most Twinkle modules use setWatchlist().
+	 *          setWatchlistFromPreferences() is only needed for the few Twinkle watchlist preferences
+	 *          that accept a string value of 'default'.
+	 */
 	this.setWatchlistFromPreferences = function(flag) {
 		if (flag) {
 			ctx.watchlistOption = 'preferences';
@@ -1942,10 +2047,19 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.suppressProtectWarning = true;
 	};
 
+	/**
+	 * returns true if the page existed on the wiki when it was last loaded
+	 */
 	this.exists = function() {
 		return ctx.pageExists;
 	};
+}
 
+	/**
+	 * Loads the text for the page
+	 *   @param {Function} onSuccess - callback function which is called when the load has succeeded
+	 *   @param {Function} onFailure - callback function which is called when the load fails (optional)
+	 */
 	this.load = function(onSuccess, onFailure) {
 		ctx.onLoadSuccess = onSuccess;
 		ctx.onLoadFailure = onFailure || emptyFunction;
@@ -1988,8 +2102,18 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.loadApi.post();
 	};
 
-	// Save updated .pageText to Wikipedia
-	// Only valid after successful .load()
+	/**
+	 * Saves the text for the page to Wikipedia
+	 * Must be preceded by successfully calling load().
+	 *    
+	 * Warning: Calling save() can result in additional calls to the previous load() callbacks to
+	 *             recover from edit conflicts!
+	 *             In this case, callers must make the same edit to the new pageText and reinvoke save().
+	 *             This behavior can be disabled with setMaxConflictRetries(0).
+	 *  @param {Function} onSuccess - callback function which is called when the save has succeeded (optional)
+	 *  @param {Function} onFailure - callback function which is called when the save fails (optional)
+	 *
+	 */
 	this.save = function(onSuccess, onFailure) {
 		ctx.onSaveSuccess = onSuccess;
 		ctx.onSaveFailure = onFailure || emptyFunction;
@@ -2081,6 +2205,12 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.saveApi.post();
 	};
 
+	/**
+	 * Adds the text provided via setAppendText() to the end of the page.
+	 * Does not require calling load() first.
+	 *    @param {Function} onSuccess - callback function which is called when the method has succeeded (optional)
+	 *    @param {Function} onFailure - callback function which is called when the method fails (optional)
+	 */
 	this.append = function(onSuccess, onFailure) {
 		ctx.editMode = 'append';
 
@@ -2093,6 +2223,12 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 	};
 
+	/**
+	 * Adds the text provided via setPrependText() to the start of the page.
+	 * Does not require calling load() first.
+	 *  @param {Function}  onSuccess - callback function which is called when the method has succeeded (optional)
+	 *  @param {Function}  onFailure - callback function which is called when the method fails (optional)
+	 */
 	this.prepend = function(onSuccess, onFailure) {
 		ctx.editMode = 'prepend';
 
@@ -2105,6 +2241,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 	};
 
+	/**
+	 * Retrieves the username of the user who created the page
+	 *    @param {Function} onSuccess - callback function which is called when the username is found 
+	 *    within the callback, the username can be retrieved using the getCreator() function
+	 */
 	this.lookupCreator = function(onSuccess) {
 		if (!onSuccess) {
 			ctx.statusElement.error("Internal error: no onSuccess callback provided to lookupCreator()!");
@@ -2130,6 +2271,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.lookupCreatorApi.post();
 	};
 
+	/**
+	 * marks the page as patrolled, if possible
+	 */
 	this.patrol = function() {
 		// There's no patrol link on page, so we can't patrol
 		if ( !$( '.patrollink' ).length ) {
@@ -2169,6 +2313,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		this.load(fnAutoSave, ctx.onSaveFailure);
 	};
 
+	/**
+	 * Moves a page to another title
+	 * @param {Function} onSuccess - callback function to run on success
+	 * @param {Function} onFailure - callback function to run on failure (optional)
+	 */
 	this.move = function(onSuccess, onFailure) {
 		ctx.onMoveSuccess = onSuccess;
 		ctx.onMoveFailure = onFailure || emptyFunction;
@@ -2203,6 +2352,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	// |delete| is a reserved word in some flavours of JS
+	/**
+	 * Deletes a page (for admins only)
+	 * @param {Function} onSuccess - callback function to run on success
+	 * @param {Function} onFailure - callback function to run on failure (optional)
+	 */
 	this.deletePage = function(onSuccess, onFailure) {
 		ctx.onDeleteSuccess = onSuccess;
 		ctx.onDeleteFailure = onFailure || emptyFunction;

--- a/morebits.js
+++ b/morebits.js
@@ -977,6 +977,7 @@ if (!String.prototype.trim) {
 	String.prototype.trim = function stringPrototypeTrim( ) {
 		return this.trimRight().trimLeft();
 	};
+	Morebits.string.splitWeightedByKeys()
 }
 
 Morebits.string = {
@@ -989,26 +990,32 @@ Morebits.string = {
 		str = str.toString();
 		return str.substr( 0, 1 ).toLowerCase() + str.substr( 1 );
 	},
-	splitWeightedByKeys: function( str, start, end, skip ) {
+
+	/**
+	 * Gives an array of substrings of `str` starting with `start` and 
+	 * ending with `end`, which is not in `skiplist`
+	 * @param {string} str  @param {string} start @param {string} end @param {(array|string)} skiplist 
+	 */
+	splitWeightedByKeys: function( str, start, end, skiplist ) {
 		if( start.length !== end.length ) {
 			throw new Error( 'start marker and end marker must be of the same length' );
 		}
 		var level = 0;
 		var initial = null;
 		var result = [];
-		if( ! Array.isArray( skip ) ) {
-			if( skip === undefined ) {
-				skip = [];
-			} else if( typeof skip === 'string' ) {
-				skip = [ skip ];
+		if( ! Array.isArray( skiplist ) ) {
+			if( skiplist === undefined ) {
+				skiplist = [];
+			} else if( typeof skiplist === 'string' ) {
+				skiplist = [ skiplist ];
 			} else {
-				throw new Error( "non-applicable skip parameter" );
+				throw new Error( "non-applicable skiplist parameter" );
 			}
 		}
 		for( var i  = 0; i < str.length; ++i ) {
-			for( var j = 0; j < skip.length; ++j ) {
-				if( str.substr( i, skip[j].length ) === skip[j] ) {
-					i += skip[j].length - 1;
+			for( var j = 0; j < skiplist.length; ++j ) {
+				if( str.substr( i, skiplist[j].length ) === skiplist[j] ) {
+					i += skiplist[j].length - 1;
 					continue;
 				}
 			}
@@ -1030,7 +1037,12 @@ Morebits.string = {
 
 		return result;
 	},
-	// for deletion/other templates taking a freeform "reason" from a textarea (e.g. PROD, XFD, RPP)
+
+	/**
+	 * Formats freeform "reason" (from a textarea) for deletion/other templates 
+	 * that are going to be substituted, (e.g. PROD, XFD, RPP)
+	 * @param {string} str 
+	 */
 	formatReasonText: function( str ) {
 		var result = str.toString().trimRight();
 		var unbinder = new Morebits.unbinder(result);
@@ -1038,29 +1050,26 @@ Morebits.string = {
 		unbinder.content = unbinder.content.replace(/\|/g, "{{subst:!}}");
 		return unbinder.rebind();
 	},
-	// a replacement for String.prototype.replace() when the second parameter (the
-	// replacement string) is arbitrary, such as a username or freeform user input,
-	// and may contain dollar signs
+
+	/**
+	 * a replacement for `String.prototype.replace()` when the second parameter 
+	 * (the replacement string) is arbitrary, such as a username or freeform user input, 
+	 * and may contain dollar signs
+	 */
 	safeReplace: function morebitsStringSafeReplace(string, pattern, replacement) {
 		return string.replace(pattern, replacement.replace(/\$/g, "$$$$"));
-	}
+	} 
 };
-
 
 
 /**
  * **************** Morebits.array ****************
- *
- * uniq(arr): returns a copy of the array with duplicates removed
- *
- * dups(arr): returns a copy of the array with the first instance of each value
- *            removed; subsequent instances of those values (duplicates) remain
- *
- * chunk(arr, size): breaks up |arr| into smaller arrays of length |size|, and
- *                   returns an array of these "chunked" arrays
  */
 
 Morebits.array = {
+	/**
+	 * returns a copy of the array with duplicates removed 
+	 */
 	uniq: function(arr) {
 		if ( ! Array.isArray( arr ) ) {
 			throw "A non-array object passed to Morebits.array.uniq";
@@ -1074,6 +1083,11 @@ Morebits.array = {
 		}
 		return result;
 	},
+
+	/**
+	 * returns a copy of the array with the first instance of each value 
+	 * removed; subsequent instances of those values (duplicates) remain
+	 */
 	dups: function(arr) {
 		if ( ! Array.isArray( arr ) ) {
 			throw "A non-array object passed to Morebits.array.dups";
@@ -1090,6 +1104,14 @@ Morebits.array = {
 		}
 		return result;
 	},
+
+
+	/**
+	 * breaks up `arr` into smaller arrays of length `size`, and
+	 * returns an array of these "chunked" arrays
+	 * @param {array} arr 
+	 * @param {number} size 
+	 */
 	chunk: function( arr, size ) {
 		if ( ! Array.isArray( arr ) ) {
 			throw "A non-array object passed to Morebits.array.chunk";
@@ -1111,14 +1133,12 @@ Morebits.array = {
 };
 
 
-
 /**
  * **************** Morebits.pageNameNorm ****************
  * Stores a normalized version of the wgPageName variable (underscores converted to spaces).
  * For queen/king/whatever and country!
  */
 Morebits.pageNameNorm = mw.config.get('wgPageName').replace(/_/g, ' ');
-
 
 
 /**
@@ -1178,35 +1198,10 @@ Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
  * is fairly unlikely that anyone will iterate over a Date object.
  */
 
-Date.monthNames = [
-	'January',
-	'February',
-	'March',
-	'April',
-	'May',
-	'June',
-	'July',
-	'August',
-	'September',
-	'October',
-	'November',
-	'December'
-];
+Date.monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 
+	'July', 'August', 'September', 'October', 'November','December' ];
 
-Date.monthNamesAbbrev = [
-	'Jan',
-	'Feb',
-	'Mar',
-	'Apr',
-	'May',
-	'Jun',
-	'Jul',
-	'Aug',
-	'Sep',
-	'Oct',
-	'Nov',
-	'Dec'
-];
+Date.monthNamesAbbrev = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 Date.prototype.getMonthName = function() {
 	return Date.monthNames[ this.getMonth() ];
@@ -1306,8 +1301,10 @@ Morebits.wikipedia.namespacesFriendly = {
 
 Morebits.wiki = {};
 
-// Determines whether the current page is a redirect or soft redirect
-// (fails to detect soft redirects on edit, history, etc. pages)
+/**
+ * Determines whether the current page is a redirect or soft redirect
+ * (fails to detect soft redirects on edit, history, etc. pages)
+ */
 Morebits.wiki.isPageRedirect = function wikipediaIsPageRedirect() {
 	return !!(mw.config.get("wgIsRedirect") || document.getElementById("softredirect"));
 };
@@ -1385,14 +1382,16 @@ Morebits.wiki.removeCheckpoint = function() {
 /**
  * **************** Morebits.wiki.api ****************
  * An easy way to talk to the MediaWiki API.
- *
- * Constructor parameters:
- *    currentAction: the current action (required)
- *    query: the query (required)
- *    onSuccess: the function to call when request gotten
- *    statusElement: a Morebits.status object to use for status messages (optional)
- *    onError: the function to call if an error occurs (optional)
  */
+
+ /**
+  * @constructor
+  * @param {*} currentAction The current action (required)
+  * @param {*} query The query object. (required)
+  * @param {*} onSuccess The function to call when request gotten
+  * @param {*} [statusElement] A Morebits.status object to use for status messages (optional)
+  * @param {*} [onError] The function to call if an error occurs (optional)
+  */
 Morebits.wiki.api = function( currentAction, query, onSuccess, statusElement, onError ) {
 	this.currentAction = currentAction;
 	this.query = query;
@@ -1421,8 +1420,10 @@ Morebits.wiki.api.prototype = {
 	errorCode: null, // short text error code, if any, as documented in the MediaWiki API
 	errorText: null, // full error description, if any
 
-	// post(): carries out the request
-	// do not specify a parameter unless you really really want to give jQuery some extra parameters
+	/**
+	 * Carries out the request.
+	 * Do not specify a parameter unless you really really want to give jQuery some extra parameters
+	 */
 	post: function( callerAjaxParameters ) {
 
 		++Morebits.wiki.numberOfActionsLeft;


### PR DESCRIPTION
Added some documentation (jsdocs) for several of morebits classes. Since jsdocs are shown by code editors in tooltips, this would greatly help the next generation of script writers. 

I converted existing documentation comments to jsdoc-comments for wiki.page, wiki.api, wiki.preview, string, array, regexp classes while adding my own $0.02 here and there. For wikitext.page, it is written from scratch. 

In the 3rd commit, I rearranged the order of several functions in wiki.page, hence the diff for that class may look quite messy. 