### PR TITLE
speedy: Enable U2 on redirects

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -771,15 +771,15 @@ Twinkle.speedy.userAllList = [
 			size: 60
 		} : null),
 		hideSubgroupWhenMultiple: true
-	}
-];
-
-Twinkle.speedy.userNonRedirectList = [
+	},
 	{
 		label: 'U2: Nonexistent user',
 		value: 'nouser',
 		tooltip: 'User pages of users that do not exist (Check Special:Listusers)'
-	},
+	}
+];
+
+Twinkle.speedy.userNonRedirectList = [
 	{
 		label: 'U3: Non-free galleries',
 		value: 'gallery',


### PR DESCRIPTION
Requested at [WT:TW](https://en.wikipedia.org/w/index.php?oldid=878315943#Function_request).  Given the data I posted there, this would get used much at all, but as far as U2 noms go it'd be about 1/3 of them, so that seems worth allowing.

U1 was enabled in 61c2f4a33