### PR TITLE
xfd and image: Remove check that prevented loading on history pages

### DIFF
--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -9,15 +9,12 @@
  *** twinkleimage.js: Image CSD module
  ****************************************
  * Mode of invocation:     Tab ("DI")
- * Active on:              File pages with a corresponding file which is local (not on Commons)
+ * Active on:              Local nonredirect file pages (not on Commons)
  * Config directives in:   TwinkleConfig
  */
 
 Twinkle.image = function twinkleimage() {
-	if (mw.config.get('wgNamespaceNumber') === 6 &&
-			!document.getElementById("mw-sharedupload") &&
-			document.getElementById("mw-imagepage-section-filehistory")) {
-
+	if (mw.config.get('wgNamespaceNumber') === 6 && mw.config.get('wgArticleId') && !document.getElementById("mw-sharedupload") && !Morebits.wiki.isPageRedirect()) {
 		Twinkle.addPortletLink(Twinkle.image.callback, "DI", "tw-di", "Nominate file for delayed speedy deletion");
 	}
 };

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -17,7 +17,7 @@ Twinkle.xfd = function twinklexfd() {
 	// Disable on:
 	// * special pages
 	// * non-existent pages
-	// * files on Commons, whether there is a local page or not (unneeded local pages of files on Commons are eligible for CSD F2)
+	// * files on Commons, whether there is a local page or not (unneeded local pages of files on Commons are eligible for CSD F2, or R4 if it's a redirect)
 	if ( mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && (document.getElementById('mw-sharedupload'))) ) {
 		return;
 	}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -18,8 +18,7 @@ Twinkle.xfd = function twinklexfd() {
 	// * special pages
 	// * non-existent pages
 	// * files on Commons, whether there is a local page or not (unneeded local pages of files on Commons are eligible for CSD F2)
-	// * file pages without actual files (these are eligible for CSD G8)
-	if ( mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && (document.getElementById('mw-sharedupload') || (!document.getElementById('mw-imagepage-section-filehistory') && !Morebits.wiki.isPageRedirect()))) ) {
+	if ( mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && (document.getElementById('mw-sharedupload'))) ) {
 		return;
 	}
 	Twinkle.addPortletLink( Twinkle.xfd.callback, "XFD", "tw-xfd", "Nominate for deletion" );


### PR DESCRIPTION
Closes #378

As noted there, the check added in 8b65bb1 meant that twinkleimage would no longer load on history pages (similar to ad5af2f).  I've loaded these changes into test.wiki, and this seems to no longer be an issue, presumably as the structure and loading of Twinkle has changed dramatically since then.

These changes are imperfect, however.  In order to allow loading on history pages, the conditions must be relaxed, such that it is possible for twinkle image and xfd to load on a local nonredirect page with no file on it.  One possible workaround could be a (morebits?) test for a file rather than trying to detect 'mw-imagepage-section-filehistory', but per [quarry:query/32775](https://quarry.wmflabs.org/query/32775) these seem rather rare (2-3 a month) so the benefit likely exceeds any perceived costs.

Still, I'm not 100% committed to either of these; the change to `twinkleimage` was what was requested, the change to xfd was done for parallelism/completion.