### PR TITLE
csd: Ask if the user wants to double-tag a page

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1404,8 +1404,8 @@ Twinkle.speedy.callbacks = {
 
 			// check for existing deletion tags
 			var tag = /(?:\{\{\s*(db|delete|db-.*?|speedy deletion-.*?)(?:\s*\||\s*\}\}))/.exec( text );
-			if( tag ) {
-				statelem.error( [ Morebits.htmlNode( 'strong', tag[1] ) , " is already placed on the page." ] );
+			// This won't make use of the db-multiple template but it probably should
+			if( tag && !confirm( "The page already has the CSD-related template {{" + tag[1] + "}} on it.  Do you want to add another CSD template?" ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Closes #348

Mirrors the message below for found XfD tags.  There are certainly cases where multiple tags
may be warranted (G11 and G12 are quite commonly paired, for example) but where only one was
placed initialy.  Ideally, this would be rewritten to fold any new tags in with the old and
group them all under db-multiple.