### PR TITLE
warn: Add option to allow automatic opening of menu after revert

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -669,12 +669,6 @@ Twinkle.config.sections = [
 			type: "customList",
 			customListValueTitle: "Template name (no curly brackets)",
 			customListLabelTitle: "Text to show in warning list (also used as edit summary)"
-		},
-
-		{
-			name: "markXfdPagesAsPatrolled",
-			label: "Mark page as patrolled when nominating for AFD (if possible)",
-			type: "boolean"
 		}
 	]
 },
@@ -775,6 +769,12 @@ Twinkle.config.sections = [
 			label: "Add user talk page of initial contributor to watchlist (when notifying)",
 			type: "enum",
 			enumValues: Twinkle.config.commonEnums.watchlist
+		},
+
+		{
+			name: "markXfdPagesAsPatrolled",
+			label: "Mark page as patrolled when nominating for AFD (if possible)",
+			type: "boolean"
 		}
 	]
 },

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -301,6 +301,15 @@ Twinkle.config.sections = [
 {
 	title: "Revert and rollback",  // twinklefluff module
 	preferences: [
+		// TwinkleConfig.autoMenuAfterRollback (bool)
+		// Option to automatically open the warning menu if the user talk page is opened post-reversion
+		{
+			name: "autoMenuAfterRollback",
+			label: "Automatically open the Twinkle warn menu on a user talk page after Twinkle rollback",
+			helptip: "Only operates if the relevant box is checked below.",
+			type: "boolean"
+		},
+
 		// TwinkleConfig.openTalkPage (array)
 		// What types of actions that should result in opening of talk page
 		{

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -16,6 +16,9 @@
 Twinkle.warn = function twinklewarn() {
 	if( mw.config.get( 'wgRelevantUserName' ) ) {
 			Twinkle.addPortletLink( Twinkle.warn.callback, "Warn", "tw-warn", "Warn/notify user" );
+			if (Twinkle.getPref('autoMenuAfterRollback') && mw.config.get('wgNamespaceNumber') === 3 && mw.util.getParamValue('vanarticle')) {
+				Twinkle.warn.callback();
+			}
 	}
 
 	// Modify URL of talk page on rollback success pages, makes use of a

--- a/twinkle.js
+++ b/twinkle.js
@@ -104,6 +104,7 @@ Twinkle.defaultConfig.twinkle = {
 	showSharedIPNotice: true,
 	watchWarnings: true,
 	customWarningList: [],
+	autoMenuAfterRollback: false,
 
 	// XfD
 	xfdWatchDiscussion: "default",


### PR DESCRIPTION
Closes #162

Still loads the page in edit mode, but optionally opens the warning menu.  Defaults to previous behavior (although perhaps there's an argument that it shouldn't).  I think this is likely to be popular!

One thing to consider is whether the config option should be in the warn or rollback on WP:TW/PREF.

The first commit is actually to `twinkleconfig` and moves an xfd-relevant item (`markXfdPagesAsPatrolled`) to the proper section (introduced in 6651b059).

I should note that I've put this live on test.wiki