### PR TITLE
morebits: enable multiline unbinder

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1241,7 +1241,7 @@ Morebits.unbinder.prototype = {
 	 * @param {string} postfix
 	 */
 	unbind: function UnbinderUnbind( prefix, postfix ) {
-		var re = new RegExp( prefix + '([\s\S]*?)' + postfix, 'g' ); //eslint-disable-line no-useless-escape
+		var re = new RegExp( prefix + '([\\s\\S]*?)' + postfix, 'g' );
 		this.content = this.content.replace( re, Morebits.unbinder.getCallback( this ) );
 	},
 

--- a/morebits.js
+++ b/morebits.js
@@ -1241,7 +1241,7 @@ Morebits.unbinder.prototype = {
 	 * @param {string} postfix
 	 */
 	unbind: function UnbinderUnbind( prefix, postfix ) {
-		var re = new RegExp( prefix + '(.*?)' + postfix, 'gs' );
+		var re = new RegExp( prefix + '([\s\S]*?)' + postfix, 'g' ); //eslint-disable-line no-useless-escape
 		this.content = this.content.replace( re, Morebits.unbinder.getCallback( this ) );
 	},
 


### PR DESCRIPTION
Regex s flag appears to be resulting in an exception in IE 11 and legacy browsers. I have used [\s\S]*? instead of it so that newlines get matched. Eslint doesn't like this syntax for whatever reason, though this usage seems to be fine and is suggested online. 

While at some point (after making the commit) it came to my attention that the regex s flag is not supported in IE 11 and the like, I did not realise that it would cause an exception - I thought that these browsers would just ignore the flag. I was working in Ubuntu and so did not have IE handily available to test on. 