### PR TITLE
fluff: Add [restore this revision] link to old revisions

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -37,6 +37,13 @@ Twinkle.fluff = {
 			span.appendChild( document.createTextNode( content ) );
 			return span;
 		};
+		var buildLink = function(color, text) {
+			var link = document.createElement('a');
+			link.appendChild(spanTag('Black', '['));
+			link.appendChild(spanTag(color, text));
+			link.appendChild(spanTag('Black', ']'));
+			return link;
+		};
 
 		// $('sp-contributions-footer-anon-range') relies on the fmbox
 		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
@@ -50,17 +57,11 @@ Twinkle.fluff = {
 				var list = $("#mw-content-text").find("ul li:has(span.mw-uctop)");
 
 				var revNode = document.createElement('strong');
-				var revLink = document.createElement('a');
-				revLink.appendChild( spanTag( 'Black', '[' ) );
-				revLink.appendChild( spanTag( 'SteelBlue', 'rollback' ) );
-				revLink.appendChild( spanTag( 'Black', ']' ) );
+				var revLink = buildLink('SteelBlue', 'rollback');
 				revNode.appendChild(revLink);
 
 				var revVandNode = document.createElement('strong');
-				var revVandLink = document.createElement('a');
-				revVandLink.appendChild( spanTag( 'Black', '[' ) );
-				revVandLink.appendChild( spanTag( 'Red', 'vandalism' ) );
-				revVandLink.appendChild( spanTag( 'Black', ']' ) );
+				var revVandLink = buildLink('Red', 'vandalism');
 				revVandNode.appendChild(revVandLink);
 
 				list.each(function(key, current) {
@@ -82,12 +83,6 @@ Twinkle.fluff = {
 				return;
 			}
 
-			var firstRev = $("div.firstrevisionheader").length;
-			if( firstRev ) {
-				// we have first revision here, nothing to do.
-				return;
-			}
-
 			var otitle, ntitle;
 			try {
 				var otitle1 = document.getElementById('mw-diff-otitle1');
@@ -104,7 +99,7 @@ Twinkle.fluff = {
 
 			var old_rev_url = $("#mw-diff-otitle1").find("strong a").attr("href");
 
-			// Lets first add a [edit this revision] link
+			// Lets first add a [restore this revision] link
 			var query = new Morebits.queryString( old_rev_url.split( '?', 2 )[1] );
 
 			var oldrev = query.get('oldid');
@@ -113,14 +108,12 @@ Twinkle.fluff = {
 			revertToRevision.setAttribute( 'id', 'tw-revert-to-orevision' );
 			revertToRevision.style.fontWeight = 'bold';
 
-			var revertToRevisionLink = revertToRevision.appendChild( document.createElement('a') );
+			var revertToRevisionLink = buildLink('SaddleBrown', 'restore this version');
 			revertToRevisionLink.href = "#";
 			$(revertToRevisionLink).click(function(){
 				Twinkle.fluff.revertToRevision(oldrev);
 			});
-			revertToRevisionLink.appendChild( spanTag( 'Black', '[' ) );
-			revertToRevisionLink.appendChild( spanTag( 'SaddleBrown', 'restore this version' ) );
-			revertToRevisionLink.appendChild( spanTag( 'Black', ']' ) );
+			revertToRevision.appendChild(revertToRevisionLink);
 
 			otitle.insertBefore( revertToRevision, otitle.firstChild );
 
@@ -132,19 +125,14 @@ Twinkle.fluff = {
 				revertToRevision = document.createElement('div');
 				revertToRevision.setAttribute( 'id', 'tw-revert-to-nrevision' );
 				revertToRevision.style.fontWeight = 'bold';
-				revertToRevisionLink = revertToRevision.appendChild( document.createElement('a') );
+				revertToRevisionLink = buildLink('SaddleBrown', 'restore this version');
 				revertToRevisionLink.href = "#";
 				$(revertToRevisionLink).click(function(){
 					Twinkle.fluff.revertToRevision(newrev);
 				});
-				revertToRevisionLink.appendChild( spanTag( 'Black', '[' ) );
-				revertToRevisionLink.appendChild( spanTag( 'SaddleBrown', 'restore this version' ) );
-				revertToRevisionLink.appendChild( spanTag( 'Black', ']' ) );
+				revertToRevision.appendChild(revertToRevisionLink);
 				ntitle.insertBefore( revertToRevision, ntitle.firstChild );
-
-				return;
-			}
-			if( Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 ) {
+			} else if( Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 ) {
 				var vandal = $("#mw-diff-ntitle2").find("a").first().text();
 
 				var revertNode = document.createElement('div');
@@ -154,9 +142,9 @@ Twinkle.fluff = {
 				var vandNode = document.createElement('strong');
 				var normNode = document.createElement('strong');
 
-				var agfLink = document.createElement('a');
-				var vandLink = document.createElement('a');
-				var normLink = document.createElement('a');
+				var agfLink = buildLink('DarkOliveGreen', 'rollback (AGF)');
+				var vandLink = buildLink('Red', 'rollback (VANDAL)');
+				var normLink = buildLink('SteelBlue', 'rollback');
 
 				agfLink.href = "#";
 				vandLink.href = "#";
@@ -170,18 +158,6 @@ Twinkle.fluff = {
 				$(normLink).click(function(){
 					Twinkle.fluff.revert('norm', vandal);
 				});
-
-				agfLink.appendChild( spanTag( 'Black', '[' ) );
-				agfLink.appendChild( spanTag( 'DarkOliveGreen', 'rollback (AGF)' ) );
-				agfLink.appendChild( spanTag( 'Black', ']' ) );
-
-				vandLink.appendChild( spanTag( 'Black', '[' ) );
-				vandLink.appendChild( spanTag( 'Red', 'rollback (VANDAL)' ) );
-				vandLink.appendChild( spanTag( 'Black', ']' ) );
-
-				normLink.appendChild( spanTag( 'Black', '[' ) );
-				normLink.appendChild( spanTag( 'SteelBlue', 'rollback' ) );
-				normLink.appendChild( spanTag( 'Black', ']' ) );
 
 				agfNode.appendChild(agfLink);
 				vandNode.appendChild(vandLink);


### PR DESCRIPTION
1st commit: Tidies up and removes duplicate/unnecessary code
- The same four lines, three of which used `spanTag`, were repeated frequently
- Newer revisions either are the latest or not
- No idea what `.firstrevisionheader` did but I can't find it anywhere on-wiki, so removed

2nd commit: Add [restore this revision] link to oldid pages


fluff: Add [restore this revision] link to oldid pages, closes #131

Checking for `wgDiffOldId` and `wgDiffNewId` excludes Special:Undelete, and so should be sufficient to avoid problematic diffs.  Some of the logic/checks may be a tad confusing since `wgDiffNewId` and `wgDiffOldId` have different behaviors (see [[[phab:T214985]]](https://phabricator.wikimedia.org/T214985)).  One advantage of the restructuring is that [restore this revision] will now appear when viewing the first revision as a diff with `diff=prev`, as may sometimes happen.

One thing to note is that when viewing old revisions, checking for `div#mw-revision-info` sufficiently prevents the link from appearing on the most recent revision, since `div#mw-revision-info-current` is used instead.  However, that is only the case if there is anything present at [[MediaWiki:Revision-info-current]], elsewise the fallback is to use `div#mw-revision-info`; this may have issues for other wikis if that page doesn't exist.  Moreover, unlike revisionasof, [$3 in revision-info](translatewiki.net/wiki/MediaWiki:Revision-info/qqq) doesn't expose a link we can capture, hence the imperfect `Morebits.query('oldid')` appears the best we can do.