### PR TITLE
Fix and improve sync.pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Each Twinkle module and dependency lives on the wiki as a separate file. The lis
 
 There is a synchronization script called `sync.pl`, which can be used to pull and push files to Wikipedia.
 
-The program depends on the modules [`Git::Repository`][Git::Repository] and [`MediaWiki::API`][MediaWiki::API], which can be installed easily using [`App::cpanminus`][App::cpanminus]:
+The program depends on a few modules, namely [`MediaWiki::API`][MediaWiki::API], [`Git::Repository`][Git::Repository], [`File::Slurper`][File::Slurper], and [`Getopt::Long::Descriptive`][Getopt::Long::Descriptive]. These can be installed easily using [`App::cpanminus`][App::cpanminus]:
 
-    cpanm --sudo install Git::Repository MediaWiki::API
+    cpanm --sudo install MediaWiki::API Git::Repository File::Slurper Getopt::Long::Descriptive
 
-Note: On some systems, additional modules such as `File::Slurp`, `Getopt::Long::Descriptive` and other dependencies may need to be installed as well. It is preferred that you install them through your operating system's packaing tool (e.g. `apt-get install libgetopt-long-descriptive-perl`) although you can install them through cpanm too.
+You may prefer to install them through your operating system's packaing tool (e.g. `apt-get install libgetopt-long-descriptive-perl`) although you can install them through cpanm too.
 
 When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a file called `~/.twinklerc` using the following format:
 
@@ -80,7 +80,7 @@ When running the program, you can enter your credentials on the command line usi
     family   = wikipedia
     base     = User:Username
 
-where `base` is the wiki path to prefix the files for `pull` and `push`.
+where `base` is the wiki path to prefix the files for `pull` and `push`. The script ignores the `modules/` part of the file path when downloading/uploading.
 
 Notice that your working directory **must** be clean; if not, either `stash` or `commit` your changes.
 
@@ -92,7 +92,7 @@ To `push` your changes to Foobar's wiki page, do:
 
     ./sync.pl --base User:Foobar --push twinkle.js morebits.js ...
 
-There is also a `deploy` command to deploy Twinkle files live to their MediaWiki:Gadget locations.
+There is also a `deploy` command for interface-admins to deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
 
     ./sync.pl --deploy twinkle.js morebits.js ...
 
@@ -104,7 +104,7 @@ Note that for syncing to a custom wiki (read: not the English Wikipedia), you wi
 
     make ARGS="--lang=test --family=wmflabs" deploy
 
-The edit summary will contain the branch, the last commit sha, and the oneliner for that commit.
+When `deploy`ing or `push`ing, the script will attempt to parse the latest on-wiki edit summary to find the most recently used commit, and will use that to create an edit summary from the commits since then. If it cannot find anything that looks like a commit hash, it will prompt you to enter one for each file.
 
 Style guideline
 ---------------
@@ -146,7 +146,10 @@ Needless to say, there are exceptions. The main sticking point is spacing around
 [MediaWiki:Gadget-twinkleblock.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleblock.js
 [User:AzaToth/twinkle.js]: https://en.wikipedia.org/wiki/User:AzaToth/twinkle.js
 [MediaWiki:Gadgets-definition]: https://en.wikipedia.org/wiki/MediaWiki:Gadgets-definition
-[Git::Repository]: https://metacpan.org/pod/Git::Repository
 [MediaWiki::API]: https://metacpan.org/pod/MediaWiki::API
+[Git::Repository]: https://metacpan.org/pod/Git::Repository
+[File::Slurper]: https://metacpan.org/pod/File::Slurper
+[Getopt::Long::Descriptive]: https://metacpan.org/pod/Getopt::Long::Descriptive
 [App::cpanminus]: https://metacpan.org/pod/App::cpanminus
+[special_botpass]: https://en.wikipedia.org/wiki/Special:BotPasswords
 [jq_style]: https://contribute.jquery.org/style-guide/js/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Other files not mentioned here are probably obsolete.
 Updating scripts on Wikipedia
 -----------------------------
 
-There are two ways to upload Twinkle scripts to Wikipedia or another destination. You can do it [manually](#manual-synchronization) or with a [Perl script](#synchronization-using-syncpl).
+There are two ways to upload Twinkle scripts to Wikipedia or another destination. You can do it [manually](#manual-synchronization) (recommended) or with a [Perl script](#synchronization-using-syncpl).
 
 After the files are synced, [MediaWiki:Gadgets-definition][] should contain the following lines:
 
@@ -66,36 +66,41 @@ Each Twinkle module and dependency lives on the wiki as a separate file. The lis
 
 There is a synchronization script called `sync.pl`, which can be used to pull and push files to Wikipedia.
 
-The program depends on Perl 5.10 and the modules [`Git::Repository`][Git::Repository] and [`MediaWiki::Bot`][MediaWiki::Bot], which can be installed easily using [`App::cpanminus`][App::cpanminus]:
+The program depends on the modules [`Git::Repository`][Git::Repository] and [`MediaWiki::API`][MediaWiki::API], which can be installed easily using [`App::cpanminus`][App::cpanminus]:
 
-    cpanm --sudo install Git::Repository MediaWiki::Bot
+    cpanm --sudo install Git::Repository MediaWiki::API
 
 Note: On some systems, additional modules such as `File::Slurp`, `Getopt::Long::Descriptive` and other dependencies may need to be installed as well. It is preferred that you install them through your operating system's packaing tool (e.g. `apt-get install libgetopt-long-descriptive-perl`) although you can install them through cpanm too.
 
-When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a file called `~/.mwbotrc` using the following format:
+When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a file called `~/.twinklerc` using the following format:
 
-    username => "Username",
-    password => "password",
-    base     => "User::Username"
+    username = username
+    password = password
+    lang     = en
+    family   = wikipedia
+    base     = User:Username
 
-where `base` is the wiki path to prefix the files for `pull` and `push`. If you do not specify the `base` parameter, files will be pushed into the MediaWiki namespace.
+where `base` is the wiki path to prefix the files for `pull` and `push`.
 
 Notice that your working directory **must** be clean; if not, either `stash` or `commit` your changes.
 
 To `pull` user Foobar's changes (i.e. `User:Foobar/morebits.js`), do:
 
-    ./sync.pl --base User:Foobar --pull morebits.js
+    ./sync.pl --base User:Foobar --pull twinkle.js morebits.js ...
 
 To `push` your changes to Foobar's wiki page, do:
 
-    ./sync.pl --base User:Foobar --push morebits.js
+    ./sync.pl --base User:Foobar --push twinkle.js morebits.js ...
 
-There is also a `deploy` command to deploy all Twinkle files live.
+There is also a `deploy` command to deploy Twinkle files live to their MediaWiki:Gadget locations.
 
-    ./sync.pl --deploy twinkle.js
+    ./sync.pl --deploy twinkle.js morebits.js ...
+
+You may also `deploy` all files via
+
     make deploy
 
-Note that for syncing to a custom wiki, you will also need to specify the --lang and --family parameters too. For instance, to sync the files with `test.wmflabs.org` you should specify `--lang=test --family=wmflabs`. If you intend to use `make deploy` to deploy all the files at once, you may also need to pass the necessary parameters through the makefile to the sync script like this example:
+Note that for syncing to a custom wiki (read: not the English Wikipedia), you will also need to specify the --lang and --family parameters too. For instance, to sync the files with `test.wmflabs.org` you should specify `--lang=test --family=wmflabs`. If you intend to use `make deploy` to deploy all the files at once, you may also need to pass the necessary parameters through the makefile to the sync script like this example:
 
     make ARGS="--lang=test --family=wmflabs" deploy
 
@@ -142,6 +147,6 @@ Needless to say, there are exceptions. The main sticking point is spacing around
 [User:AzaToth/twinkle.js]: https://en.wikipedia.org/wiki/User:AzaToth/twinkle.js
 [MediaWiki:Gadgets-definition]: https://en.wikipedia.org/wiki/MediaWiki:Gadgets-definition
 [Git::Repository]: https://metacpan.org/pod/Git::Repository
-[MediaWiki::Bot]: https://metacpan.org/pod/MediaWiki::Bot
+[MediaWiki::API]: https://metacpan.org/pod/MediaWiki::API
 [App::cpanminus]: https://metacpan.org/pod/App::cpanminus
 [jq_style]: https://contribute.jquery.org/style-guide/js/

--- a/sync.pl
+++ b/sync.pl
@@ -5,28 +5,28 @@ use strict;
 use warnings;
 
 use English qw(-no_match_vars);
-use Encode;
 use utf8;
 
 use Config::General qw(ParseConfig);
 use Getopt::Long::Descriptive;
 use Git::Repository;
 use MediaWiki::API;
-use File::Slurp;
+use File::Slurper qw(read_text write_text);
 
 # Config file should be a simple file consisting of keys and values:
 # username = Jimbo Wales
 # lang = en
 # etc.
+my %conf;
 my $config_file = "$ENV{HOME}/.twinklerc";
-my %conf = ParseConfig($config_file);
+%conf = ParseConfig($config_file) if -e -f -r $config_file;
 
 my ($opt, $usage) = describe_options(
     "$PROGRAM_NAME %o <files...>",
     ['username|u=s', 'username for account on wikipedia', {default => $conf{username} // q{}}],
     ['password|p=s', 'password for account on wikipedia (do not use)', {default => $conf{password} // q{}}],
-    ['lang=s', 'Target language', {default => $conf{lang} // 'en'}],
-    ['family=s', 'Target family', {default => $conf{family} // 'wikipedia'}],
+    ['lang|l=s', 'Target language', {default => $conf{lang} // 'en'}],
+    ['family|f=s', 'Target family', {default => $conf{family} // 'wikipedia'}],
     ['base|b=s', 'base location on wikipedia where user files exist (default User:AzaToth or entry in .twinklerc)', {default => $conf{base} // 'User:AzaToth'}],
     [],
     ['mode' => hidden =>
@@ -39,115 +39,188 @@ my ($opt, $usage) = describe_options(
             ]
         }
     ],
-    ['strip', 'strip line end spaces'],
     [],
     ['help', 'print usage message and exit'],
 );
-
-if ($opt->help || !scalar @ARGV) {
+if ($opt->help || !scalar @ARGV || !($opt->username && $opt->password)) {
   print $usage->text;
   exit;
 }
 
-my %pages = map {+"$opt->{base}/$_" => $_} @ARGV;
-my %deploys = (
-	'twinkle.js' => 'MediaWiki:Gadget-Twinkle.js',
-	'twinkle.css' => 'MediaWiki:Gadget-Twinkle.css',
-	'twinkle-pagestyles.css' => 'MediaWiki:Gadget-Twinkle-pagestyles.css',
-	'morebits.js' => 'MediaWiki:Gadget-morebits.js',
-	'morebits.css' => 'MediaWiki:Gadget-morebits.css',
-	'modules/friendlyshared.js' => 'MediaWiki:Gadget-friendlyshared.js',
-	'modules/friendlytag.js' => 'MediaWiki:Gadget-friendlytag.js',
-	'modules/friendlytalkback.js' => 'MediaWiki:Gadget-friendlytalkback.js',
-	'modules/friendlywelcome.js' => 'MediaWiki:Gadget-friendlywelcome.js',
-	'modules/twinklearv.js' => 'MediaWiki:Gadget-twinklearv.js',
-	'modules/twinklebatchdelete.js' => 'MediaWiki:Gadget-twinklebatchdelete.js',
-	'modules/twinklebatchprotect.js' => 'MediaWiki:Gadget-twinklebatchprotect.js',
-	'modules/twinklebatchundelete.js' => 'MediaWiki:Gadget-twinklebatchundelete.js',
-	'modules/twinkleblock.js' => 'MediaWiki:Gadget-twinkleblock.js',
-	'modules/twinkleconfig.js' => 'MediaWiki:Gadget-twinkleconfig.js',
-	'modules/twinkledeprod.js' => 'MediaWiki:Gadget-twinkledeprod.js',
-	'modules/twinklediff.js' => 'MediaWiki:Gadget-twinklediff.js',
-	'modules/twinklefluff.js' => 'MediaWiki:Gadget-twinklefluff.js',
-	'modules/twinkleimage.js' => 'MediaWiki:Gadget-twinkleimage.js',
-	'modules/twinkleprotect.js' => 'MediaWiki:Gadget-twinkleprotect.js',
-	'modules/twinklespeedy.js' => 'MediaWiki:Gadget-twinklespeedy.js',
-	'modules/twinkleunlink.js' => 'MediaWiki:Gadget-twinkleunlink.js',
-	'modules/twinklewarn.js' => 'MediaWiki:Gadget-twinklewarn.js',
-	'modules/twinklexfd.js' => 'MediaWiki:Gadget-twinklexfd.js',
-	'modules/twinkleprod.js' => 'MediaWiki:Gadget-twinkleprod.js'
-);
+# Ensure we've got a clean branch
+my $repo = Git::Repository->new();
+my @status = $repo->run(status => '--porcelain');
+if (scalar @status) {
+  print "Repository is not clean, aborting\n";
+  exit;
+}
+# Make sure we know what we're doing before doing it
+forReal();
 
+# Build file->page hashes
+my %deploys;
+while (<DATA>) {
+  chomp;
+  my @map = split;
+  $deploys{$map[0]} = $map[1];
+}
+# Remove 'modules/' from ARGV input filenames
+my %pages = map {+(my $s = $_) =~ s/modules\///; $_ => "$opt->{base}/$s"} @ARGV;
+
+# Open API and log in before anything else
 my $mw = MediaWiki::API->new({
 			      api_url => "https://$opt->{lang}.$opt->{family}.org/w/api.php",
 			      max_lag => 1000000 # not a botty script, thus smash it!
 			     });
 $mw->login({lgname => $opt->username, lgpassword => $opt->password})
-  or die $mw->{error}->{code} . ': ' . $mw->{error}->{details};
+  or die "Error logging in: $mw->{error}->{code}: $mw->{error}->{details}\n";
 
-my $repo = Git::Repository->new();
-
+### Main loop to parse options
 if ($opt->mode eq 'pull') {
-  my @status = $repo->run( status => '--porcelain');
-
-  if (scalar @status) {
-    print "repository is not clean. aborting...\n";
-    exit;
-  }
-
-  while (my ($page, $file) = each %pages) {
-    print "Grabbing $page\n";
-    my $wikiPage = $mw->get_page({title => $page});
-    if (defined $wikiPage->{missing}) {
-      print "$page does not exist\n";
-      exit 1;
+  while (my ($file, $page) = each %pages) {
+    my $wikiPage = checkPage($page);
+    next if !$wikiPage;
+    print "Grabbing $page";
+    my $text = $wikiPage->{q{*}}."\n"; # MediaWiki doesn't have trailing newlines
+    # Might be faster to check this using git and eof, but here makes sense
+    if ($text eq read_text($file)) {
+      print "... No changes found, skipping\n";
+      next;
     } else {
-      my $text = $wikiPage->{q{*}};
-      $text =~ s/\h+$//mg if $opt->{'strip'};
-      write_file( $file, {binmode => ':raw' }, encode('UTF-8',$text));
+      print "\n";
+      write_text($file, $text);
     }
   }
+  # Show a summary of any changes
   my $cmd = $repo->command(diff => '--stat', '--color');
   my $s = $cmd->stdout;
   while (<$s>) {
-    print "$_\n";
+    print;
   }
   $cmd->close;
 } elsif ($opt->mode eq 'push') {
-  while (my ($page, $file) = each %pages) {
-    my $tag = $repo->run(describe => '--always', '--all', '--dirty');
-    my $log = $repo->run(log => '-1', '--oneline', '--no-color', $file);
-    $tag =~ m{(?:heads/)?(?<branch>.+)};
-    my $text = read_file($file,  {binmode => ':raw' });
-    my $editReturn = editPage($page, decode('UTF-8', $text), "$LAST_PAREN_MATCH{branch}:$log");
-    if ($editReturn->{_msg} eq 'OK') {
-      print "$file successfully pushed to $page\n";
-    } else {
-      print "Error pushing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
-    }
+  while (my ($file, $page) = each %pages) {
+    next if saltNPepa($page, $file);
   }
 } elsif ($opt->mode eq 'deploy') {
-  foreach my $file (values %pages) {
+  foreach my $file (keys %pages) {
     if (!defined $deploys{$file}) {
-      print "$file not deployable\n";
-      exit 1;
+      print "$file not deployable, skipping\n";
+      next;
     }
     my $page = $deploys{$file};
-    print "$file -> $opt->{lang}.$opt->{family}.org/wiki/$page\n";
-    my $tag = $repo->run(describe => '--always', '--dirty');
-    my $log = $repo->run(log => '-1', '--pretty=format:%s', '--no-color');
-    my $text = read_file($file,  {binmode => ':raw' });
-    my $editReturn = editPage($page, decode('UTF-8', $text), "$tag: $log");
-    if ($editReturn->{_msg} eq 'OK') {
-      print "$file successfully pushed to $page\n";
-    } else {
-      print "Error pushing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
-    }
+    next if saltNPepa($page, $file);
   }
 }
 
 
 ### SUBROUTINES
+# Check that everything is in order
+# Data::Dumper is simpler but the output is ugly, and this ain't worth another
+# dependency
+sub forReal {
+  my @meaningful = qw (username base lang family);
+  print "Here are the current parameters specified:\n\n";
+  foreach my $key (@meaningful) {
+    print "\t$key = ${$opt}{$key}\n";
+  }
+  print "\nThis means User:$opt->{username} will ";
+  print uc $opt->{mode}.q{ };
+  if ($opt->{mode} eq 'pull') {
+    print "from subpages of $opt->{base}";
+  } elsif ($opt->{mode} eq 'push') {
+    print "to subpages of $opt->{base}";
+  } elsif ($opt->{mode} eq 'deploy') {
+    print 'live to the MediaWiki gadget';
+  }
+  print " at $opt->{lang}.$opt->{family}.org\n";
+  while (42) {
+    print "Enter (y)es to proceed or (n)o to cancel:\n";
+    my $input = <STDIN>;
+    chomp $input;
+    $input = lc $input;
+    if ($input eq 'n' || $input eq 'no') {
+      print "Aborting\n";
+      exit 0;
+    } elsif ($input eq 'y' || $input eq 'yes') {
+      print "Proceeding\n";
+      return 0;
+    } else {
+      print 'Unknown entry... ';
+    }
+  }
+  return 1; # We should never get here but just in case
+}
+
+# Check if file exists
+sub checkFile {
+  my $file = shift;
+  if (-e -f -r $file) {
+    return 0;
+  } else {
+    print "$file does not exist, skipping\n";
+    return 1;
+  }
+}
+
+# Check if page exists
+sub checkPage {
+  my $page = shift;
+  my $wikiPage = $mw->get_page({title => $page}) or die "$mw->{error}->{code}: $mw->{error}->{details}\n";
+  if (defined $wikiPage->{missing}) {
+    print "$page does not exist, skipping\n";
+    return 0;
+  } else {
+    return $wikiPage;
+  }
+}
+
+# Tries to figure out a good edit summary by using the last one onwiki to find
+# the latest changes; prompts user if it can't find a commit hash
+sub buildEditSummary {
+  my ($page, $file, $oldCommitish) = @_;
+  my $editSummary;
+  # User:Amorymeltzer & User:MusikAnimal or User:Amalthea et al.
+  if ($oldCommitish =~ /(?:Repo|v2\.0) at (\w*?): / || $oldCommitish =~ /v2\.0-\d+-g(\w*?): /) {
+    # Ensure it's a valid commit and no errors are reported back
+    my $valid = $repo->command('merge-base' => '--is-ancestor', "$1", 'HEAD');
+    my $validC = $valid->stderr();
+    if (eof $validC) {
+      print "$1\n";
+      my $newLog = $repo->run(log => '--oneline', '--no-color', "$1..HEAD", $file);
+      open my $nl, '<', \$newLog or die $ERRNO;
+      while (<$nl>) {
+	chomp;
+	my @arr = split / /, $_, 2;
+	next if $arr[1] =~ /Merge pull request #\d+/;
+
+	if ($arr[1] =~ /(\S+(?:\.(?:js|css))?) ?[:|-] ?(.+)/) {
+	  $2 =~ s/\.$//; # Just in case
+	  $editSummary .= "$2; ";
+	}
+      }
+      close $nl or die $ERRNO;
+    }
+  }
+
+  # Prompt for manual entry
+  if (!$editSummary) {
+    my $log = $repo->run(log => '-1', '--pretty=format:%s', '--no-color', $file);
+    print "\nUnable to autogenerate edit summary for $page.  The most recent edit summary is:\n";
+    print "\t$oldCommitish\nThe most recent log entry in git is:\n";
+    print "\t$log\nPlease provide an edit summary (commit ref will be added automatically):\n";
+    $editSummary = <STDIN>;
+    chomp $editSummary;
+  }
+  $editSummary =~ s/[\.; ]{1,2}$//; # Tidy
+  # Be helpful
+  my $editBeg = 'Repo at ';
+  $editBeg .= $repo->run('rev-parse' => '--short', 'HEAD');
+  $editBeg .= ': ';
+  return $editBeg.$editSummary;
+}
+
+# Edit the page
 sub editPage {
   my ($pTitle, $nText, $pSummary) = @_;
   my $ref = $mw->get_page({title => $pTitle});
@@ -162,7 +235,67 @@ sub editPage {
 	       basetimestamp => $timestamp, # Avoid edit conflicts
 	       text => $nText,
 	       summary => $pSummary
-	      }) || die $mw->{error}->{code} . ': ' . $mw->{error}->{details};
+	      }) || die "Error editing the page: $mw->{error}->{code}: $mw->{error}->{details}\n";
   }
   return $mw->{response};
 }
+
+# All together now!
+sub saltNPepa {
+  my ($page, $file) = @_;
+  return 1 if checkFile($file);
+  my $text = read_text($file);
+  my $wikiPage = checkPage($page);
+  return 1 if !$wikiPage;
+  # print "$file -> $opt->{lang}.$opt->{family}.org/wiki/$page";
+  print ucfirst $opt->{mode};
+  print "ing $file to $page";
+
+  my $wp = $wikiPage->{q{*}}."\n"; # MediaWiki doesn't have trailing newlines
+  if ($text eq $wp) {
+    print "... No changes needed, skipping\n";
+    return 1;
+  } else {
+    print "\n";;
+    my $summary = buildEditSummary($page, $file, $wikiPage->{comment});
+    my $editReturn = editPage($page, $text, $summary);
+    if ($editReturn->{_msg} eq 'OK') {
+      print "$file successfully pushed to $page\n";
+    } else {
+      print "Error pushing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
+    }
+    return 0;
+  }
+}
+
+
+## The lines below do not represent Perl code, and are not examined by the
+## compiler.  Rather, they are used by %deploys to map filenames from the
+## Twinkle git repo to their corresponding location in the MediaWiki Gadget
+## psuedonamespace.
+__DATA__
+twinkle.js MediaWiki:Gadget-Twinkle.js
+  twinkle.css MediaWiki:Gadget-Twinkle.css
+  twinkle-pagestyles.css MediaWiki:Gadget-Twinkle-pagestyles.css
+  morebits.js MediaWiki:Gadget-morebits.js
+  morebits.css MediaWiki:Gadget-morebits.css
+  modules/friendlyshared.js MediaWiki:Gadget-friendlyshared.js
+  modules/friendlytag.js MediaWiki:Gadget-friendlytag.js
+  modules/friendlytalkback.js MediaWiki:Gadget-friendlytalkback.js
+  modules/friendlywelcome.js MediaWiki:Gadget-friendlywelcome.js
+  modules/twinklearv.js MediaWiki:Gadget-twinklearv.js
+  modules/twinklebatchdelete.js MediaWiki:Gadget-twinklebatchdelete.js
+  modules/twinklebatchprotect.js MediaWiki:Gadget-twinklebatchprotect.js
+  modules/twinklebatchundelete.js MediaWiki:Gadget-twinklebatchundelete.js
+  modules/twinkleblock.js MediaWiki:Gadget-twinkleblock.js
+  modules/twinkleconfig.js MediaWiki:Gadget-twinkleconfig.js
+  modules/twinkledeprod.js MediaWiki:Gadget-twinkledeprod.js
+  modules/twinklediff.js MediaWiki:Gadget-twinklediff.js
+  modules/twinklefluff.js MediaWiki:Gadget-twinklefluff.js
+  modules/twinkleimage.js MediaWiki:Gadget-twinkleimage.js
+  modules/twinkleprotect.js MediaWiki:Gadget-twinkleprotect.js
+  modules/twinklespeedy.js MediaWiki:Gadget-twinklespeedy.js
+  modules/twinkleunlink.js MediaWiki:Gadget-twinkleunlink.js
+  modules/twinklewarn.js MediaWiki:Gadget-twinklewarn.js
+  modules/twinklexfd.js MediaWiki:Gadget-twinklexfd.js
+  modules/twinkleprod.js MediaWiki:Gadget-twinkleprod.js

--- a/sync.pl
+++ b/sync.pl
@@ -1,136 +1,168 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
+# sync.pl by azatoth (2011), update by amorymeltzer (2019)
 
-use v5.10;
+use strict;
+use warnings;
 
-use Git::Repository;
-use MediaWiki::Bot;
-use File::Slurp;
-use Getopt::Long::Descriptive;
+use English qw(-no_match_vars);
 use Encode;
 use utf8;
 
-my $config_file = "$ENV{HOME}/.mwbotrc";
-my $c = {do "$config_file"} if -f $config_file;
+use Config::General qw(ParseConfig);
+use Getopt::Long::Descriptive;
+use Git::Repository;
+use MediaWiki::API;
+use File::Slurp;
+
+# Config file should be a simple file consisting of keys and values:
+# username = Jimbo Wales
+# lang = en
+# etc.
+my $config_file = "$ENV{HOME}/.twinklerc";
+my %conf = ParseConfig($config_file);
 
 my ($opt, $usage) = describe_options(
-    "$0 %o <files...>",
-    [ 'username|u=s', "username for account on wikipedia", {default => $c->{username} // ""} ],
-    [ 'password|p=s', "password for account on wikipedia (do not use)", {default => $c->{password} // ""} ],
-    [ 'base|b=s', "base location on wikipedia where files exist (default User:AzaToth or entry in .mwbotrc)", {default => $c->{base} // "User:AzaToth"} ],
-    [ 'lang=s', 'Target language', {default => 'en'} ],
-    [ 'family=s', 'Target family', {default => 'wikipedia'} ],
-    [ 'mode' => hidden =>
+    "$PROGRAM_NAME %o <files...>",
+    ['username|u=s', 'username for account on wikipedia', {default => $conf{username} // q{}}],
+    ['password|p=s', 'password for account on wikipedia (do not use)', {default => $conf{password} // q{}}],
+    ['lang=s', 'Target language', {default => $conf{lang} // 'en'}],
+    ['family=s', 'Target family', {default => $conf{family} // 'wikipedia'}],
+    ['base|b=s', 'base location on wikipedia where user files exist (default User:AzaToth or entry in .twinklerc)', {default => $conf{base} // 'User:AzaToth'}],
+    [],
+    ['mode' => hidden =>
         {
             required => 1,
             one_of => [
-                ["pull" => "pull changes from wikipedia"],
-                ["push" => "push changes to wikipedia"],
-                ["deploy" => "push changes to wikipedia as gadgets"]
+                ['pull' => 'pull changes from wikipedia'],
+                ['push' => 'push changes to wikipedia'],
+                ['deploy' => 'push changes to wikipedia as gadgets']
             ]
         }
     ],
-    [ 'strip', "strip line end spaces"],
+    ['strip', 'strip line end spaces'],
     [],
-    [ 'verbose|v',  "print extra stuff"            ],
-    [ 'help',       "print usage message and exit" ],
+    ['help', 'print usage message and exit'],
 );
 
-print($usage->text), exit if $opt->help || !scalar(@ARGV);
+if ($opt->help || !scalar @ARGV) {
+  print $usage->text;
+  exit;
+}
 
-my %pages = map +("$opt->{base}/$_" => $_), @ARGV;
+my %pages = map {+"$opt->{base}/$_" => $_} @ARGV;
 my %deploys = (
 	'twinkle.js' => 'MediaWiki:Gadget-Twinkle.js',
 	'twinkle.css' => 'MediaWiki:Gadget-Twinkle.css',
 	'twinkle-pagestyles.css' => 'MediaWiki:Gadget-Twinkle-pagestyles.css',
 	'morebits.js' => 'MediaWiki:Gadget-morebits.js',
 	'morebits.css' => 'MediaWiki:Gadget-morebits.css',
-	'modules/twinkleprod.js' => 'MediaWiki:Gadget-twinkleprod.js',
-	'modules/twinkleimage.js' => 'MediaWiki:Gadget-twinkleimage.js',
-	'modules/twinklebatchundelete.js' => 'MediaWiki:Gadget-twinklebatchundelete.js',
-	'modules/twinklewarn.js' => 'MediaWiki:Gadget-twinklewarn.js',
-	'modules/twinklespeedy.js' => 'MediaWiki:Gadget-twinklespeedy.js',
 	'modules/friendlyshared.js' => 'MediaWiki:Gadget-friendlyshared.js',
-	'modules/twinklediff.js' => 'MediaWiki:Gadget-twinklediff.js',
-	'modules/twinkleunlink.js' => 'MediaWiki:Gadget-twinkleunlink.js',
 	'modules/friendlytag.js' => 'MediaWiki:Gadget-friendlytag.js',
-	'modules/twinkledeprod.js' => 'MediaWiki:Gadget-twinkledeprod.js',
+	'modules/friendlytalkback.js' => 'MediaWiki:Gadget-friendlytalkback.js',
 	'modules/friendlywelcome.js' => 'MediaWiki:Gadget-friendlywelcome.js',
-	'modules/twinklexfd.js' => 'MediaWiki:Gadget-twinklexfd.js',
+	'modules/twinklearv.js' => 'MediaWiki:Gadget-twinklearv.js',
 	'modules/twinklebatchdelete.js' => 'MediaWiki:Gadget-twinklebatchdelete.js',
 	'modules/twinklebatchprotect.js' => 'MediaWiki:Gadget-twinklebatchprotect.js',
+	'modules/twinklebatchundelete.js' => 'MediaWiki:Gadget-twinklebatchundelete.js',
+	'modules/twinkleblock.js' => 'MediaWiki:Gadget-twinkleblock.js',
 	'modules/twinkleconfig.js' => 'MediaWiki:Gadget-twinkleconfig.js',
+	'modules/twinkledeprod.js' => 'MediaWiki:Gadget-twinkledeprod.js',
+	'modules/twinklediff.js' => 'MediaWiki:Gadget-twinklediff.js',
 	'modules/twinklefluff.js' => 'MediaWiki:Gadget-twinklefluff.js',
+	'modules/twinkleimage.js' => 'MediaWiki:Gadget-twinkleimage.js',
 	'modules/twinkleprotect.js' => 'MediaWiki:Gadget-twinkleprotect.js',
-	'modules/twinklearv.js' => 'MediaWiki:Gadget-twinklearv.js',
-	'modules/friendlytalkback.js' => 'MediaWiki:Gadget-friendlytalkback.js',
-	'modules/twinkleblock.js' => 'MediaWiki:Gadget-twinkleblock.js'
+	'modules/twinklespeedy.js' => 'MediaWiki:Gadget-twinklespeedy.js',
+	'modules/twinkleunlink.js' => 'MediaWiki:Gadget-twinkleunlink.js',
+	'modules/twinklewarn.js' => 'MediaWiki:Gadget-twinklewarn.js',
+	'modules/twinklexfd.js' => 'MediaWiki:Gadget-twinklexfd.js',
+	'modules/twinkleprod.js' => 'MediaWiki:Gadget-twinkleprod.js'
 );
 
-# Config file should be an hash consisting of username and password keys
+my $mw = MediaWiki::API->new({
+			      api_url => "https://$opt->{lang}.$opt->{family}.org/w/api.php",
+			      max_lag => 1000000 # not a botty script, thus smash it!
+			     });
+$mw->login({lgname => $opt->username, lgpassword => $opt->password})
+  or die $mw->{error}->{code} . ': ' . $mw->{error}->{details};
 
 my $repo = Git::Repository->new();
 
+if ($opt->mode eq 'pull') {
+  my @status = $repo->run( status => '--porcelain');
 
-my $bot = MediaWiki::Bot->new({
-        assert      => 'user',
-        protocol    => 'https',
-        host        => "$opt->{lang}.$opt->{family}.org",
-        operator    => $opt->username,
-        login_data  => { username => $opt->username, password => $opt->password},
-        debug => $opt->{verbose} ? 2 : 0,
-		maxlag => 1000000 # not a botty script, thus smash it!
-    }
-);
+  if (scalar @status) {
+    print "repository is not clean. aborting...\n";
+    exit;
+  }
 
-if( $opt->mode eq "pull" ) {
-    my @status = $repo->run( status => '--porcelain');
+  while (my ($page, $file) = each %pages) {
+    print "Grabbing $page\n";
+    my $wikiPage = $mw->get_page({title => $page});
+    if (defined $wikiPage->{missing}) {
+      print "$page does not exist\n";
+      exit 1;
+    } else {
+      my $text = $wikiPage->{q{*}};
+      $text =~ s/\h+$//mg if $opt->{'strip'};
+      write_file( $file, {binmode => ':raw' }, encode('UTF-8',$text));
+    }
+  }
+  my $cmd = $repo->command(diff => '--stat', '--color');
+  my $s = $cmd->stdout;
+  while (<$s>) {
+    print "$_\n";
+  }
+  $cmd->close;
+} elsif ($opt->mode eq 'push') {
+  while (my ($page, $file) = each %pages) {
+    my $tag = $repo->run(describe => '--always', '--all', '--dirty');
+    my $log = $repo->run(log => '-1', '--oneline', '--no-color', $file);
+    $tag =~ m{(?:heads/)?(?<branch>.+)};
+    my $text = read_file($file,  {binmode => ':raw' });
+    my $editReturn = editPage($page, decode('UTF-8', $text), "$LAST_PAREN_MATCH{branch}:$log");
+    if ($editReturn->{_msg} eq 'OK') {
+      print "$file successfully pushed to $page\n";
+    } else {
+      print "Error pushing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
+    }
+  }
+} elsif ($opt->mode eq 'deploy') {
+  foreach my $file (values %pages) {
+    if (!defined $deploys{$file}) {
+      print "$file not deployable\n";
+      exit 1;
+    }
+    my $page = $deploys{$file};
+    print "$file -> $opt->{lang}.$opt->{family}.org/wiki/$page\n";
+    my $tag = $repo->run(describe => '--always', '--dirty');
+    my $log = $repo->run(log => '-1', '--pretty=format:%s', '--no-color');
+    my $text = read_file($file,  {binmode => ':raw' });
+    my $editReturn = editPage($page, decode('UTF-8', $text), "$tag: $log");
+    if ($editReturn->{_msg} eq 'OK') {
+      print "$file successfully pushed to $page\n";
+    } else {
+      print "Error pushing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
+    }
+  }
+}
 
-    if( scalar @status ) {
-        say "repository is not clean. aborting...";
-		#exit;
-    }
 
-    while(my($page, $file) = each %pages) {
-        say "Grabbing $page";
-        my $text = $bot->get_text($page);
-        $text =~ s/\h+$//mg if $opt->{'strip'};
-        write_file( $file, {binmode => ':raw' }, encode('UTF-8',$text));
-    }
-    my $cmd = $repo->command( diff => '--stat', '--color' );
-    my $s = $cmd->stdout;
-    while (<$s>) {
-        say $_;
-    }
-    $cmd->close;
-} elsif( $opt->mode eq "push" ) {
-    while(my($page, $file) = each %pages) {
-        my $tag = $repo->run(describe => '--always', '--all', '--dirty');
-        my $log = $repo->run(log => '-1', '--oneline', '--no-color', $file);
-        $tag =~ m{(?:heads/)?(?<branch>.+)};
-        my $text = read_file($file,  {binmode => ':raw' });
-        $bot->edit({
-                page    => $page,
-                text    => decode("UTF-8", $text),
-                summary => "$+{branch}:$log",
-            });
-    }
-} elsif( $opt->mode eq "deploy" ) {
-    foreach my $file (values %pages) {
-		unless(defined $deploys{$file}) {
-			die "file not deployable";
-		}
-		$page = $deploys{$file};
-		say "$file -> $opt->{lang}.$opt->{family}.org/wiki/$page";
-        my $tag = $repo->run(describe => '--always', '--dirty');
-        my $log = $repo->run(log => '-1', '--pretty=format:%s', '--no-color');
-        my $text = read_file($file,  {binmode => ':raw' });
-        my $ret = $bot->edit({
-                page    => $page,
-                text    => decode("UTF-8", $text),
-                summary => "$tag: $log",
-            });
-		unless($ret) {
-			die "Error $bot->{error}->{code}: $bot->{error}->{details}";
-		}
-    }
+### SUBROUTINES
+sub editPage {
+  my ($pTitle, $nText, $pSummary) = @_;
+  my $ref = $mw->get_page({title => $pTitle});
+  if (defined $ref->{missing}) {
+    print "$pTitle does not exist\n";
+    exit 1;
+  } else {
+    my $timestamp = $ref->{basetimestamp};
+    $mw->edit({
+	       action => 'edit',
+	       title => $pTitle,
+	       basetimestamp => $timestamp, # Avoid edit conflicts
+	       text => $nText,
+	       summary => $pSummary
+	      }) || die $mw->{error}->{code} . ': ' . $mw->{error}->{details};
+  }
+  return $mw->{response};
 }


### PR DESCRIPTION
1st commit: Fix sync.pl
- Roughly match previous behavior, although some dependencies have changed.
- Doesn't respect previous .mwbotrc preferences, but then again they haven't worked in years and won't work here

2nd commit: Autogenerate edit summaries, add some safety/error handling, other improvements
    
- Grab a commit hash from the edit summary of the most recent revsion of the on-wiki page, - and do our best to concatenate the log from there
- Require a clean working environment for all actions, not just --pull (matches implied intent in docs)
- Require confirmation of edit parameters before initiating
- Ensure files and pages being pulled/pushed/deployed exist
- Skip files without any changes
- Use File::Slurper over File::Slurp (See <http://blogs.perl.org/users/leon_timmermans/2015/08/fileslurp-is-broken-and-wrong.html>)

cc @MusikAnimal as the other active collaborator as well as @azatoth as the original author.  I've tested this at testwiki, and would be happy to walk though any of the changes or improvements.  The new version is rather more verbose, but should be a lot less likely to muck things up, which seems the right balance to me.

I didn't feel too bad about breaking past configurations since they haven't worked for ages, but also because this method should be safer.  The `pull` and `push` functions have been left in, as I think they may be useful for developing on non-enWiki projects; likewise the makefile, although I think that's likely to be more confusing than not at this point.  I've got a few other ideas for improvements, but this is enough for the time being.

On a personal note, it's nice to be able to work in perl again!