### PR TITLE
xfd/protect/speedy: Improve handling in Module space

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -67,7 +67,7 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 					label: 'Tag page with protection template',
 					value: 'tag',
 					tooltip: 'If the protecting admin forgot to apply a protection template, or you have just protected the page without tagging, you can use this to apply the appropriate protection tag.',
-					disabled: mw.config.get('wgArticleId') === 0
+					disabled: mw.config.get('wgArticleId') === 0 || mw.config.get('wgPageContentModel') === 'Scribunto'
 				}
 			]
 		} );
@@ -504,7 +504,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'protectReason',
 					label: 'Reason (for protection log):'
 				});
-			if (!mw.config.get('wgArticleId')) {  // tagging isn't relevant for non-existing pages
+			if (!mw.config.get('wgArticleId') || mw.config.get('wgPageContentModel') === 'Scribunto') {  // tagging isn't relevant for non-existing or module pages
 				break;
 			}
 			/* falls through */
@@ -1016,8 +1016,8 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			reasonField.value = '';
 		}
 
-		// sort out tagging options
-		if (mw.config.get('wgArticleId')) {
+		// sort out tagging options, disabled if nonexistent or lua
+		if (mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto') {
 			if( form.category.value === 'unprotect' ) {
 				form.tagtype.value = 'none';
 			} else {
@@ -1059,7 +1059,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 	}
 
 	var tagparams;
-	if( actiontype === 'tag' || (actiontype === 'protect' && mw.config.get('wgArticleId')) ) {
+	if( actiontype === 'tag' || (actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto') ) {
 		tagparams = {
 			tag: form.tagtype.value,
 			reason: ((form.tagtype.value === 'pp-protected' || form.tagtype.value === 'pp-semi-protected' || form.tagtype.value === 'pp-move') && form.protectReason) ? form.protectReason.value : null,

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1398,7 +1398,8 @@ Twinkle.speedy.callbacks = {
 		main: function(pageobj) {
 			var statelem = pageobj.getStatusElement();
 
-			if (!pageobj.exists()) {
+			// defaults to /doc for lua modules, which may not exist
+			if (!pageobj.exists() && mw.config.get('wgPageContentModel') !== 'Scribunto') {
 				statelem.error( "It seems that the page doesn't exist; perhaps it has already been deleted" );
 				return;
 			}
@@ -1465,7 +1466,7 @@ Twinkle.speedy.callbacks = {
 			pageobj.setPageText(code + ((params.normalizeds.indexOf('g10') !== -1) ? '' : ("\n" + text) )); // cause attack pages to be blanked
 			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 			pageobj.setWatchlist(params.watch);
-			pageobj.setCreateOption('nocreate');
+			pageobj.setCreateOption('recreate'); // Module /doc might not exist
 			pageobj.save(Twinkle.speedy.callbacks.user.tagComplete);
 		},
 
@@ -2046,7 +2047,9 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 	Morebits.wiki.actionCompleted.notice = "Tagging complete";
 
-	var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), "Tagging page");
+	// Modules can't be tagged, follow standard at TfD and place on /doc subpage
+	var isScribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
+	var wikipedia_page = isScribunto ? new Morebits.wiki.page(mw.config.get('wgPageName')+'/doc', "Tagging module documentation page") : new Morebits.wiki.page(mw.config.get('wgPageName'), "Tagging page");
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.speedy.callbacks.user.main);
 };

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -219,6 +219,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				type: 'div',
 				label: 'Stub types and userboxes are not eligible for TfD. Stub types go to CfD, and userboxes go to MfD.'
 			} );
+		var templateOrModule = (mw.config.get('wgPageContentModel') === 'Scribunto') ? 'module' : 'template';
 		var tfd_category = work_area.append( {
 				type: 'select',
 				label: 'Choose type of action wanted: ',
@@ -230,7 +231,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 						var xfdtarget = new Morebits.quickForm.element( {
 							name: 'xfdtarget',
 							type: 'input',
-							label: 'Other template to be merged: '
+							label: 'Other ' + templateOrModule + ' to be merged: '
 						} );
 						target.parentNode.appendChild(xfdtarget.render());
 					} else {
@@ -249,10 +250,14 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			label: 'Deletion tag display style: ',
 			tooltip: 'Which <code>type=</code> parameter to pass to the TfD tag template.'
 		} );
-		tfd_template_type.append( { type: 'option', value: 'standard', label: 'Standard', selected: true } );
-		tfd_template_type.append( { type: 'option', value: 'sidebar', label: 'Sidebar/infobox' } );
-		tfd_template_type.append( { type: 'option', value: 'inline', label: 'Inline template' } );
-		tfd_template_type.append( { type: 'option', value: 'tiny', label: 'Tiny inline' } );
+		if (templateOrModule === 'module') {
+			tfd_template_type.append( { type: 'option', value: 'module', label: 'Module', selected: true } );
+		} else {
+			tfd_template_type.append( { type: 'option', value: 'standard', label: 'Standard', selected: true } );
+			tfd_template_type.append( { type: 'option', value: 'sidebar', label: 'Sidebar/infobox' } );
+			tfd_template_type.append( { type: 'option', value: 'inline', label: 'Inline template' } );
+			tfd_template_type.append( { type: 'option', value: 'tiny', label: 'Tiny inline' } );
+		}
 
 		work_area.append( {
 				type: 'checkbox',
@@ -261,7 +266,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 							label: 'Wrap deletion tag with <noinclude> (for substituted templates only)',
 							value: 'noinclude',
 							name: 'noinclude',
-							tooltip: 'Will wrap the deletion tag in &lt;noinclude&gt; tags, so that it won\'t get substituted along with the template.'
+							tooltip: 'Will wrap the deletion tag in &lt;noinclude&gt; tags, so that it won\'t get substituted along with the template.',
+							disabled: templateOrModule === 'module'
 						}
 					]
 			} );
@@ -462,6 +468,9 @@ Twinkle.xfd.callbacks = {
 			text += "|redirect=" + Morebits.pageNameNorm;
 		} else {
 			text += "|1=" + mw.config.get('wgTitle');
+			if (mw.config.get('wgPageContentModel') === 'Scribunto') {
+				text += "|module=Module:";
+			}
 		}
 
 		if (params.target) {
@@ -730,8 +739,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var tableNewline = (params.tfdtype === 'standard' || params.tfdtype === 'sidebar') ? '\n' : ''; // No newline for inline
 
-			pageobj.setPageText((params.noinclude ? "<noinclude>" : "") + "{{subst:template for discussion|help=off|" +
-				(params.tfdtype !== "standard" ? "type=" + params.tfdtype + "|" : "") + mw.config.get('wgTitle') + (params.noinclude ? "}}</noinclude>" : "}}") + tableNewline + text);
+			pageobj.setPageText((params.noinclude ? "<noinclude>" : "") + "{{subst:template for discussion|help=off" +
+				(params.tfdtype !== "standard" ? "|type=" + params.tfdtype : "") + (params.noinclude ? "}}</noinclude>" : "}}") + tableNewline + text);
 			pageobj.setEditSummary("Nominated for deletion; see [[:" + params.logpage + "#" + Morebits.pageNameNorm + "]]." + Twinkle.getPref('summaryAd'));
 			switch (Twinkle.getPref('xfdWatchPage')) {
 				case 'yes':
@@ -744,7 +753,7 @@ Twinkle.xfd.callbacks = {
 					pageobj.setWatchlistFromPreferences(true);
 					break;
 			}
-			pageobj.setCreateOption('nocreate');
+			pageobj.setCreateOption('recreate'); // Module /doc might not exist
 			pageobj.save();
 		},
 		taggingTemplateForMerge: function(pageobj) {
@@ -753,7 +762,7 @@ Twinkle.xfd.callbacks = {
 			var tableNewline = (params.tfdtype === 'standard' || params.tfdtype === 'sidebar') ? '\n' : ''; // No newline for inline
 
 			pageobj.setPageText((params.noinclude ? "<noinclude>" : "") + "{{subst:tfm|help=off|" +
-				(params.tfdtype !== "standard" ? "type=" + params.tfdtype + "|" : "") + "1=" + params.otherTemplateName.replace(/^Template:/, "") +
+				(params.tfdtype !== "standard" ? "type=" + params.tfdtype + "|" : "") + "1=" + params.otherTemplateName.replace(/^(?:Template|Module):/, "") +
 				(params.noinclude ? "}}</noinclude>" : "}}") + tableNewline + text);
 			pageobj.setEditSummary("Nominated for merging with [[:" + params.otherTemplateName + "]]; see [[:" +
 				params.logpage + "#" + Morebits.pageNameNorm + "]]." + Twinkle.getPref('summaryAd'));
@@ -768,7 +777,7 @@ Twinkle.xfd.callbacks = {
 					pageobj.setWatchlistFromPreferences(true);
 					break;
 			}
-			pageobj.setCreateOption('nocreate');
+			pageobj.setCreateOption('recreate'); // Module /doc might not exist
 			pageobj.save();
 		},
 		todaysList: function(pageobj) {
@@ -784,7 +793,7 @@ Twinkle.xfd.callbacks = {
 				return;
 			}
 			pageobj.setPageText(text);
-			pageobj.setEditSummary("Adding [[Template:" + mw.config.get('wgTitle') + "]]." + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary("Adding [[:" + Morebits.pageNameNorm + "]]." + Twinkle.getPref('summaryAd'));
 			switch (Twinkle.getPref('xfdWatchDiscussion')) {
 				case 'yes':
 					pageobj.setWatchlist(true);
@@ -813,12 +822,13 @@ Twinkle.xfd.callbacks = {
 
 			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, "Notifying initial contributor (" + initialContrib + ")");
 			var notifytext = "\n";
+			var modNotice = mw.config.get('wgPageContentModel') === 'Scribunto' ? '|module=yes' : '';
 			switch (params.xfdcat) {
 			case 'tfd':
-				notifytext += "{{subst:tfdnotice|1=" + mw.config.get('wgTitle') + "}} ~~~~";
+				notifytext += "{{subst:tfdnotice|1=" + mw.config.get('wgTitle') + modNotice + "}} ~~~~";
 				break;
 			case 'tfm':
-				notifytext += "{{subst:tfmnotice|1=" + mw.config.get('wgTitle') + "|2=" + params.target + "}} ~~~~";
+				notifytext += "{{subst:tfmnotice|1=" + mw.config.get('wgTitle') + "|2=" + params.target + modNotice + "}} ~~~~";
 				break;
 			default:
 				alert("twinklexfd in userNotification: unknown TFD action");
@@ -1504,9 +1514,8 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 	case 'tfd': // TFD
 		Morebits.wiki.addCheckpoint();
-
 		if (xfdtarget) {
-			xfdtarget = Morebits.string.toUpperCaseFirstChar(xfdtarget.replace(/^:?Template:/i, ''));
+			xfdtarget = Morebits.string.toUpperCaseFirstChar(xfdtarget.replace(/^:?(?:Template|Module):/i, ''));
 		} else {
 			xfdtarget = '';
 		}
@@ -1515,24 +1524,39 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 		params = { tfdtype: tfdtype, logpage: logpage, noinclude: noinclude, xfdcat: xfdcat, target: xfdtarget, reason: reason };
 
-		// Tagging template(s)
-		if (xfdcat === "tfm") {
-			// Tag this template
-			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), "Tagging this template with merge tag");
+		// Modules can't be tagged, TfD instructions are to place on /doc subpage
+		var isScribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
+		// Tagging template(s)/module(s)
+		if (xfdcat === "tfm") { // Merge
+			// Tag this template/module
+			if (isScribunto) {
+				wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName')+'/doc', "Tagging this module documentation with merge tag");
+				params.otherTemplateName = "Module:" + xfdtarget;
+			} else {
+				wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), "Tagging this template with merge tag");
+				params.otherTemplateName = "Template:" + xfdtarget;
+			}
 			wikipedia_page.setFollowRedirect(true);
-			params.otherTemplateName = "Template:" + xfdtarget;
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
 
-			// Tag other template
-			wikipedia_page = new Morebits.wiki.page("Template:" + xfdtarget, "Tagging other template with merge tag");
+			// Tag other template/module
+			if (isScribunto) {
+				wikipedia_page = new Morebits.wiki.page("Module:" + xfdtarget+'/doc', "Tagging other module documentation with merge tag");
+			} else {
+				wikipedia_page = new Morebits.wiki.page("Template:" + xfdtarget, "Tagging other template with merge tag");
+			}
 			wikipedia_page.setFollowRedirect(true);
 			params = $.extend(params);
 			params.otherTemplateName = Morebits.pageNameNorm;
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
-		} else {
-			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), "Tagging template with deletion tag");
+		} else {	// delete
+			if (isScribunto) {
+				wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName')+'/doc', "Tagging module documentation with deletion tag");
+			} else {
+				wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), "Tagging template with deletion tag");
+			}
 			wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the page is moved, we would want to follow the redirect
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.tfd.taggingTemplate);
@@ -1554,7 +1578,11 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			var seenusers = [];
 			involvedpages.push(new Morebits.wiki.page(mw.config.get('wgPageName')));
 			if (xfdcat === "tfm") {
-				involvedpages.push(new Morebits.wiki.page("Template:" + xfdtarget));
+				if (isScribunto) {
+					involvedpages.push(new Morebits.wiki.page("Module:" + xfdtarget));
+				} else {
+					involvedpages.push(new Morebits.wiki.page("Template:" + xfdtarget));
+				}
 			}
 			involvedpages.forEach(function(page) {
 				page.setCallbackParameters(params);


### PR DESCRIPTION
See individual commit messages for the specifics, but basically this just hammers `wgPageContentModel` to avoid the lua error message and be helpful.  Closes #478 

**Protect**:
- Disable tagging of modules

**CSD**:
- Places the CSD tag on the /doc subpage (i.e., what is done at WP:TFD)

**XFD**:
- Place the XFD tag on the /doc subpage
- General fixes and tweaks to handle modules, in particular language changes

Regarding the changes to `twinklexfd`:
- As written, the display style will show only `module` for modules.  Another option is to always list all the options (module, standard, tiny inline, etc.) but disable module for templates and disable the others for modules.  The first seems more reasonable to me? 
 Another option is to just always list 'em all, default to the correct one, and hope people don't muck it up.
- The `noinclude` option is still available for Modules, thought I don't imagine it should ever be used.  Might be good to turn that off?
- I avoided ternaries given how involved some of the items could be, hoping that if/else would be more readable
