### PR TITLE
warn: Remove uw-subst

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -999,10 +999,6 @@ Twinkle.warn.messages = {
 			label: "Adding spoiler alerts or removing spoilers from appropriate sections",
 			summary: "Notice: Don't delete or flag potential 'spoilers' in Wikipedia articles"
 		},
-		"uw-subst": {
-			label: "Remember to subst: templates",
-			summary: "Notice: Remember to subst: templates"
-		},
 		"uw-talkinarticle": {
 			label: "Talk in article",
 			summary: "Notice: Talk in article"


### PR DESCRIPTION
[Deleted at TfD](https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2017_September_21#Template:Uw-subst) 18 months ago.
[Reported at WT:TW](https://en.wikipedia.org/w/index.php?oldid=883976908#Deleted_Template:Uw-subst_in_warning_screen?)