### PR TITLE
block/warn/welcome/xfd: Make sure the preview renderer uses wikitext

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -731,7 +731,7 @@ Twinkle.welcome.callbacks = {
 		previewDialog.setContent(previewdiv);
 
 		var previewer = new Morebits.wiki.preview(previewdiv);
-		previewer.beginRender(Twinkle.welcome.getTemplateWikitext(form.getChecked("template"), form.article.value));
+		previewer.beginRender(Twinkle.welcome.getTemplateWikitext(form.getChecked("template"), form.article.value), "WP:TW"); // Force wikitext
 
 		var submit = document.createElement("input");
 		submit.setAttribute("type", "submit");

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1091,7 +1091,7 @@ Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
 
 	var templateText = Twinkle.block.callback.getBlockNoticeWikitext(params);
 
-	form.previewer.beginRender(templateText);
+	form.previewer.beginRender(templateText, 'WP:TW'); // Force wikitext
 };
 
 Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1304,7 +1304,7 @@ Twinkle.warn.callbacks = {
 		templatetext = Twinkle.warn.callbacks.getWarningWikitext(templatename, linkedarticle,
 			form.reason.value, form.main_group.value === 'custom');
 
-		form.previewer.beginRender(templatetext);
+		form.previewer.beginRender(templatetext, 'WP:TW'); // Force wikitext
 	},
 	main: function( pageobj ) {
 		var text = pageobj.getPageText();

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -476,7 +476,7 @@ Twinkle.xfd.callbacks = {
 	},
 	showPreview: function(form, venue, params) {
 		var templatetext = Twinkle.xfd.callbacks.getDiscussionWikitext(venue, params);
-		form.previewer.beginRender(templatetext, "Wikipedia:Null");
+		form.previewer.beginRender(templatetext, "WP:TW"); // Force wikitext
 	},
 	preview: function(form) {
 		var venue = form.category.value;


### PR DESCRIPTION
`Morebits.wiki.preview`, specifically `beginRender`, takes an optional second parameter, defaulting to the current page, which is used to determine the content model of the output from the parse API query.  We've largely ignored that parameter, meaning that if you attempt to generate a preview while on a non-wikitext page (JS, CSS, JSON, etc.), `beginRender` defaults to the model of that page.  This fixes that by explicitly providing a wikitext page (`xfd` already did).

I chose `WP:TW` because it is:
- Already fully protected
- Within the project scope (i.e. "ours")
- Heavily used so unlikely to be changed

If merged, I'll leave an inline comment in the shortcut alerting any sysops not to change the content model, although I imagine that will never happen.