### PR TITLE
morebits: Protection error needn't be full protection

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2759,7 +2759,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 			// non-admin attempting to edit a protected page - this gives a friendlier message than the default
 			if ( errorCode === "protectedpage" ) {
-				ctx.statusElement.error( "Failed to save edit: Page is fully protected" );
+				ctx.statusElement.error( "Failed to save edit: Page is protected" );
 			} else {
 				ctx.statusElement.error( "Failed to save edit: " + ctx.saveApi.getErrorText() );
 			}


### PR DESCRIPTION
Could also be extendedconfirmed or template; don't think PC would throw an error.

The split here was added in b504af2d to make the protection response nicer, stating that:

>The API gives some pithy error stating which particular right the user lacks

I'm not sure what that previous message was, but the current response from `getErrorText()` is:

>This page has been protected to prevent editing or other actions.

That seems friendly enough but doesn't give the missing right and certainly isn't pithy, so I suppsoe it's worth maintaining the split.