### PR TITLE
improve alert text for {{now commons}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1313,7 +1313,7 @@ Twinkle.tag.callbacks = {
 						/* falls through */
 					case "Keep local":
 						input = prompt( "{{" + (tag === "subst:ncd" ? "Now Commons" : tag) +
-							"}} - Enter the name of the image on Commons (if different from local name), excluding the File: prefix:", "" );
+							"}} - Enter the name of the image on Commons (if different from local name), excluding the \"File:\" prefix but including the \".format\" suffix:", "" );
 						if (input === null) {
 							return true;  // continue
 						} else if (input !== "") {


### PR DESCRIPTION
Tweak line 1316: Explain that you do need to add the file extension, since its unclear (see my mistake at https://en.wikipedia.org/w/index.php?title=File:6150K.3347642.png&diff=885151052&oldid=584194465&diffmode=source)