### PR TITLE
twinkle.js: change default talkback heading to "New message"

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -163,7 +163,7 @@ Twinkle.defaultConfig.friendly = {
 	// Talkback
 	markTalkbackAsMinor: true,
 	insertTalkbackSignature: true,  // always sign talkback templates
-	talkbackHeading: "Talkback",
+	talkbackHeading: "New message",
 	adminNoticeHeading: "Notice",
 	mailHeading: "You've got mail!",
 


### PR DESCRIPTION
Solving #513. Does not affect user set preferences, just the default.