### PR TITLE
speedy/tag: Move histmerge from speedy to tag

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -276,6 +276,28 @@ Twinkle.tag.updateSortOrder = function(e) {
 					]
 				};
 				break;
+			case "history merge":
+				checkbox.subgroup = [
+					{
+						name: 'histmergeOriginalPage',
+						type: 'input',
+						label: 'Other article: ',
+						tooltip: 'Name of the page that should be merged into this one (required).'
+					},
+					{
+						name: 'histmergeReason',
+						type: 'input',
+						label: 'Reason: ',
+						tooltip: 'Short explanation describing the reason a history merge is needed. Should probably begin with "because" and end with a period.'
+					},
+					{
+						name: 'histmergeSysopDetails',
+						type: 'input',
+						label: 'Extra details: ',
+						tooltip: 'For complex cases, provide extra instructions for the reviewing administrator.'
+					}
+				];
+				break;
 			case "merge":
 			case "merge from":
 			case "merge to":
@@ -496,6 +518,7 @@ Twinkle.tag.article.tags = {
 	"fiction": "article fails to distinguish between fact and fiction",
 	"globalize": "article may not represent a worldwide view of the subject",
 	"GOCEinuse": "article is currently undergoing a major copy edit by the Guild of Copy Editors",
+	"history merge": "another page should be history merged into this one",
 	"hoax": "article may be a complete hoax",
 	"improve categories": "article may require additional categories",
 	"incomprehensible": "article is very hard to understand or incomprehensible",
@@ -669,8 +692,9 @@ Twinkle.tag.article.tagCategories = {
 			"uncategorized"
 		]
 	},
-	"Merging": [  // these three have a subgroup with several options
-		"merge",
+	"Merging": [
+		"history merge",
+		"merge",   // these three have a subgroup with several options
 		"merge from",
 		"merge to"
 	],
@@ -994,6 +1018,7 @@ Twinkle.tag.multipleIssuesExceptions = [
 	'copypaste',
 	'expand language',
 	'GOCEinuse',
+	'history merge',
 	'improve categories',
 	'in use',
 	'merge',
@@ -1078,6 +1103,15 @@ Twinkle.tag.callbacks = {
 							currentTag += '|listed=yes';
 						}
 						break;
+					case 'history merge':
+						currentTag += '|originalpage=' + params.histmergeOriginalPage;
+						if (params.histmergeReason) {
+							currentTag += '|reason=' + params.histmergeReason;
+						}
+						if (params.histmergeSysopDetails) {
+							currentTag += '|details=' + params.histmergeSysopDetails;
+						}
+						break;
 					case 'merge':
 					case 'merge to':
 					case 'merge from':
@@ -1154,7 +1188,8 @@ Twinkle.tag.callbacks = {
 						tags = tags.concat( tag );
 					}
 				} else {
-					if(tag === 'merge from') {
+					// Allow multiple {{merge from}} and {{histmerge}} per page
+					if(tag === 'merge from' || tag === 'history merge') {
 						tags = tags.concat( tag );
 					} else {
 						Morebits.status.warn( 'Info', 'Found {{' + tag +
@@ -1506,6 +1541,10 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 				alert( 'Please select only one of {{not English}} and {{rough translation}}.' );
 				return;
 			}
+			if( params.tags.indexOf('history merge') !== -1 && params.histmergeOriginalPage.trim() === '') {
+				alert( 'You must specify a page to be merged for the {{history merge}} tag.' );
+				return;
+			}
 			if( params.tags.indexOf('cleanup') !== -1 && params.cleanup.trim() === '') {
 				alert( 'You must specify a reason for the {{cleanup}} tag.' );
 				return;
@@ -1584,5 +1623,6 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 	}
 };
 })(jQuery);
+
 
 //</nowiki>

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -897,18 +897,6 @@ Twinkle.speedy.generalList = [
 		hideSubgroupWhenMultiple: true
 	},
 	{
-		label: 'G6: History merge',
-		value: 'histmerge',
-		tooltip: 'Temporarily deleting a page in order to merge page histories',
-		subgroup: {
-			name: 'histmerge_1',
-			type: 'input',
-			label: 'Page to be merged into this one: '
-		},
-		hideWhenMultiple: true,
-		hideWhenSysop: true
-	},
-	{
 		label: 'G6: Move',
 		value: 'move',
 		tooltip: 'Making way for an uncontroversial move like reversing a redirect',
@@ -1087,7 +1075,6 @@ Twinkle.speedy.normalizeHash = {
 	'hoax': 'g3',
 	'repost': 'g4',
 	'banned': 'g5',
-	'histmerge': 'g6',
 	'move': 'g6',
 	'xfd': 'g6',
 	'movedab': 'g6',
@@ -1456,8 +1443,6 @@ Twinkle.speedy.callbacks = {
 				editsummary += ').';
 			} else if (params.normalizeds[0] === "db") {
 				editsummary = 'Requesting [[WP:CSD|speedy deletion]] with rationale "' + params.templateParams[0]["1"] + '".';
-			} else if (params.values[0] === "histmerge") {
-				editsummary = "Requesting history merge with [[:" + params.templateParams[0]["1"] + "]] ([[WP:CSD#G6|CSD G6]]).";
 			} else {
 				editsummary = "Requesting speedy deletion ([[WP:CSD#" + params.normalizeds[0].toUpperCase() + "|CSD " + params.normalizeds[0].toUpperCase() + "]]).";
 			}
@@ -1669,18 +1654,6 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 			case 'banned':  // G5
 				if (form["csd.banned_1"] && form["csd.banned_1"].value) {
 					currentParams["1"] = form["csd.banned_1"].value.replace(/^\s*User:/i, "");
-				}
-				break;
-
-			case 'histmerge':  // G6
-				if (form["csd.histmerge_1"]) {
-					var merger = form["csd.histmerge_1"].value;
-					if (!merger || !merger.trim()) {
-						alert( 'CSD G6 (histmerge):  Please specify the page to be merged.' );
-						parameters = null;
-						return false;
-					}
-					currentParams["1"] = merger;
 				}
 				break;
 


### PR DESCRIPTION
{{db-histmerge}} was [renamed](https://en.wikipedia.org/w/index.php?title=Template:History_merge&diff=420055188&oldid=401464558) and [removed](https://en.wikipedia.org/w/index.php?title=Wikipedia%3ACriteria_for_speedy_deletion&diff=prev&oldid=420062064) from the the CSD criteria in March, 2011, following [brief discussion](https://en.wikipedia.org/wiki/Wikipedia_talk:Criteria_for_speedy_deletion/Archive_42#Remove_db-histmerge_from_CSD).  Of interest, the initial import of Twinkle into GitHub happened merely a week earlier.

Both have remained thus for nearly eight years, so we've technically been wrong for quite some time.  `{{history merge}}` is a bit of a weird beast, with a warning associated with it (`{{w-c&pmove}}`) like a speedy; that template is available in `twinklewarn`, and I don't think people expect the tag module to handle those, so I think we're fine not doing that here.  Allows for multiple instances of the template, a la `{{merge from}}`.

Closes #293