### PR TITLE
warn: Don't autowarn when autowelcoming

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -16,7 +16,7 @@
 Twinkle.warn = function twinklewarn() {
 	if( mw.config.get( 'wgRelevantUserName' ) ) {
 			Twinkle.addPortletLink( Twinkle.warn.callback, "Warn", "tw-warn", "Warn/notify user" );
-			if (Twinkle.getPref('autoMenuAfterRollback') && mw.config.get('wgNamespaceNumber') === 3 && mw.util.getParamValue('vanarticle')) {
+			if (Twinkle.getPref('autoMenuAfterRollback') && mw.config.get('wgNamespaceNumber') === 3 && mw.util.getParamValue('vanarticle') && !mw.util.getParamValue('friendlywelcome')) {
 				Twinkle.warn.callback();
 			}
 	}


### PR DESCRIPTION
Favor autowelcoming (via the `friendlywelcome` parameter) over autowarning (added in #509); both use vanarticle