### PR TITLE
friendlytag: Put tags under csd and prod nominations (not afd yet)

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1161,10 +1161,11 @@ Twinkle.tag.callbacks = {
 				pageText += '\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
 			}
 		} else {
-			// smartly insert the new tags after any hatnotes. Regex is a bit more
-			// complicated than it'd need to be, to allow templates as parameters,
-			// and to handle whitespace properly.
-			pageText = pageText.replace(/^\s*(?:((?:\s*\{\{\s*(?:about|correct title|dablink|distinguish|for|other\s?(?:hurricaneuses|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\s?(?:also|wiktionary)|selfref|the)\d*\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\})+(?:\s*\n)?)\s*)?/i,
+			// Smartly insert the new tags after any csd or prod templates
+			// or hatnotes; afd not yet supported since it places a comment
+			// not a template first. Regex is more complicated than it needs to be,
+			// which allows templates as parameters and to handle whitespace properly.
+			pageText = pageText.replace(/^\s*(?:((?:\s*\{\{\s*(?:db|delete|db-.*?|speedy deletion-.*?|(?:proposed deletion|prod blp)\/dated|about|correct title|dablink|distinguish|for|other\s?(?:hurricaneuses|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\s?(?:also|wiktionary)|selfref|the)\d*\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\})+(?:\s*\n)?)\s*)?/i,
 				"$1" + tagText);
 		}
 		summaryText += ( tags.length > 0 ? ' tag' + ( tags.length > 1 ? 's' : '' ) : '' ) +


### PR DESCRIPTION
Uses regex from the speedy module, partial fix for #237.  AfD is NOT supported because it doesn't lead with a template, but rather with a <!-- comment.

This regex was already enormous and unwieldy, and is now even worse.  It'd be good to clean it up, but even modern js isn't fully pcre, so there's no /x to help us out.