### PR TITLE
block/warn: Use 'page' instead of 'article' in label/tooltip

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -289,9 +289,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				type: 'input',
 				name: 'article',
 				display: 'none',
-				label: 'Linked article',
+				label: 'Linked page',
 				value: '',
-				tooltip: 'An article can be linked within the notice, perhaps if it was the primary target of disruption. Leave empty for no article to be linked.'
+				tooltip: 'A page can be linked within the notice, perhaps if it was the primary target of disruption. Leave empty for no page to be linked.'
 			} );
 		if (!$form.find('[name=actiontype][value=block]').is(':checked')) {
 			field_template_options.append( {

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -82,9 +82,9 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	form.append( {
 			type: 'input',
 			name: 'article',
-			label: 'Linked article',
+			label: 'Linked page',
 			value:( Morebits.queryString.exists( 'vanarticle' ) ? Morebits.queryString.get( 'vanarticle' ) : '' ),
-			tooltip: 'An article can be linked within the notice, perhaps because it was a revert to said article that dispatched this notice. Leave empty for no article to be linked.'
+			tooltip: 'A page can be linked within the notice, perhaps because it was a revert to said page that dispatched this notice. Leave empty for no page to be linked.'
 		} );
 
 	var more = form.append( { type: 'field', name: 'reasonGroup', label: 'Warning information' } );


### PR DESCRIPTION
No code changed, just the display text.  `warn` has used 'article' since the initial gh import, and `block` used that same language; still, people warn or block based on all pages, not just articles, so we might as well be exact.