### PR TITLE
csd: Don't multiply submit buttons for multi-input subgroups (radioClick)

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -477,7 +477,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 
 		if (criterion.subgroup && !hasSubmitButton) {
 			if (Array.isArray(criterion.subgroup)) {
-				criterion.subgroup.push({
+				criterion.subgroup = criterion.subgroup.concat({
 					type: 'button',
 					name: 'submit',
 					label: 'Submit Query',


### PR DESCRIPTION
This solves a long-standing issue for `radioClick` fans.  Toggling between deletion and tagging modes, or turning OFF "delete/tag with multiple" would increase the number of "Submit" buttons on any subgroup with two or more inputs (currently G6 move and G12).

Per https://github.com/azatoth/twinkle/pull/300#issuecomment-159598393 this is only affected a handful of users... but I was one of them!