### PR TITLE
csd: Only show R2 and R4 criterion when applicable

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -397,16 +397,18 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 			work_area.append( { type: 'header', label: 'User pages' } );
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.userAllList, mode) } );
 		}
-		else if (namespace == 0) {
+		work_area.append( { type: 'header', label: 'Redirects' } );
+		if (namespace == 0) {
 			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
-			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.mainspaceRedirect, mode) } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.articleRedirect.concat(Twinkle.speedy.redirectList), mode) } );
 		}
 		else if (namespace == 6) {
 			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
-			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.fileRedirect, mode) } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList.concat(Twinkle.speedy.fileRedirect), mode) } );
 		}
-		work_area.append( { type: 'header', label: 'Redirects' } );
-		work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList, mode) } );
+		else {
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList, mode) } );
+		}
 	}
 
 	var generalCriteria = Twinkle.speedy.generalList;
@@ -1077,7 +1079,7 @@ Twinkle.speedy.redirectList = [
 	}
 ];
 	
-Twinkle.speedy.mainspaceRedirect = [
+Twinkle.speedy.articleRedirect = [
 	{
 		label: 'R2: Redirects from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
 		value: 'rediruser',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -397,6 +397,14 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 			work_area.append( { type: 'header', label: 'User pages' } );
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.userAllList, mode) } );
 		}
+		else if (namespace == 1) {
+			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.mainspaceRedirect, mode) } );
+		}
+		else if (namespace == 6) {
+			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.fileRedirect, mode) } );
+		}
 		work_area.append( { type: 'header', label: 'Redirects' } );
 		work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList, mode) } );
 	}
@@ -1051,19 +1059,9 @@ Twinkle.speedy.generalList = [
 
 Twinkle.speedy.redirectList = [
 	{
-		label: 'R2: Redirects from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
-		value: 'rediruser',
-		tooltip: '(this does not include the Wikipedia shortcut pseudo-namespaces). If this was the result of a page move, consider waiting a day or two before deleting the redirect'
-	},
-	{
 		label: 'R3: Redirects as a result of an implausible typo or misnomers that were recently created',
 		value: 'redirtypo',
 		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
-	},
-	{
-		label: 'R4: File namespace redirect with name that matches a Commons page',
-		value: 'redircom',
-		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).'
 	},
 	{
 		label: 'G6: Redirect to malplaced disambiguation page',
@@ -1076,6 +1074,22 @@ Twinkle.speedy.redirectList = [
 		value: 'redirnone',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true
+	}
+];
+	
+Twinkle.speedy.mainspaceRedirect = [
+	{
+		label: 'R2: Redirects from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
+		value: 'rediruser',
+		tooltip: '(this does not include the Wikipedia shortcut pseudo-namespaces). If this was the result of a page move, consider waiting a day or two before deleting the redirect'
+	}
+];
+	
+Twinkle.speedy.fileRedirect = [
+	{
+		label: 'R4: File namespace redirect with name that matches a Commons page',
+		value: 'redircom',
+		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).'
 	}
 ];
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -399,13 +399,13 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		}
 		work_area.append( { type: 'header', label: 'Redirects' } );
 		if (namespace == 0) {
-			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.articleRedirect.concat(Twinkle.speedy.redirectList), mode) } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.articleRedirect.concat(Twinkle.speedy.redirectCriterion, Twinkle.speedy.generalRedirectList), mode) } );
 		}
 		else if (namespace == 6) {
-			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.fileRedirect, mode) } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectCriterion.concat(Twinkle.speedy.fileRedirect, Twinkle.speedy.generalRedirectList), mode) } );
 		}
 		else {
-			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList, mode) } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectCriterion.concat(Twinkle.speedy.generalRedirectList), mode) } );
 		}
 	}
 
@@ -1057,12 +1057,7 @@ Twinkle.speedy.generalList = [
 	}
 ];
 
-Twinkle.speedy.redirectList = [
-	{
-		label: 'R3: Redirects as a result of an implausible typo or misnomers that were recently created',
-		value: 'redirtypo',
-		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
-	},
+Twinkle.speedy.generalRedirectList = [
 	{
 		label: 'G6: Redirect to malplaced disambiguation page',
 		value: 'movedab',
@@ -1076,6 +1071,14 @@ Twinkle.speedy.redirectList = [
 		hideWhenMultiple: true
 	}
 ];
+Twinkle.speedy.redirectCriterion = [
+	{
+		label: 'R3: Redirects as a result of an implausible typo or misnomers that were recently created',
+		value: 'redirtypo',
+		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
+	}
+];
+	
 	
 Twinkle.speedy.articleRedirect = [
 	{
@@ -1087,26 +1090,9 @@ Twinkle.speedy.articleRedirect = [
 	
 Twinkle.speedy.fileRedirect = [
 	{
-		label: 'R3: Redirects as a result of an implausible typo or misnomers that were recently created',
-		value: 'redirtypo',
-		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
-	},
-	{
 		label: 'R4: File namespace redirect with name that matches a Commons page',
 		value: 'redircom',
 		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).'
-	},
-	{
-		label: 'G6: Redirect to malplaced disambiguation page',
-		value: 'movedab',
-		tooltip: 'This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.',
-		hideWhenMultiple: true
-	},
-	{
-		label: 'G8: Redirects to invalid targets, such as nonexistent targets, redirect loops, and bad titles',
-		value: 'redirnone',
-		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
-		hideWhenMultiple: true
 	}
 ];
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -402,7 +402,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.articleRedirect.concat(Twinkle.speedy.redirectList), mode) } );
 		}
 		else if (namespace == 6) {
-			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList.concat(Twinkle.speedy.fileRedirect), mode) } );
+			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.fileRedirect, mode) } );
 		}
 		else {
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList, mode) } );
@@ -1087,9 +1087,26 @@ Twinkle.speedy.articleRedirect = [
 	
 Twinkle.speedy.fileRedirect = [
 	{
+		label: 'R3: Redirects as a result of an implausible typo or misnomers that were recently created',
+		value: 'redirtypo',
+		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
+	},
+	{
 		label: 'R4: File namespace redirect with name that matches a Commons page',
 		value: 'redircom',
 		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).'
+	},
+	{
+		label: 'G6: Redirect to malplaced disambiguation page',
+		value: 'movedab',
+		tooltip: 'This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.',
+		hideWhenMultiple: true
+	},
+	{
+		label: 'G8: Redirects to invalid targets, such as nonexistent targets, redirect loops, and bad titles',
+		value: 'redirnone',
+		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
+		hideWhenMultiple: true
 	}
 ];
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -397,7 +397,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 			work_area.append( { type: 'header', label: 'User pages' } );
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.userAllList, mode) } );
 		}
-		else if (namespace == 1) {
+		else if (namespace == 0) {
 			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.mainspaceRedirect, mode) } );
 		}

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1071,6 +1071,7 @@ Twinkle.speedy.generalRedirectList = [
 		hideWhenMultiple: true
 	}
 ];
+
 Twinkle.speedy.redirectCriterion = [
 	{
 		label: 'R3: Redirects as a result of an implausible typo or misnomers that were recently created',
@@ -1078,8 +1079,6 @@ Twinkle.speedy.redirectCriterion = [
 		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
 	}
 ];
-	
-	
 Twinkle.speedy.articleRedirect = [
 	{
 		label: 'R2: Redirects from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
@@ -1087,7 +1086,6 @@ Twinkle.speedy.articleRedirect = [
 		tooltip: '(this does not include the Wikipedia shortcut pseudo-namespaces). If this was the result of a page move, consider waiting a day or two before deleting the redirect'
 	}
 ];
-	
 Twinkle.speedy.fileRedirect = [
 	{
 		label: 'R4: File namespace redirect with name that matches a Commons page',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -399,11 +399,9 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		}
 		work_area.append( { type: 'header', label: 'Redirects' } );
 		if (namespace == 0) {
-			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.articleRedirect.concat(Twinkle.speedy.redirectList), mode) } );
 		}
 		else if (namespace == 6) {
-			work_area.append( { type: 'header', label: 'Mainspace redirects' } );
 			work_area.append( { type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.redirectList.concat(Twinkle.speedy.fileRedirect), mode) } );
 		}
 		else {


### PR DESCRIPTION
Solves #554 by separating speedy deletion criterion R2 and R4 into separate fileRedirect and mainspaceRedirect, and then adding those only when the page is a redirect in the file namespace or in mainspace