### PR TITLE
deprod: Only get pages in appropriate namespaces (0|2|6|108)

### DIFF
--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -9,7 +9,7 @@
 *** twinkledeprod.js: Batch deletion of expired PRODs (sysops only)
 ****************************************
 * Mode of invocation:     Tab ("Deprod")
-* Active on:              Categories whose name starts with "Category:Proposed deletion as of"
+* Active on:              Categories whose name contains "proposed_deletion"
 * Config directives in:   TwinkleConfig
 */
 
@@ -46,6 +46,7 @@ Twinkle.deprod.callback = function() {
 		'generator': 'categorymembers',
 		'gcmtitle': mw.config.get( 'wgPageName' ),
 		'gcmlimit' : 5000, // the max for sysops
+		"gcmnamespace" : '0|6|108|2', // mostly to ignore categories
 		'prop': [ 'info', 'revisions' ],
 		'rvprop': [ 'content' ],
 		'inprop': [ 'protection' ]


### PR DESCRIPTION
PROD is only valid in mainspace and filespace, and BOOKPROD is valid for bookspace and userspace books, so we should only query for pages in those namespaces.

`deprod` initially only activated on categories named like "Category:Proposed_deletion_as_of_DATE", but since 315c06b it has been available in any category with "proposed deletion" in the name.  That might be something to revisit, but regardless, that allowed invocation on [[:Category:Expired proposed deletions]]; this will prevent [[:Category:Expired proposed deletions of unsourced BLPs]] from showing up in the `deprod` list in that case.  Could also avoid some erroneous deletions by an unwatchful eye.