### PR TITLE
readme: Migrate badges to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Twinkle [![Build Status](https://travis-ci.org/azatoth/twinkle.svg?branch=master)](https://travis-ci.org/azatoth/twinkle)
+Twinkle [![Build Status](https://travis-ci.com/azatoth/twinkle.svg?branch=master)](https://travis-ci.com/azatoth/twinkle)
 =======
 
 Twinkle is a JavaScript library and application that gives Wikipedians a quick way of performing common maintenance tasks, such as nominating pages for deletion and cleaning up vandalism.


### PR DESCRIPTION
[Travis announced](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps) in May 2018 that they would be (slowly) migrating all the travis-ci.org folks to travis-ci.com.  The main advantage appears to be integration into the GitHub Apps system (e.g. the "checks" tab up above).  Their [migration guide](https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/) offers no clue on if there's a deadline involved, but this is something we should do at some point.

Since this isn't an organization @azatoth, I think you would still need to do the honors on their end (as in #400). It's not entirely clear to me how much effort is involved although it [seems straightforward](https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/#existing-open-source-repositories-on-travis-ciorg).