### PR TITLE
twinkle.js: Change default talkback heading to "New message from" + username

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -164,7 +164,7 @@ Twinkle.defaultConfig.friendly = {
 	// Talkback
 	markTalkbackAsMinor: true,
 	insertTalkbackSignature: true,  // always sign talkback templates
-	talkbackHeading: "Talkback",
+	talkbackHeading: "New message from " + mw.config.get("wgUserName"),
 	adminNoticeHeading: "Notice",
 	mailHeading: "You've got mail!",
 


### PR DESCRIPTION
Closes #513. Does not affect user set preferences, just the default.

Fix for #529 