### PR TITLE
protect: Disable pending changes dropdown on ineligible namespaces

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -384,7 +384,8 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 								label: 'Modify pending changes protection',
 								value: 'pcmodify',
 								tooltip: 'If this is turned off, the pending changes level, and expiry time, will be left as is.',
-								checked: true
+								checked: true,
+								disabled: (mw.config.get('wgNamespaceNumber') !== 0 && mw.config.get('wgNamespaceNumber') !== 4) // Hardcoded until [[phab:T218479]]
 							}
 						]
 					});


### PR DESCRIPTION
Similar to #451, it would be better if we didn't offer inappropriate options.  The error from the API request is clear enough, but it resets the form.

We *could* turn it off entirely a la #551, but I think it'd be better to do this for 6-12 months before removing it entirely to smooth the transition and get the additional nudge.

In the distant future, it would be nice for this not to be hardcoded, but $wgFlaggedRevsNamespaces isn't exposed to javascript; that's [[[phab:T218479]]](https://phabricator.wikimedia.org/T218479)