### PR TITLE
speedy: New option for sysops: notify creator upon deletion

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -397,10 +397,10 @@ Twinkle.config.sections = [
 		},
 
 		// TwinkleConfig.watchSpeedyPages (array)
-		// Whether to add speedy tagged pages to watchlist
+		// Whether to add speedy tagged or deleted pages to watchlist
 		{
 			name: "watchSpeedyPages",
-			label: "Add page to watchlist when tagging with these criteria",
+			label: "Add page to watchlist when using these criteria",
 			type: "set",
 			setValues: Twinkle.config.commonSets.csdCriteria,
 			setDisplayOrder: Twinkle.config.commonSets.csdCriteriaDisplayOrder
@@ -414,24 +414,36 @@ Twinkle.config.sections = [
 			type: "boolean"
 		},
 
+		// TwinkleConfig.welcomeUserOnSpeedyDeletionNotification (array of strings)
+		// On what types of speedy deletion notifications shall the user be welcomed
+		// with a "firstarticle" notice if their talk page has not yet been created.
+		{
+			name: "welcomeUserOnSpeedyDeletionNotification",
+			label: "Welcome page creator when notifying with these criteria",
+			helptip: "The welcome is issued only if the user is notified about the deletion, and only if their talk page does not already exist. The template used is {{firstarticle}}.",
+			type: "set",
+			setValues: Twinkle.config.commonSets.csdCriteriaNotification,
+			setDisplayOrder: Twinkle.config.commonSets.csdCriteriaNotificationDisplayOrder
+		},
+
 		// TwinkleConfig.notifyUserOnSpeedyDeletionNomination (array)
-		// What types of actions should result that the author of the page being notified of nomination
+		// What types of actions should result in the author of the page being notified of nomination
 		{
 			name: "notifyUserOnSpeedyDeletionNomination",
-			label: "Notify page creator only when tagging with these criteria",
+			label: "Notify page creator when tagging with these criteria",
 			helptip: "Even if you choose to notify from the CSD screen, the notification will only take place for those criteria selected here.",
 			type: "set",
 			setValues: Twinkle.config.commonSets.csdCriteriaNotification,
 			setDisplayOrder: Twinkle.config.commonSets.csdCriteriaNotificationDisplayOrder
 		},
 
-		// TwinkleConfig.welcomeUserOnSpeedyDeletionNotification (array of strings)
-		// On what types of speedy deletion notifications shall the user be welcomed
-		// with a "firstarticle" notice if his talk page has not yet been created.
+		// TwinkleConfig.warnUserOnSpeedyDelete (array)
+		// What types of actions should result in the author of the page being notified of speedy deletion (admin only)
 		{
-			name: "welcomeUserOnSpeedyDeletionNotification",
-			label: "Welcome page creator alongside notification when tagging with these criteria",
-			helptip: "The welcome is issued only if the user is notified about the deletion, and only if their talk page does not already exist. The template used is {{firstarticle}}.",
+			name: "warnUserOnSpeedyDelete",
+			label: "Notify page creator when deleting under these criteria",
+			helptip: "Even if you choose to notify from the CSD screen, the notification will only take place for those criteria selected here.",
+			adminOnly: true,
 			type: "set",
 			setValues: Twinkle.config.commonSets.csdCriteriaNotification,
 			setDisplayOrder: Twinkle.config.commonSets.csdCriteriaNotificationDisplayOrder
@@ -441,17 +453,6 @@ Twinkle.config.sections = [
 		{
 			name: "promptForSpeedyDeletionSummary",
 			label: "Allow editing of deletion summary when deleting under these criteria",
-			adminOnly: true,
-			type: "set",
-			setValues: Twinkle.config.commonSets.csdAndDICriteria,
-			setDisplayOrder: Twinkle.config.commonSets.csdAndDICriteriaDisplayOrder
-		},
-
-		// TwinkleConfig.openUserTalkPageOnSpeedyDelete (array of strings)
-		// What types of actions that should result user talk page to be opened when speedily deleting (admin only)
-		{
-			name: "openUserTalkPageOnSpeedyDelete",
-			label: "Open user talk page when deleting under these criteria",
 			adminOnly: true,
 			type: "set",
 			setValues: Twinkle.config.commonSets.csdAndDICriteria,

--- a/twinkle.js
+++ b/twinkle.js
@@ -83,10 +83,10 @@ Twinkle.defaultConfig.twinkle = {
 	markSpeedyPagesAsPatrolled: false,
 
 	// these next two should probably be identical by default
-	notifyUserOnSpeedyDeletionNomination:    [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "g14", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],
 	welcomeUserOnSpeedyDeletionNotification: [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "g14", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],
+	notifyUserOnSpeedyDeletionNomination:    [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "g14", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],
+	warnUserOnSpeedyDelete: [ "db", "g1", "g2", "g3", "g4", "g6", "g10", "g11", "g12", "g13", "g14", "a1", "a2", "a3", "a5", "a7", "a9", "a10", "a11", "f1", "f2", "f3", "f7", "f9", "f10", "u3", "u5", "t2", "t3", "p1", "p2" ],
 	promptForSpeedyDeletionSummary: [],
-	openUserTalkPageOnSpeedyDelete: [ "db", "g1", "g2", "g3", "g4", "g5", "g10", "g11", "g12", "a1", "a3", "a7", "a9", "a10", "a11", "f3", "f7", "f9", "u3", "u5", "t2", "p1" ],
 	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,
 	deleteSysopDefaultToTag: false,


### PR DESCRIPTION
Closes #520 and #505.  Removes the old "open talk page" sysop option and folds the non-sysop tagging system into a unified `noteToCreator` notification system for both tagfing and deleting.  Uses the existing system for tagging to determine whether or not to notify, rather than the bespoke option for `openUserTalk` from #300; that is, it will notify only if the corresponding box is checked AND (at least one of) the CSD in question is checked in the user preferences.

The box is checked by default, unless it finds `$('#delete-reason')` on the page, indicating some sort of XfD or CSD or the like; in the latter scenario, if the box is subsequently checked, there is an additional prompt (this might be a good candidate for removal down the line, but I think it's important to include now, especially since it's a new feature).  It uses the existing preference about whether to welcome the user alongside the notification rather than create a separate one just for post-deletion notifications.

New templates all listed at [[Template:Speedy deletion deleted]].