### PR TITLE
prod: Update regex for non-prod deletion templates

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -184,7 +184,7 @@ Twinkle.prod.callbacks = {
 		var params = pageobj.getCallbackParameters();
 
 		// Check for already existing deletion tags
-		var tag_re = /({{(?:db-?|delete|[aitcmrs]fd|md1)[^{}]*?\|?[^{}]*?}})/i;
+		var tag_re = /{{(?:db-?|delete|article for deletion\/dated|ffd\b)|#invoke:RfD/i;
 		if( tag_re.test( text ) ) {
 			statelem.warn( 'Page already tagged with a deletion template, aborting procedure' );
 			return;


### PR DESCRIPTION
Basically just copied from #494, with the irrelevant bits taken out.  These have changed a fair amount in the past decade or so, and this line hasn't been updated since the initial GitHub import.