### PR TITLE
prod: Add {{old prod}} to talkpage on nomination

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -227,6 +227,16 @@ Twinkle.prod.callbacks = {
 				summaryText = "Proposing " + namespace + " for deletion per [[WP:PROD]].";
 				text = "{{subst:prod|1=" + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? "|help=off" : "") + "}}\n" + text;
 			}
+
+			// Add {{Old prod}} to the talk page
+			var oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
+			var talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+			var talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
+			talkpage.setPrependText(oldprodfull);
+			talkpage.setEditSummary('Placing {{Old prod}} on the talk page' + Twinkle.getPref('summaryAd'));
+			talkpage.setFollowRedirect(true);  // match behavior for page tagging
+			talkpage.setCreateOption('recreate');
+			talkpage.prepend();
 		}
 		else {  // already tagged for PROD, so try endorsing it
 			var prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/;


### PR DESCRIPTION
Recent changes to [[Template:Old prod]] (<https://en.wikipedia.org/w/index.php?title=Template:Old_prod&diff=877241714&oldid=875601620>) by User:SD0001 (aka @siddharthvp) added a parameter that allowed for {{old prod}} to be added before contestation, without being added to the category until a timer has elapsed.  As such, Twinkle can feel free to safely add the template upon nomination, thus ensuring the page, if not deleted, will actually be tagged with the old prod template.  This would be a huge improvement, as contested prods are rarely tagged.  In theory the talk page won't be updated with the appropriate category until edited/purged, but that's still a clear gain over the current situation.

This doesn't endorse an already-existing {{old prod}} if the user is endorsing a {{prod}}, not sure there's value in that for all the extra loading/parsing it would entail.  It also doesn't do anything fancy with already-existing templates on the talkpage, although we could look into what Evad37 does with XfDC for this sort of thing; in theory, given the one-shot nature of PROD and changes in #566, it should be rare, limited mainly to BLPPRODs not having gone through AfD.

Closes #435.

Opened as draft to allow #566 to go through first; this is most useful with that in mind.