### PR TITLE
unlink: remove unnecessary api call, and hardcoded api limits

### DIFF
--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -77,8 +77,8 @@ Twinkle.unlink.callback = function(presetReason) {
 			'list': [ 'backlinks', 'imageusage' ],
 			'bltitle': mw.config.get('wgPageName'),
 			'iutitle': mw.config.get('wgPageName'),
-			'bllimit': Morebits.userIsInGroup( 'sysop' ) ? 5000 : 500, // 500 is max for normal users, 5000 for bots and sysops
-			'iulimit': Morebits.userIsInGroup( 'sysop' ) ? 5000 : 500, // 500 is max for normal users, 5000 for bots and sysops
+			'bllimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
+			'iulimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
 			'blnamespace': Twinkle.getPref('unlinkNamespaces'),
 			'iunamespace': Twinkle.getPref('unlinkNamespaces'),
 			'rawcontinue': true
@@ -89,7 +89,7 @@ Twinkle.unlink.callback = function(presetReason) {
 			'list': 'backlinks',
 			'bltitle': mw.config.get('wgPageName'),
 			'blfilterredir': 'nonredirects',
-			'bllimit': Morebits.userIsInGroup( 'sysop' ) ? 5000 : 500, // 500 is max for normal users, 5000 for bots and sysops
+			'bllimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
 			'blnamespace': Twinkle.getPref('unlinkNamespaces'),
 			'rawcontinue': true
 		};

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -14,15 +14,11 @@
  */
 
 Twinkle.unlink = function twinkleunlink() {
-	if( mw.config.get('wgNamespaceNumber') < 0 || mw.config.get('wgPageName') === 'Wikipedia:Sandbox' ) {
+	if( mw.config.get('wgNamespaceNumber') < 0 || mw.config.get('wgPageName') === 'Wikipedia:Sandbox' ||
+		(!Morebits.userIsInGroup('extendedconfirmed') && !Morebits.userIsInGroup('sysop')) ) {
 		return;
 	}
-	// Restrict to extended confirmed users. This is done here instead of above to avoid an unnecessary API call.
-	mw.user.getRights().then(function (rights) {
-		if( rights.indexOf('extendedconfirmed') !== -1 ) {
-			Twinkle.addPortletLink( Twinkle.unlink.callback, "Unlink", "tw-unlink", "Unlink backlinks" );
-		}
-	});
+	Twinkle.addPortletLink( Twinkle.unlink.callback, "Unlink", "tw-unlink", "Unlink backlinks" );
 };
 
 Twinkle.unlink.getChecked2 = function twinkleunlinkGetChecked2( nodelist ) {


### PR DESCRIPTION
- remove unnecessary API call to check for extendconfirmed right
- avoid hardcoding maximum api limits