### PR TITLE
speedy/prod: don't log notification if that failed

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -97,7 +97,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 	if(namespace !== 'article') {
 		$(result).find('#prodtype_fieldset').hide();
 	}
-	
+
 	// Fake a change event on the first prod type radio, to initialize the type-dependent controls
 	var evt = document.createEvent( "Event" );
 	evt.initEvent( 'change', true, true );
@@ -236,8 +236,8 @@ Twinkle.prod.callbacks = {
 			}
 			var confirmtext = "A {{proposed deletion}} tag was already found on this page. \nWould you like to add a {{proposed deletion endorsed}} tag with your explanation?";
 			if (params.blp) {
-				confirmtext = "A non-BLP {{proposed deletion}} tag was found on this article.\nWould you like to add a {{proposed deletion endorsed}} tag with explanation \"article is a biography of a living person with no sources\"?";	
-				// FIXME: this msg is shown even if it was a BLPPROD tag. 
+				confirmtext = "A non-BLP {{proposed deletion}} tag was found on this article.\nWould you like to add a {{proposed deletion endorsed}} tag with explanation \"article is a biography of a living person with no sources\"?";
+				// FIXME: this msg is shown even if it was a BLPPROD tag.
 			}
 			if( !confirm( confirmtext ) ) {
 				statelem.warn( 'Aborted per user request' );
@@ -290,11 +290,18 @@ Twinkle.prod.callbacks = {
 		usertalkpage.setEditSummary("Notification: proposed deletion of [[:" + Morebits.pageNameNorm + "]]." + Twinkle.getPref('summaryAd'));
 		usertalkpage.setCreateOption('recreate');
 		usertalkpage.setFollowRedirect(true);
-		usertalkpage.append();
-		if (Twinkle.getPref('logProdPages')) {
-			params.logInitialContrib = initialContrib;
-			Twinkle.prod.callbacks.addToLog(params);
-		}
+		usertalkpage.append(function onNotifySuccess() {
+			// add nomination to the userspace log, if the user has enabled it
+			if (Twinkle.getPref('logProdPages')) {
+				params.logInitialContrib = initialContrib;
+				Twinkle.prod.callbacks.addToLog(params);
+			}
+		}, function onNotifyError() {
+			// if user could not be notified, log nomination without mentioning that notification was sent
+			if (Twinkle.getPref('logProdPages')) {
+				Twinkle.prod.callbacks.addToLog(params);
+			}
+		});
 	},
 
 	addToLog: function(params) {
@@ -351,7 +358,7 @@ Twinkle.prod.callbacks = {
 Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	var form = e.target;
 	var prodtype;
-	
+
 	if( namespace === 'article' ) {
 		var prodtypes = form.prodtype;
 		for( var i = 0; i < prodtypes.length; i++ ) {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1548,13 +1548,20 @@ Twinkle.speedy.callbacks = {
 						usertalkpage.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 						usertalkpage.setCreateOption('recreate');
 						usertalkpage.setFollowRedirect(true);
-						usertalkpage.append();
+						usertalkpage.append(function onNotifySuccess() {
+							// add this nomination to the user's userspace log, if the user has enabled it
+							if (params.lognomination) {
+								Twinkle.speedy.callbacks.user.addToLog(params, initialContrib);
+							}
+						}, function onNotifyError() {
+							// if user could not be notified, log nomination without mentioning that notification was sent
+							if (params.lognomination) {
+								Twinkle.speedy.callbacks.user.addToLog(params, null);
+							}
+						});
 					}
 
-					// add this nomination to the user's userspace log, if the user has enabled it
-					if (params.lognomination) {
-						Twinkle.speedy.callbacks.user.addToLog(params, initialContrib);
-					}
+
 				};
 				var thispage = new Morebits.wiki.page(Morebits.pageNameNorm);
 				thispage.lookupCreator(callback);


### PR DESCRIPTION
Closes #577. If notification to page creator couldn't be sent (eg. when the
user talk page is protected), then don't say "notified ___" in log entry