### PR TITLE
batchdelete: allow deletion of subpages

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3783,7 +3783,9 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
 				}
 
 				for (i = start; i <= finish; i++) {
-					cbs[i].checked = endState;
+					if (cbs[i].checked !== endState) {
+						cbs[i].click();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Trying to solve #305. Though I can't be sure whether this works without having the sysop bit.

This handles the subpages just as the redirects are being handled (they are deleted without being listed, so individual pages can't be de-selected). We may need to think about whether sysops ought to be deleting subpages without knowing anything about which are the subpages or how many of them are there (until they see the "Deleting ___" status messages). If deemed necessary, this can be tweaked to list out all the subpages along with the main pages (so that they are known to the user beforehand, and can be de-selected). 