### PR TITLE
speedy: Further improve extra parameters in CSD log

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1650,7 +1650,7 @@ Twinkle.speedy.callbacks = {
 						params.templateParams.forEach(function(item, index) {
 							var keys = Object.keys(item);
 							if (keys[0] !== undefined && keys[0].length > 0) {
-								//Second loop required since G12 can have multiple urls
+								//Second loop required since some items (G12, F9) may have multiple keys
 								keys.forEach(function(key, keyIndex) {
 									if (keys[keyIndex] === 'blanked' || keys[keyIndex] === 'ts') {
 										return true; // Not worth logging
@@ -1869,8 +1869,12 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 						parameters = null;
 						return false;
 					}
-					currentParams.url = f9url;
-					currentParams.rationale = f9rationale;
+					if (form["csd.imgcopyvio_url"].value) {
+						currentParams.url = f9url;
+					}
+					if (form["csd.imgcopyvio_rationale"].value) {
+						currentParams.rationale = f9rationale;
+					}
 				}
 				break;
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -859,7 +859,7 @@ Twinkle.speedy.portalList = [
 	{
 		label: 'P1: Portal that would be subject to speedy deletion if it were an article',
 		value: 'p1',
-		tooltip: 'You must specify the article criterion that applies in this case (A1, A3, A7, or A10).',
+		tooltip: 'You must specify a single article criterion that applies in this case (A1, A3, A7, or A10).',
 		subgroup: {
 			name: 'p1_criterion',
 			type: 'input',
@@ -951,6 +951,7 @@ Twinkle.speedy.generalList = [
 			name: 'xfd_fullvotepage',
 			type: 'input',
 			label: 'Page where the deletion discussion was held: ',
+			tooltip: 'Must start with "Wikipedia:"',
 			size: 40
 		},
 		hideWhenMultiple: true
@@ -1032,21 +1033,21 @@ Twinkle.speedy.generalList = [
 				name: 'copyvio_url',
 				type: 'input',
 				label: 'URL (if available): ',
-				tooltip: 'If the material was copied from an online source, put the URL here, including the "http://" or "https://" protocol. If the URL is on the spam blacklist, you can leave off the protocol.',
+				tooltip: 'If the material was copied from an online source, put the URL here, including the "http://" or "https://" protocol.',
 				size: 60
 			},
 			{
 				name: 'copyvio_url2',
 				type: 'input',
 				label: 'Additional URL: ',
-				tooltip: 'Optional.',
+				tooltip: 'Optional. Should begin with "http://" or "https://"',
 				size: 60
 			},
 			{
 				name: 'copyvio_url3',
 				type: 'input',
 				label: 'Additional URL: ',
-				tooltip: 'Optional.',
+				tooltip: 'Optional. Should begin with "http://" or "https://"',
 				size: 60
 			}
 		]
@@ -1602,7 +1603,23 @@ Twinkle.speedy.callbacks = {
 			}
 
 			var formatParamLog = function(normalize, csdparam, input) {
-				return ' [' + normalize + ' ' + csdparam + ': ' + input + ']';
+				if ((normalize === 'G4' && csdparam === 'xfd') || (normalize === 'G6' && csdparam === 'page') || (normalize === 'G6' && csdparam === 'fullvotepage') || (normalize === 'G6' && csdparam === 'sourcepage')
+					|| (normalize === 'A2' && csdparam === 'source') || (normalize === 'A10' && csdparam === 'article') || (normalize === 'F5' && csdparam === 'replacement')) {
+					input = '[[:' + input + ']]';
+				} else if (normalize === 'G5' && csdparam === 'user') {
+					input = '[[:User:' + input + ']]';
+				} else if (normalize === 'G12' && csdparam.lastIndexOf('url', 0) === 0 && input.lastIndexOf('http', 0) === 0) {
+					input = '[' + input + ' ' + input + ']';
+				} else if (normalize === 'F1' && csdparam === 'filename') {
+					input = '[[:File:' + input + ']]';
+				} else if (normalize === 'T3' && csdparam === 'template') {
+					input = '[[:Template:' + input + ']]';
+				} else if (normalize === 'F8' && csdparam === 'filename') {
+					input = '[[commons:' + input + ']]';
+				} else if (normalize === 'P1' && csdparam === 'criterion') {
+					input = '[[WP:CSD#' + input + ']]';
+				}
+				return ' {' + normalize + ' ' + csdparam + ': ' + input + '}';
 			};
 
 			var extraInfo = '';
@@ -1931,7 +1948,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				if (form["csd.p1_criterion"]) {
 					var criterion = form["csd.p1_criterion"].value;
 					if (!criterion || !criterion.trim()) {
-						alert( 'CSD P1:  Please specify a criterion and/or associated rationale.' );
+						alert( 'CSD P1:  Please specify a single criterion.' );
 						parameters = null;
 						return false;
 					}


### PR DESCRIPTION
1st commit: Ignore blank f9 rationale or url in log (bugfix)
- Fix logic from #546 that would allow url or rationale as an empty string when logging in #441

2nd commit: link additional parameters in the CSD log if possible (enhancement)
- wikilink: G4 `xfd`; G6 `page`, `fullvotepage`, `sourcepage`; A2 `source`; A10 `article`; F5 `replacement`
- user: G5 `user`
- file: F1 `filename`
- template: T3 `template`
- external: G12 `url`, `url2`, `url3` (only if beginning with http)
- commons: F8 `filename`
- WP:CSD section: P1 `criterion`

Style the link using curly braces `{}` instead of square brackets `[]`.  Also adds a tooltip to the G6 xfd input.