### PR TITLE
warn: Show signature in preview as well

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1196,7 +1196,7 @@ Twinkle.warn.callbacks = {
 			text += " ''" + reason + "''";
 		}
 
-		return text;
+		return text + ' ~~~~';
 	},
 	preview: function(form) {
 		var templatename = form.sub_group.value;
@@ -1274,7 +1274,7 @@ Twinkle.warn.callbacks = {
 			text += "== " + date.getUTCMonthName() + " " + date.getUTCFullYear() + " ==\n";
 		}
 		text += Twinkle.warn.callbacks.getWarningWikitext(params.sub_group, params.article,
-			params.reason, params.main_group === 'custom') + " ~~~~";
+			params.reason, params.main_group === 'custom');
 
 		if ( Twinkle.getPref('showSharedIPNotice') && mw.util.isIPAddress( mw.config.get('wgTitle') ) ) {
 			Morebits.status.info( 'Info', 'Adding a shared IP notice' );


### PR DESCRIPTION
Put the signature in getWarningWikitext since both preview and the actual edit will want it.  Asked for at WT:TW https://en.wikipedia.org/wiki/Special:Permalink/893444378#Double_signature

See 96e6ac36 for the rise of the current implementation, but the real divide is from 86a052c3