### PR TITLE
warn: remove old fix for out-of-range defaultGroup

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -66,7 +66,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		} );
 
 	var defaultGroup = parseInt(Twinkle.getPref('defaultWarningGroup'), 10);
-	main_group.append( { type: 'option', label: '1: General note', value: 'level1', selected: ( defaultGroup === 1 || defaultGroup < 1 || ( Morebits.userIsInGroup( 'sysop' ) ? defaultGroup > 8 : defaultGroup > 7 ) ) } );
+	main_group.append( { type: 'option', label: '1: General note', value: 'level1', selected: ( defaultGroup === 1 ) } );
 	main_group.append( { type: 'option', label: '2: Caution', value: 'level2', selected: ( defaultGroup === 2 ) } );
 	main_group.append( { type: 'option', label: '3: Warning', value: 'level3', selected: ( defaultGroup === 3 ) } );
 	main_group.append( { type: 'option', label: '4: Final warning', value: 'level4', selected: ( defaultGroup === 4 ) } );


### PR DESCRIPTION
This dates back to 2008 (<https://en.wikipedia.org/w/index.php?diff=247182138&oldid=245908598&title=User:AzaToth/twinklewarn.js>).  There used to be a group 8 with block templates for sysops, hence the `Morebits.userIsInGroup` switch, but after #260 it was removed and this persisted, meaning that we don't need any special handling for sysops or nonsysops here.  That is, `defaultGroup > 7` would handle any remaining unmodified options (there are some).  <s>That being said, if even *that* isn't present, I don't get any errors in Chrome, FireFox, or Safari, so it doesn't seem necessary.  Perhaps it throws/threw an error in IE?</s>  Similarly, `undefined` or -1 groups were possible due to how the config was structured back then: in your skin.js rather than a separate file.

Perhaps old browsers threw an error, but for now I can't seem to trigger any errors and regardless, the default behavior if something isn't true is the first option, so none of this is needed.