### PR TITLE
Shift morebits lookupCreator to lookupCreation, also include timestamp; use in prod to limit BLP category alert

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1328,7 +1328,7 @@ Twinkle.tag.callbacks = {
 					});
 				}
 				if (params.translationNotify) {
-					pageobj.lookupCreator(function(innerPageobj) {
+					pageobj.lookupCreation(function(innerPageobj) {
 						var initialContrib = innerPageobj.getCreator();
 
 						// Disallow warning yourself

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -255,7 +255,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 
 	// Notifying uploader
 	if( notify ) {
-		wikipedia_page.lookupCreator(Twinkle.image.callbacks.userNotification);
+		wikipedia_page.lookupCreation(Twinkle.image.callbacks.userNotification);
 	} else {
 		// add to CSD log if desired
 		if (lognomination) {

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -247,7 +247,7 @@ Twinkle.prod.callbacks = {
 			if( params.usertalk ) {
 				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
-				thispage.lookupCreator(Twinkle.prod.callbacks.userNotification);
+				thispage.lookupCreation(Twinkle.prod.callbacks.userNotification);
 			}
 			// If not notifying, log this PROD
 			else if( Twinkle.getPref('logProdPages') ) {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1326,7 +1326,7 @@ Twinkle.speedy.callbacks = {
 			// Otherwise open the talk page directly
 			if (params.warnUser) {
 				thispage.setCallbackParameters(params);
-				thispage.lookupCreator(Twinkle.speedy.callbacks.noteToCreator);
+				thispage.lookupCreation(Twinkle.speedy.callbacks.noteToCreator);
 			}
 		},
 		deleteTalk: function( params ) {
@@ -1511,7 +1511,7 @@ Twinkle.speedy.callbacks = {
 			if (params.usertalk) {
 				var thispage = new Morebits.wiki.page(Morebits.pageNameNorm);
 				thispage.setCallbackParameters(params);
-				thispage.lookupCreator(Twinkle.speedy.callbacks.noteToCreator);
+				thispage.lookupCreation(Twinkle.speedy.callbacks.noteToCreator);
 			}
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
 			else if (params.lognomination) {

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -605,7 +605,7 @@ Twinkle.xfd.callbacks = {
 		if (venue === "ffd") {
 			// Fetch the uploader
 			var page = new Morebits.wiki.page(mw.config.get('wgPageName'));
-			page.lookupCreator(function() {
+			page.lookupCreation(function() {
 				params.uploader = page.getCreator();
 				Twinkle.xfd.callbacks.showPreview(form, venue, params);
 			});
@@ -715,7 +715,7 @@ Twinkle.xfd.callbacks = {
 			if (params.usertalk) {
 				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
-				thispage.lookupCreator(Twinkle.xfd.callbacks.afd.userNotification);
+				thispage.lookupCreation(Twinkle.xfd.callbacks.afd.userNotification);
 			}
 
 			// List at deletion sorting pages
@@ -950,7 +950,7 @@ Twinkle.xfd.callbacks = {
 			if (apiobj.params.usertalk) {
 				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(apiobj.params);
-				thispage.lookupCreator(Twinkle.xfd.callbacks.mfd.userNotification);
+				thispage.lookupCreation(Twinkle.xfd.callbacks.mfd.userNotification);
 			}
 		},
 		taggingPage: function(pageobj) {
@@ -1036,7 +1036,7 @@ Twinkle.xfd.callbacks = {
 
 	ffd: {
 		main: function(pageobj) {
-			// this is coming in from lookupCreator...!
+			// this is coming in from lookupCreation...!
 			var params = pageobj.getCallbackParameters();
 			var initialContrib = pageobj.getCreator();
 			params.uploader = initialContrib;
@@ -1279,7 +1279,7 @@ Twinkle.xfd.callbacks = {
 			if (params.usertalk || params.relatedpage) {
 				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
-				thispage.lookupCreator(Twinkle.xfd.callbacks.rfd.sendNotifications);
+				thispage.lookupCreation(Twinkle.xfd.callbacks.rfd.sendNotifications);
 			}
 		},
 		taggingRedirect: function(pageobj) {
@@ -1492,7 +1492,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			}
 			involvedpages.forEach(function(page) {
 				page.setCallbackParameters(params);
-				page.lookupCreator(function(innerpage) {
+				page.lookupCreation(function(innerpage) {
 					var username = innerpage.getCreator();
 					if (seenusers.indexOf(username) === -1) {
 						seenusers.push(username);
@@ -1540,7 +1540,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 		// Contributor specific edits
 		wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 		wikipedia_page.setCallbackParameters(params);
-		wikipedia_page.lookupCreator(Twinkle.xfd.callbacks.ffd.main);
+		wikipedia_page.lookupCreation(Twinkle.xfd.callbacks.ffd.main);
 
 		Morebits.wiki.removeCheckpoint();
 		break;
@@ -1585,7 +1585,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 		if (usertalk) {
 			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			wikipedia_page.setCallbackParameters(params);
-			wikipedia_page.lookupCreator(Twinkle.xfd.callbacks.cfd.userNotification);
+			wikipedia_page.lookupCreation(Twinkle.xfd.callbacks.cfd.userNotification);
 		}
 
 		Morebits.wiki.removeCheckpoint();

--- a/morebits-test.js
+++ b/morebits-test.js
@@ -52,8 +52,8 @@ mw.loader.using( 'jquery.ui.dialog', function() {
 			}
 			page.setCreateOption(window.morebits_test_createOption);
 
-			if ( $('#runTestForm input[name="lookupCreator"]').attr('checked') ) {
-				page.lookupCreator(Twinkle.morebitsTest.lookupCreatorCallback);
+			if ( $('#runTestForm input[name="lookupCreation"]').attr('checked') ) {
+				page.lookupCreation(Twinkle.morebitsTest.lookupCreationCallback);
 			}
 		},
 
@@ -75,8 +75,8 @@ mw.loader.using( 'jquery.ui.dialog', function() {
 			page.save(Twinkle.morebitsTest.finalSaveCallback);
 		},
 
-		lookupCreatorCallback: function(page) {
-			alert("Page was created by: " + page.getCreator());
+		lookupCreationCallback: function(page) {
+			alert("Page was created by: " + page.getCreator() + " at: " + page.getCreationTimestamp());
 		},
 
 		finalSaveCallback: function(page) {
@@ -102,7 +102,7 @@ mw.loader.using( 'jquery.ui.dialog', function() {
 				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="checkbox" name="watchlist"/> Add to watchlist') )
 				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="checkbox" name="watchlistFromPreferences"/> Add to watchlist based on preference settings') )
 				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="checkbox" name="noRetries"/> Disable retries') )
-				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="checkbox" name="lookupCreator"/> Lookup page creator<hr/>') )
+				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="checkbox" name="lookupCreation"/> Lookup page creator and timestamp<hr/>') )
 				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="radio" name="createOption" value="" onclick="window.morebits_test_createOption=value" checked/> Create page if needed, unless deleted since loaded<br>') )
 				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="radio" name="createOption" value="recreate" onclick="window.morebits_test_createOption=value"/> Create page if needed<br>') )
 				.append( $('<div style="margin-top:0.4em;"></div>').html('<input type="radio" name="createOption" value="createonly" onclick="window.morebits_test_createOption=value"/> Only create a new page<br>') )


### PR DESCRIPTION
1st commit: morebits: Shift lookupCreator to lookupCreation, also include timestamp

It's a free lookup and the time of creation can be useful.  Includes a notice about deprecation of `lookupCreator`, but still let's it be used.  Should probably notify any users with scripts depending on this.

2nd commit: prod: Wait three days before issuing BLPPROD alert if not in BLP cat

There was some annoyance with the alert given that BLPPORD taggings may frequently happen as part of NPP, where the category wouldn't be added.  See https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_40#BLPPROD_Issue_-_Pseudo-Improvement

Since we've added a callback to get the time of creation before tagging, we can restructure the user notification to remove that callback, essentially staying net-neutral

----
There are a few different ways to do this, but figured including the timestamp in the lookup could be helpful down the road for other options, and wouldn't cost anything.  @siddharthvp as you wrote the initial alert in #458 and are up-to-date on `morebits` so I'd appreciate you taking a look over this.