### PR TITLE
Config: Add <nowiki> tags to user config pages

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1689,7 +1689,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 		"// changing the configuration parameters in a valid-JavaScript way) will be\n" +
 		"// overwritten the next time you click \"save\" in the Twinkle preferences\n" +
 		"// panel.  If modifying this file, make sure to use correct JavaScript.\n" +
-	    	"// <no" + "wiki>\n"+
+		"// <no" + "wiki>\n" +
 		"\n" +
 		"window.Twinkle.prefs = ";
 	text += JSON.stringify(newConfig, null, 2);

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1689,12 +1689,14 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 		"// changing the configuration parameters in a valid-JavaScript way) will be\n" +
 		"// overwritten the next time you click \"save\" in the Twinkle preferences\n" +
 		"// panel.  If modifying this file, make sure to use correct JavaScript.\n" +
+	    	"// <no" + "wiki>\n"+
 		"\n" +
 		"window.Twinkle.prefs = ";
 	text += JSON.stringify(newConfig, null, 2);
 	text +=
 		";\n" +
 		"\n" +
+		"// </no" + "wiki>\n" + 
 		"// End of twinkleoptions.js\n";
 
 	pageobj.setPageText(text);


### PR DESCRIPTION
Add <nowiki> at the start of users' twinkleoptions.js, and </nowiki> at the end, to ensure that templates listed in them aren't parsed. Currently, [this tracking category](https://en.wikipedia.org/wiki/Category:Pages_with_templates_in_the_wrong_namespace) lists https://en.wikipedia.org/wiki/User:BilCat/twinkleoptions.js and https://en.wikipedia.org/wiki/User:Senator2029/twinkleoptions.js as in the wrong namespace, likely because they have templates in the source. The nowiki tags are written in 2 parts to avoid them being parsed at  [the gadget page itself](https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleconfig.js)