### PR TITLE
batchundelete: Improvements to morebits.wiki.page, short- and long-term alleviation of #613, color like batchdelete

### DIFF
--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -138,6 +138,7 @@ Twinkle.batchundelete.callback.evaluate = function( event ) {
 		wikipedia_page.setCallbackParameters(params);
 		wikipedia_page.setEditSummary(reason + Twinkle.getPref('deletionSummaryAd'));
 		wikipedia_page.suppressProtectWarning();
+		wikipedia_page.setMaxRetries(3); // temporary increase from 2 to make batchundelete more likely to succeed [[phab:T222402]] #613
 		wikipedia_page.undeletePage(function onSuccess(apiobj) {
 			pageUndeleter.workerSuccess();
 			var talkpagename = new mw.Title(apiobj.query.title).getTalkPage().getPrefixedText();

--- a/morebits.js
+++ b/morebits.js
@@ -1622,7 +1622,7 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  * getPageText(): returns a string containing the text of the page after a successful load()
  *
  * save([onSuccess], [onFailure]):  Saves the text set via setPageText() for the page.
- * 									Must be preceded by calling load().
+ * Must be preceded by calling load().
  *    Warning: Calling save() can result in additional calls to the previous load() callbacks to
  *             recover from edit conflicts!
  *             In this case, callers must make the same edit to the new pageText and reinvoke save().
@@ -1637,6 +1637,8 @@ Morebits.wiki.api.setApiUserAgent = function( ua ) {
  * move(onSuccess, [onFailure]): Moves a page to another title
  *
  * deletePage(onSuccess, [onFailure]): Deletes a page (for admins only)
+ *
+ * undeletePage(onSuccess, [onFailure]): Undeletes a page (for admins only)
  *
  * protect(onSuccess, [onFailure]): Protects a page
  *
@@ -1782,6 +1784,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		onMoveFailure: null,
 		onDeleteSuccess: null,
 		onDeleteFailure: null,
+		onUndeleteSuccess: null,
+		onUndeleteFailure: null,
 		onProtectSuccess: null,
 		onProtectFailure: null,
 		onStabilizeSuccess: null,
@@ -1796,6 +1800,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		moveProcessApi: null,
 		deleteApi: null,
 		deleteProcessApi: null,
+		undeleteApi: null,
+		undeleteProcessApi: null,
 		protectApi: null,
 		protectProcessApi: null,
 		stabilizeApi: null,
@@ -2407,6 +2413,44 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
+	 * Undeletes a page (for admins only)
+	 * @param {Function} onSuccess - callback function to run on success
+	 * @param {Function} [onFailure] - callback function to run on failure (optional)
+	 */
+	this.undeletePage = function(onSuccess, onFailure) {
+		ctx.onUndeleteSuccess = onSuccess;
+		ctx.onUndeleteFailure = onFailure || emptyFunction;
+
+		// if a non-admin tries to do this, don't bother
+		if (!Morebits.userIsInGroup('sysop')) {
+			ctx.statusElement.error("Cannot undelete page: only admins can do that");
+			ctx.onUndeleteFailure(this);
+			return;
+		}
+		if (!ctx.editSummary) {
+			ctx.statusElement.error("Internal error: undelete reason not set before undelete (use setEditSummary function)!");
+			ctx.onUndeleteFailure(this);
+			return;
+		}
+
+		if (fnCanUseMwUserToken('undelete')) {
+			fnProcessUndelete.call(this, this);
+		} else {
+			var query = {
+				action: 'query',
+				prop: 'info',
+				inprop: 'protection',
+				intoken: 'undelete',
+				titles: ctx.pageName
+			};
+
+			ctx.undeleteApi = new Morebits.wiki.api("retrieving undelete token...", query, fnProcessUndelete, ctx.statusElement, ctx.onUndeleteFailure);
+			ctx.undeleteApi.setParent(this);
+			ctx.undeleteApi.post();
+		}
+	};
+
+	/**
 	 * Protects a page (for admins only)
 	 * @param {Function} onSuccess - callback function to run on success
 	 * @param {Function} [onFailure] - callback function to run on failure (optional)
@@ -2879,11 +2923,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		// check for "Database query error"
 		if ( errorCode === "internal_api_error_DBQueryError" && ctx.retries++ < ctx.maxRetries ) {
-
 			ctx.statusElement.info("Database query error, retrying");
 			--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 			ctx.deleteProcessApi.post(); // give it another go!
-
 		} else if ( errorCode === "badtoken" ) {
 			// this is pathetic, but given the current state of Morebits.wiki.page it would
 			// be a dog's breakfast to try and fix this
@@ -2891,20 +2933,100 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			if (ctx.onDeleteFailure) {
 				ctx.onDeleteFailure.call(this, this, ctx.deleteProcessApi);
 			}
-
 		} else if ( errorCode === "missingtitle" ) {
-
 			ctx.statusElement.error("Cannot delete the page, because it no longer exists");
 			if (ctx.onDeleteFailure) {
 				ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
 			}
-
 		// hard error, give up
 		} else {
-
 			ctx.statusElement.error( "Failed to delete the page: " + ctx.deleteProcessApi.getErrorText() );
 			if (ctx.onDeleteFailure) {
 				ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
+			}
+		}
+	};
+
+	var fnProcessUndelete = function() {
+		var pageTitle, token;
+
+		// The whole handling of tokens in Morebits is outdated (#615)
+		// but has generally worked since intoken has been deprecated
+		// but remains.  intoken does not, however, take undelete, so
+		// fnCanUseMwUserToken('undelete') is no good.  Everything
+		// except watching and patrolling should eventually use csrf,
+		// but until then (#615) the stupid hack below should work for
+		// undeletion.
+		if (fnCanUseMwUserToken('undelete')) {
+			token = mw.user.tokens.get('editToken');
+			pageTitle = ctx.pageName;
+		} else {
+			var xml = ctx.undeleteApi.getXML();
+
+			if ($(xml).find('page').attr('missing') !== "") {
+				ctx.statusElement.error("Cannot undelete the page, because it already exists");
+				ctx.onUndeleteFailure(this);
+				return;
+			}
+
+			// extract protection info
+			var editprot = $(xml).find('pr[type="create"]');
+			if (editprot.length > 0 && editprot.attr('level') === 'sysop' && !ctx.suppressProtectWarning &&
+				!confirm('You are about to undelete the fully create protected page "' + ctx.pageName +
+				(editprot.attr('expiry') === 'infinity' ? '" (protected indefinitely)' : ('" (protection expiring ' + editprot.attr('expiry') + ')')) +
+				'.  \n\nClick OK to proceed with the undeletion, or Cancel to skip this undeletion.')) {
+				ctx.statusElement.error("Undeletion of fully create protected page was aborted.");
+				ctx.onUndeleteFailure(this);
+				return;
+			}
+
+			// KLUDGE:
+			token = mw.user.tokens.get('editToken');
+			pageTitle = ctx.pageName;
+		}
+
+		var query = {
+			'action': 'undelete',
+			'title': pageTitle,
+			'token': token,
+			'reason': ctx.editSummary
+		};
+		if (ctx.watchlistOption === 'watch') {
+			query.watch = 'true';
+		}
+
+		ctx.undeleteProcessApi = new Morebits.wiki.api("undeleting page...", query, ctx.onUndeleteSuccess, ctx.statusElement, fnProcessUndeleteError);
+		ctx.undeleteProcessApi.setParent(this);
+		ctx.undeleteProcessApi.post();
+	};
+
+	// callback from undeleteProcessApi.post()
+	var fnProcessUndeleteError = function() {
+
+		var errorCode = ctx.undeleteProcessApi.getErrorCode();
+
+		// check for "Database query error"
+		if ( errorCode === "internal_api_error_DBQueryError" && ctx.retries++ < ctx.maxRetries ) {
+			ctx.statusElement.info("Database query error, retrying");
+			--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
+			ctx.undeleteProcessApi.post(); // give it another go!
+		} else if ( errorCode === "badtoken" ) {
+			// this is pathetic, but given the current state of Morebits.wiki.page it would
+			// be a dog's breakfast to try and fix this
+			ctx.statusElement.error("Invalid token. Please refresh the page and try again.");
+			if (ctx.onUndeleteFailure) {
+				ctx.onUndeleteFailure.call(this, this, ctx.undeleteProcessApi);
+			}
+		} else if ( errorCode === "cantundelete" ) {
+			ctx.statusElement.error("Cannot undelete the page, either because there are no revisions to undelete or because it has already been undeleted");
+			if (ctx.onUndeleteFailure) {
+				ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);  // invoke callback
+			}
+		// hard error, give up
+		} else {
+			ctx.statusElement.error( "Failed to undelete the page: " + ctx.undeleteProcessApi.getErrorText() );
+			if (ctx.onUndeleteFailure) {
+				ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);  // invoke callback
 			}
 		}
 	};

--- a/morebits.js
+++ b/morebits.js
@@ -3826,7 +3826,7 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
  * |pageName| property on the Morebits.wiki.api object.
  *
  * There are sample batchOperation implementations using Morebits.wiki.page in
- * twinklebatchdelete.js, and using Morebits.wiki.api in twinklebatchundelete.js.
+ * twinklebatchdelete.js, twinklebatchundelete.js, and twinklebatchprotect.js.
  */
 
 /**


### PR DESCRIPTION
tl;dr — Add `undeletePage` to `Morebits.wiki.page`, use it in `twinklebatchundelete` (helps with #613), bump `maxRetries` (helps with #613), restructure talkpage undeletion (from #601), and add red color for fully create protected pages.

- 1st commit: morebits: Add undeletePage to morebits.wiki.page
Basically just copy the stuff for deletePage, less following redirects.  deletePage was added in 4b92869 along with move, but unlike protect (68132e5) delete and undelete are one-way streets.  Uses a dumb kludge to get around the lack of a proper token until we can rewrite the token handling stuff in `morebits` (#615).
- 2nd commit: batchundelete: convert to use Morebits.wiki.page.undeletePage
Added in prior commit (47c9cf9).  Some testing suggests this helps a bit with #613, but regardless, it's clearer this way anyway.
- 3rd commit: batchundelete: temporarily bump maxRetries up to 3 to avoid DB errors and alleviate #613
Increase from 2 to 3, makes `twinklebatchundelete` much more likely to succeed until phabricator.wikimedia.org/T222402 can be dealt with.  We've been handling `internal_api_error_DBQueryError` for deletion since #198, before even `batchOperation` was added (ecfff3b).
- 4th commit: batchundelete: Use same format in talkpage restoration as batchdelete
Follows up on #601.  Allows for a better, more clear message when listing deletions, as well as more full error handling and clearer code.  Easier to expand, should we desire.
- 5th commit: batchundelete: Add red color and confirmation for create-protected pages a la batchdelete