### PR TITLE
xfd: Fix broken AfD category sorting

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -475,6 +475,9 @@ Twinkle.xfd.callbacks = {
 
 		if (venue === "afd" || venue === "mfd") {
 			text += "|pg=" + Morebits.pageNameNorm;
+			if (venue === "afd") {
+				text += "|cat=" + params.xfdcat;
+			}
 		} else if (venue === "rfd") {
 			text += "|redirect=" + Morebits.pageNameNorm;
 		} else {


### PR DESCRIPTION
Fixes #617.  Introduced by me in #521: basically, `xfdcat` is used by cfd/cfds and tfd to switch the type of nomination (cfd versus cfr, tfd versus tfm) but for AfD it does something entirely different: sort the discussion into one of the various AfD categories (biography, media, etc.).  While the former is used via `venue`, we still need to call it for afd.