### PR TITLE
Speedy: Tweak db-xfd tooltip to be sysop-agnostic

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -951,7 +951,7 @@ Twinkle.speedy.generalList = [
 	{
 		label: 'G6: XfD',
 		value: 'xfd',
-		tooltip: 'An admin has closed a deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) as "delete", but they didn\'t actually delete the page.',
+		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but they didn\'t actually delete the page.',
 		subgroup: {
 			name: 'xfd_fullvotepage',
 			type: 'input',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -951,7 +951,7 @@ Twinkle.speedy.generalList = [
 	{
 		label: 'G6: XfD',
 		value: 'xfd',
-		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but they didn\'t actually delete the page.',
+		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but the page wasn\'t actually deleted.',
 		subgroup: {
 			name: 'xfd_fullvotepage',
 			type: 'input',


### PR DESCRIPTION
Deletion discussions can be closed as delete by non-admins (specifically in the case of TfD, where they can be closed as delete but need to be orphaned first) - change "An admin has closed a deletion discussion..." to "A deletion discussion was closed..."