### PR TITLE
Image: Link "speedy deletion policy" directly to #Files

### DIFF
--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -23,7 +23,7 @@ Twinkle.image.callback = function twinkleimageCallback() {
 	var Window = new Morebits.simpleWindow( 600, 330 );
 	Window.setTitle( "File for dated speedy deletion" );
 	Window.setScriptName( "Twinkle" );
-	Window.addFooterLink( "Speedy deletion policy", "WP:CSD" );
+	Window.addFooterLink( "Speedy deletion policy", "WP:CSD#Files" );
 	Window.addFooterLink( "Twinkle help", "WP:TW/DOC#image" );
 
 	var form = new Morebits.quickForm( Twinkle.image.callback.evaluate );


### PR DESCRIPTION
Since the DI tab is only available on files, and only includes speedy deletion criteria applicable to files, the link should point to the specific section of the speedy deletion policy.