### PR TITLE
fluff: Remove overly parsimonious check for diffs, blocked links if diff content hidden

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -81,81 +81,79 @@ Twinkle.fluff = {
 	},
 
 	diff: function() {
-		if (mw.config.get('wgDiffNewId') === mw.config.get('wgRevisionId')) {
-			// Add a [restore this revision] link to the older revision
-			// Don't show if there's a single revision or weird diff (cur on latest)
-			if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
-				var revertToRevision = document.createElement('div');
-				revertToRevision.setAttribute( 'id', 'tw-revert-to-orevision' );
-				revertToRevision.style.fontWeight = 'bold';
+		// Add a [restore this revision] link to the older revision
+		// Don't show if there's a single revision or weird diff (cur on latest)
+		if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
+			var revertToRevision = document.createElement('div');
+			revertToRevision.setAttribute( 'id', 'tw-revert-to-orevision' );
+			revertToRevision.style.fontWeight = 'bold';
 
-				var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-				revertToRevisionLink.href = "#";
-				$(revertToRevisionLink).click(function(){
-					Twinkle.fluff.revertToRevision(mw.config.get('wgDiffOldId').toString());
-				});
-				revertToRevision.appendChild(revertToRevisionLink);
+			var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
+			revertToRevisionLink.href = "#";
+			$(revertToRevisionLink).click(function(){
+				Twinkle.fluff.revertToRevision(mw.config.get('wgDiffOldId').toString());
+			});
+			revertToRevision.appendChild(revertToRevisionLink);
 
-				var otitle = document.getElementById('mw-diff-otitle1').parentNode;
-				otitle.insertBefore( revertToRevision, otitle.firstChild );
-			}
+			var otitle = document.getElementById('mw-diff-otitle1').parentNode;
+			otitle.insertBefore( revertToRevision, otitle.firstChild );
+		}
 
-			// Add either restore or rollback links to the newer revision
-			// Don't show if there's a single revision or weird diff (prev on first)
-			var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
-			if( document.getElementById('differences-nextlink') ) {
-				// Not latest revision
-				var revertToRevisionN = document.createElement('div');
-				revertToRevisionN.setAttribute( 'id', 'tw-revert-to-nrevision' );
-				revertToRevisionN.style.fontWeight = 'bold';
+		// Add either restore or rollback links to the newer revision
+		// Don't show if there's a single revision or weird diff (prev on first)
+		var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
+		if( document.getElementById('differences-nextlink') ) {
+			// Not latest revision
+			var revertToRevisionN = document.createElement('div');
+			revertToRevisionN.setAttribute( 'id', 'tw-revert-to-nrevision' );
+			revertToRevisionN.style.fontWeight = 'bold';
 
-				var revertToRevisionNLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-				revertToRevisionNLink.href = "#";
-				$(revertToRevisionNLink).click(function(){
-					Twinkle.fluff.revertToRevision(mw.config.get('wgDiffNewId').toString());
-				});
-				revertToRevisionN.appendChild(revertToRevisionNLink);
+			var revertToRevisionNLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
+			revertToRevisionNLink.href = "#";
+			$(revertToRevisionNLink).click(function(){
+				Twinkle.fluff.revertToRevision(mw.config.get('wgDiffNewId').toString());
+			});
+			revertToRevisionN.appendChild(revertToRevisionNLink);
 
-				ntitle.insertBefore( revertToRevisionN, ntitle.firstChild );
-			} else if( Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
-				var vandal = $("#mw-diff-ntitle2").find("a").first().text();
+			ntitle.insertBefore( revertToRevisionN, ntitle.firstChild );
+		} else if( Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
+			var vandal = $("#mw-diff-ntitle2").find("a").first().text();
 
-				var revertNode = document.createElement('div');
-				revertNode.setAttribute( 'id', 'tw-revert' );
+			var revertNode = document.createElement('div');
+			revertNode.setAttribute( 'id', 'tw-revert' );
 
-				var agfNode = document.createElement('strong');
-				var vandNode = document.createElement('strong');
-				var normNode = document.createElement('strong');
+			var agfNode = document.createElement('strong');
+			var vandNode = document.createElement('strong');
+			var normNode = document.createElement('strong');
 
-				var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', 'rollback (AGF)');
-				var vandLink = Twinkle.fluff.buildLink('Red', 'rollback (VANDAL)');
-				var normLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
+			var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', 'rollback (AGF)');
+			var vandLink = Twinkle.fluff.buildLink('Red', 'rollback (VANDAL)');
+			var normLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
 
-				agfLink.href = "#";
-				vandLink.href = "#";
-				normLink.href = "#";
-				$(agfLink).click(function(){
-					Twinkle.fluff.revert('agf', vandal);
-				});
-				$(vandLink).click(function(){
-					Twinkle.fluff.revert('vand', vandal);
-				});
-				$(normLink).click(function(){
-					Twinkle.fluff.revert('norm', vandal);
-				});
+			agfLink.href = "#";
+			vandLink.href = "#";
+			normLink.href = "#";
+			$(agfLink).click(function(){
+				Twinkle.fluff.revert('agf', vandal);
+			});
+			$(vandLink).click(function(){
+				Twinkle.fluff.revert('vand', vandal);
+			});
+			$(normLink).click(function(){
+				Twinkle.fluff.revert('norm', vandal);
+			});
 
-				agfNode.appendChild(agfLink);
-				vandNode.appendChild(vandLink);
-				normNode.appendChild(normLink);
+			agfNode.appendChild(agfLink);
+			vandNode.appendChild(vandLink);
+			normNode.appendChild(normLink);
 
-				revertNode.appendChild( agfNode );
-				revertNode.appendChild( document.createTextNode(' || ') );
-				revertNode.appendChild( normNode );
-				revertNode.appendChild( document.createTextNode(' || ') );
-				revertNode.appendChild( vandNode );
+			revertNode.appendChild( agfNode );
+			revertNode.appendChild( document.createTextNode(' || ') );
+			revertNode.appendChild( normNode );
+			revertNode.appendChild( document.createTextNode(' || ') );
+			revertNode.appendChild( vandNode );
 
-				ntitle.insertBefore( revertNode, ntitle.firstChild );
-			}
+			ntitle.insertBefore( revertNode, ntitle.firstChild );
 		}
 	},
 
@@ -585,7 +583,7 @@ Twinkle.fluff.init = function twinklefluffinit() {
 			Twinkle.fluff.auto();
 		} else if( mw.config.get('wgNamespaceNumber') === -1 && mw.config.get('wgCanonicalSpecialPageName') === "Contributions" ) {
 			Twinkle.fluff.contributions();
-		} else if( mw.config.get('wgDiffOldId') || mw.config.get('wgDiffNewId') ) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
+		} else if( mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId') ) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
 			mw.hook( 'wikipage.diff' ).add( function () { // Reload alongside the revision slider
 				Twinkle.fluff.diff();
 			} );


### PR DESCRIPTION
Fixes #627.  If a user has "Do not show page content below diffs" selected in Special:Preferences, `wgRevisionId` will be set to 0 on diffs, meaning no links would be shown on diffs.  Comparing `wgRevisionId` to `wgDiffNewId` from #563 appears to be a holdover from some (local) attempts to handle merge conflicts between #511 and #407, when I initially had this structured differently, but that should now handled in the init, so this was excessive.