### PR TITLE
fluff: don't create rollback links for single-revision pages on contribs

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -67,14 +67,16 @@ Twinkle.fluff = {
 
 				list.each(function(key, current) {
 					var href = $(current).find(".mw-changeslist-diff").attr("href");
-					current.appendChild( document.createTextNode(' ') );
-					var tmpNode = revNode.cloneNode( true );
-					tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'norm' } ) );
-					current.appendChild( tmpNode );
-					current.appendChild( document.createTextNode(' ') );
-					tmpNode = revVandNode.cloneNode( true );
-					tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'vand' } ) );
-					current.appendChild( tmpNode );
+					if (href) {
+						current.appendChild( document.createTextNode(' ') );
+						var tmpNode = revNode.cloneNode( true );
+						tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'norm' } ) );
+						current.appendChild( tmpNode );
+						current.appendChild( document.createTextNode(' ') );
+						tmpNode = revVandNode.cloneNode( true );
+						tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'vand' } ) );
+						current.appendChild( tmpNode );
+					}
 				});
 			}
 		}


### PR DESCRIPTION
Possibly a result from the fix in #467, but either way, this would create rollback/vandal links for every page marked with `mw-uctop`, even if it had only a single revision and thus couldn't be reverted.  The rollback links would fail (using & instead of ?) but wouldn't have been properly constructed anyway.  Check for the existence of a `href` here should remove those links.