### PR TITLE
fluff: Only add links if the user has necessary perms to edit the page

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -49,13 +49,13 @@ Twinkle.fluff = {
 		// $('sp-contributions-footer-anon-range') relies on the fmbox
 		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
 		// is used to show rollback/vandalism links for IP ranges
-		if( mw.config.get('wgCanonicalSpecialPageName') === "Contributions" && (mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0])) {
+		if( mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0]) {
 			//Get the username these contributions are for
 			var username = mw.config.get('wgRelevantUserName');
 			if( Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
 				( mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1 ) ||
 				( mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1 ) ) {
-				var list = $("#mw-content-text").find("ul li:has(span.mw-uctop)");
+				var list = $("#mw-content-text").find("ul li:has(span.mw-uctop):has(.mw-changeslist-diff)");
 
 				var revNode = document.createElement('strong');
 				var revLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
@@ -67,16 +67,14 @@ Twinkle.fluff = {
 
 				list.each(function(key, current) {
 					var href = $(current).find(".mw-changeslist-diff").attr("href");
-					if (href) {
-						current.appendChild( document.createTextNode(' ') );
-						var tmpNode = revNode.cloneNode( true );
-						tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'norm' } ) );
-						current.appendChild( tmpNode );
-						current.appendChild( document.createTextNode(' ') );
-						tmpNode = revVandNode.cloneNode( true );
-						tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'vand' } ) );
-						current.appendChild( tmpNode );
-					}
+					current.appendChild( document.createTextNode(' ') );
+					var tmpNode = revNode.cloneNode( true );
+					tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'norm' } ) );
+					current.appendChild( tmpNode );
+					current.appendChild( document.createTextNode(' ') );
+					tmpNode = revVandNode.cloneNode( true );
+					tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'vand' } ) );
+					current.appendChild( tmpNode );
 				});
 			}
 		}
@@ -583,7 +581,7 @@ Twinkle.fluff.init = function twinklefluffinit() {
 
 		if ( Morebits.queryString.exists( 'twinklerevert' ) ) {
 			Twinkle.fluff.auto();
-		} else if( mw.config.get('wgNamespaceNumber') === -1 && mw.config.get('wgCanonicalSpecialPageName') === "Contributions" ) {
+		} else if( mw.config.get('wgCanonicalSpecialPageName') === "Contributions" ) {
 			Twinkle.fluff.contributions();
 		} else if( mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId') ) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
 			mw.hook( 'wikipage.diff' ).add( function () { // Reload alongside the revision slider

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -45,27 +45,50 @@ Twinkle.fluff = {
 		Twinkle.fluff.revert( Morebits.queryString.get( 'twinklerevert' ), vandal, true );
 	},
 
-	contributions: function() {
-		// $('sp-contributions-footer-anon-range') relies on the fmbox
-		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
-		// is used to show rollback/vandalism links for IP ranges
-		if( mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0]) {
-			//Get the username these contributions are for
-			var username = mw.config.get('wgRelevantUserName');
-			if( Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
-				( mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1 ) ||
-				( mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1 ) ) {
-				var list = $("#mw-content-text").find("ul li:has(span.mw-uctop):has(.mw-changeslist-diff)");
+	contributions: {
+		findPages: function() {
+			// $('sp-contributions-footer-anon-range') relies on the fmbox
+			// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
+			// is used to show rollback/vandalism links for IP ranges
+			if( mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0]) {
+				//Get the username these contributions are for
+				var username = mw.config.get('wgRelevantUserName');
+				if( Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
+					( mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1 ) ||
+					( mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1 ) ) {
+					var list = $("#mw-content-text").find("ul li:has(span.mw-uctop):has(.mw-changeslist-diff)");
+					var titles = $(list).find(".mw-changeslist-date").map(function(){return $(this).attr("title");}).get();
 
-				var revNode = document.createElement('strong');
-				var revLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
-				revNode.appendChild(revLink);
+					var query = {
+						'action': 'query',
+						'prop': 'info',
+						'intestactions': 'edit',
+						'titles': titles.join('|').replace(/ /g,'_')
+					};
 
-				var revVandNode = document.createElement('strong');
-				var revVandLink = Twinkle.fluff.buildLink('Red', 'vandalism');
-				revVandNode.appendChild(revVandLink);
+					var wikipedia_api = new Morebits.wiki.api('Checking ability to edit each page', query, Twinkle.fluff.contributions.main);
+					wikipedia_api.params = { list: list, titles: titles };
+					wikipedia_api.post();
+				}
+			}
+		},
 
-				list.each(function(key, current) {
+		main: function(apiobj) {
+			var xmlDoc = apiobj.responseXML;
+
+			var revNode = document.createElement('strong');
+			var revLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
+			revNode.appendChild(revLink);
+
+			var revVandNode = document.createElement('strong');
+			var revVandLink = Twinkle.fluff.buildLink('Red', 'vandalism');
+			revVandNode.appendChild(revVandLink);
+
+			apiobj.params.list.each(function(key, current) {
+				var page = $(xmlDoc).find("page[title='"+apiobj.params.titles[key]+"']");
+				var canEdit = page.find('actions').attr('edit');
+
+				if (typeof canEdit !== 'undefined') {
 					var href = $(current).find(".mw-changeslist-diff").attr("href");
 					current.appendChild( document.createTextNode(' ') );
 					var tmpNode = revNode.cloneNode( true );
@@ -75,8 +98,8 @@ Twinkle.fluff = {
 					tmpNode = revVandNode.cloneNode( true );
 					tmpNode.firstChild.setAttribute( 'href', href + '&' + Morebits.queryString.create( { 'twinklerevert': 'vand' } ) );
 					current.appendChild( tmpNode );
-				});
-			}
+				}
+			});
 		}
 	},
 
@@ -582,13 +605,21 @@ Twinkle.fluff.init = function twinklefluffinit() {
 		if ( Morebits.queryString.exists( 'twinklerevert' ) ) {
 			Twinkle.fluff.auto();
 		} else if( mw.config.get('wgCanonicalSpecialPageName') === "Contributions" ) {
-			Twinkle.fluff.contributions();
-		} else if( mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId') ) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
-			mw.hook( 'wikipage.diff' ).add( function () { // Reload alongside the revision slider
-				Twinkle.fluff.diff();
-			} );
-		} else if( mw.config.get('wgAction') === 'view' && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId') ) {
-			Twinkle.fluff.oldid();
+			Twinkle.fluff.contributions.findPages();
+		} else if (mw.config.get('wgIsProbablyEditable')) {
+			// Only proceed if the user can actually edit the page
+			// in question (handled individually on contributions.
+			// wgIsProbablyEditable should take care of
+			// namespace/contentModel restrictions as well as
+			// explicit protections; it won't take care of
+			// cascading or TitleBlacklist restrictions
+			if( mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId') ) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
+				mw.hook( 'wikipage.diff' ).add( function () { // Reload alongside the revision slider
+					Twinkle.fluff.diff();
+				} );
+			} else if( mw.config.get('wgAction') === 'view' && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId') ) {
+				Twinkle.fluff.oldid();
+			}
 		}
 	}
 };


### PR DESCRIPTION
Closes #605.  Basically, we need a way to check for ability to edit the covers both explicit (protection) and implicit (namespace and content model) restrictions.

Since we're on the page in question, `diff` and `oldid` (#562) can be handled together with mostly-accurate results by simply checking `wgIsProbablyEditable`.  It won't handle cascading protection or TitleBlacklist restrictions, but neither does MediaWiki when choosing to display either "edit this page" or "view source"; being more accurate than the software would require an API check a la contributions (see following section as well as https://gerrit.wikimedia.org/r/c/mediawiki/core/+/65009).

`contributions` is the more <s>complex</s> interesting implementation, since we've got to check each and every page.  Querying for `edit` in `intestactions` is excellent, because it covers all bases (i.e., it includes the "expensive" checks that `wgIsProbablyEditable` skips, hence `Probably`).  I also restructured/split the contributions routine to avoid doing `async` and to look more Twinkley.

`intestactions` was added in MW 1.25 (https://www.mediawiki.org/wiki/MediaWiki_1.25) circa 2014-2015, and should probably be used more frequently by Twinkle, particularly in `Morebits`, as it's a more correct determiner of whether the user can edit (or move or protect or...) the page in question.

The first commit (remove redundant checks; better way of doing #630 aka e0f3d9c) is worth doing regardless.