### PR TITLE
morebits: internationalize Date, and remove unused functions

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1266,25 +1266,12 @@ Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
  * is fairly unlikely that anyone will iterate over a Date object.
  */
 
-Date.monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
-	'July', 'August', 'September', 'October', 'November','December' ];
-
-Date.monthNamesAbbrev = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-Date.prototype.getMonthName = function() {
-	return Date.monthNames[ this.getMonth() ];
-};
-
-Date.prototype.getMonthNameAbbrev = function() {
-	return Date.monthNamesAbbrev[ this.getMonth() ];
-};
-
 Date.prototype.getUTCMonthName = function() {
-	return Date.monthNames[ this.getUTCMonth() ];
+	return mw.config.get('wgMonthNames')[ this.getUTCMonth() + 1 ];
 };
 
 Date.prototype.getUTCMonthNameAbbrev = function() {
-	return Date.monthNamesAbbrev[ this.getUTCMonth() ];
+	return mw.config.get('wgMonthNamesShort')[ this.getUTCMonth() + 1 ];
 };
 
 


### PR DESCRIPTION
- remove `Date.monthNames` and `Date.monthNamesAbbrev` in favour of mw.config objects `wgMonthNames` and `wgMonthNamesShort`, which work across wikis and languages. A difference is that they are indexed from 0-11 while the config objects are indexed 1-12. These are unused except from `Date.prototype.getUTCMonthName`/ `Date.prototype.getUTCMonthNameAbrev`. 
- remove `Date.prototype.getMonthName` and `Date.prototype.getMonthNameAbbrev` as they are completely unused - not used in Twinkle or any other Morebits-based gadget/script. See searches [1](https://en.wikipedia.org/w/index.php?search=insource%3A%2FgetMonthNameAbbrev%2F&title=Special%3ASearch&profile=advanced&fulltext=1&advancedSearch-current=%7B%7D&ns0=1&ns1=1&ns2=1&ns3=1&ns4=1&ns5=1&ns6=1&ns7=1&ns8=1&ns9=1&ns10=1&ns11=1&ns12=1&ns13=1&ns14=1&ns15=1&ns100=1&ns101=1&ns108=1&ns109=1&ns118=1&ns119=1&ns446=1&ns447=1&ns710=1&ns711=1&ns828=1&ns829=1&ns2300=1&ns2301=1&ns2302=1&ns2303=1) and [2](https://en.wikipedia.org/w/index.php?title=Special:Search&limit=100&offset=0&ns0=1&ns1=1&ns2=1&ns3=1&ns4=1&ns5=1&ns6=1&ns7=1&ns8=1&ns9=1&ns10=1&ns11=1&ns12=1&ns13=1&ns14=1&ns15=1&ns100=1&ns101=1&ns108=1&ns109=1&ns118=1&ns119=1&ns446=1&ns447=1&ns710=1&ns711=1&ns828=1&ns829=1&ns2300=1&ns2301=1&ns2302=1&ns2303=1&search=insource%3A%2FgetMonthName%2F&advancedSearch-current=%7B%7D&searchToken=5hiz771molt4nbkx8bcva4k7t). 