### PR TITLE
Speedy: Use fullurl when linking to file logs on CSD log

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1634,7 +1634,7 @@ Twinkle.speedy.callbacks = {
 			var extraInfo = '';
 
 			// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-			var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([' + mw.config.get('wgServer') + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName')}) + ' log])' : '';
+			var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.config.get('wgPageName') + '}} log])' : '';
 
 			var editsummary = "Logging speedy deletion nomination";
 			appendText += "\n# [[:" + Morebits.pageNameNorm;

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1634,7 +1634,7 @@ Twinkle.speedy.callbacks = {
 			var extraInfo = '';
 
 			// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-			var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.config.get('wgPageName') + '}} log])' : '';
+			var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode (mw.config.get('wgPageName')) + '}} log])' : '';
 
 			var editsummary = "Logging speedy deletion nomination";
 			appendText += "\n# [[:" + Morebits.pageNameNorm;


### PR DESCRIPTION
No need to write out the full url and place multiple calls to get the server and log url when a parser function does the trick.