### PR TITLE
xfd: check "Wrap deletion tag with <noinclude>" if page carries {{sub…

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -320,7 +320,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 							value: 'noinclude',
 							name: 'noinclude',
 							tooltip: 'Will wrap the deletion tag in &lt;noinclude&gt; tags, so that it won\'t get substituted along with the template.',
-							disabled: templateOrModule === 'module'
+							disabled: templateOrModule === 'module',
+							checked: !!$('.box-Subst_only').length // Default to checked if page carries {{subst only}} 
 						}
 					]
 			} );


### PR DESCRIPTION
Check "Wrap deletion tag with <noinclude>" by default if template page (or its documentation) carries {{[subst only](https://en.wikipedia.org/wiki/Template:Subst_only)}}.