### PR TITLE
Protect: Hide on mediawiki pages

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -9,7 +9,7 @@
  *** twinkleprotect.js: Protect/RPP module
  ****************************************
  * Mode of invocation:     Tab ("PP"/"RPP")
- * Active on:              Non-special pages
+ * Active on:              Non-special, non-MediaWiki pages
  * Config directives in:   TwinkleConfig
  */
 

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -16,7 +16,7 @@
 // Note: a lot of code in this module is re-used/called by batchprotect.
 
 Twinkle.protect = function twinkleprotect() {
-	if ( mw.config.get('wgNamespaceNumber') < 0 ) {
+	if ( mw.config.get('wgNamespaceNumber') < 0 || mw.config.get('wgNamespaceNumber') === 8 ) {
 		return;
 	}
 


### PR DESCRIPTION
Can't be protected or unprotected (neither can gadget / gadget description pages, but those are blocked by the title blacklist) - doesn't need to be shown.