### PR TITLE
warn: use jquery.chosen on select box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ jsl.conf
 stash*.txt
 stash*.diff
 *.jsX
+.vscode/
 
 # Windows
 Thumbs.db

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1130,7 +1130,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		} );
 	}
 
-	$('select[name=sub_group]').chosen();
+	$('select[name=sub_group]').chosen({search_contains: true});
 
 	// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
 	mw.util.addCSS('.chosen-container .chosen-results { max-height: 180px !important }');

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1133,7 +1133,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	$('select[name=sub_group]').chosen({search_contains: true});
 
 	// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
-	mw.util.addCSS('.chosen-container .chosen-results { max-height: 180px !important }');
+	$('.chosen-results').css({'overflow': 'auto', 'max-height': '180px'});
 
 	// clear overridden label on article textbox
 	Morebits.quickForm.setElementTooltipVisibility(e.target.root.article, true);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -62,7 +62,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	var main_group = main_select.append( {
 			type: 'select',
 			name: 'main_group',
-			event:Twinkle.warn.callback.change_category
+			event: Twinkle.warn.callback.change_category
 		} );
 
 	var defaultGroup = parseInt(Twinkle.getPref('defaultWarningGroup'), 10);
@@ -110,7 +110,9 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	// We must init the first choice (General Note);
 	var evt = document.createEvent( "Event" );
 	evt.initEvent( 'change', true, true );
-	result.main_group.dispatchEvent( evt );
+	mw.loader.using('jquery.chosen').then(function() {
+		result.main_group.dispatchEvent( evt );
+	});
 };
 
 // This is all the messages that might be dispatched by the code
@@ -1050,6 +1052,8 @@ Twinkle.warn.prev_article = null;
 Twinkle.warn.prev_reason = null;
 
 Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCategory(e) {
+	$("select[name=sub_group]").chosen("destroy");
+
 	var value = e.target.value;
 	var sub_group = e.target.root.sub_group;
 	sub_group.main_group = value;
@@ -1096,7 +1100,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			// Slice out leading uw- from the menu display
 			var elem = new Morebits.quickForm.element( {
 				type: 'option',
-				label: (value === 'custom' ? "{{" + key + "}}" : key.slice(3)) + level + ": " + (level ? itemProperties[value].label : itemProperties.label),
+				label: "{{" + key + level + "}}: " + (level ? itemProperties[value].label : itemProperties.label),
 				value: key + level,
 				selected: selected
 			} );
@@ -1125,6 +1129,11 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			createEntries( groupContents, optgroup, false );
 		} );
 	}
+
+	$('select[name=sub_group]').chosen();
+
+	// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
+	mw.util.addCSS('.chosen-container .chosen-results { max-height: 180px !important }');
 
 	// clear overridden label on article textbox
 	Morebits.quickForm.setElementTooltipVisibility(e.target.root.article, true);


### PR DESCRIPTION
Add jquery.chosen on select box to make templates (and their descriptions) searchable.
Partially revert #517, bringing back the `{{uw-` prefix, as chosen's search works properly despite the presence of that prefix.
Closes #631.

Have used `mw.loader.using('jquery.chosen')` here, until `jquery.chosen` gets added to the gadget definition. 

We should probably revisit the descriptions of templates to make them include relevant keywords that attract search hits. 