### PR TITLE
tag: place new tags under {{AfDM}}, make \n optional in prod

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1528,7 +1528,7 @@ Twinkle.tag.callbacks = {
 					// capture template(s)
 					'(?:((?:\\s*' +
 					// AfD is special, as the tag includes html comments before and after the actual template
-					'(?:<!--.*AfD.*\\n\\{\\{Article for deletion\\/dated.*\\}\\}\\n<!--.*\\n<!--.*AfD.*(?:\\s*\\n))?|' + // trailing whitespace/newline needed since this subst's a newline
+					'(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?|' + // trailing whitespace/newline needed since this subst's a newline
 					// begin template format
 					'\\{\\{\\s*(?:' +
 					// CSD

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1534,7 +1534,7 @@ Twinkle.tag.callbacks = {
 					// CSD
 					'db|delete|db-.*?|speedy deletion-.*?|' +
 					// PROD
-					'(?:proposed deletion|prod blp)\\/dated\\n(?:\\s+\\|(?:concern|user|timestamp|help).*)+|' +
+					'(?:proposed deletion|prod blp)\\/dated(?:\\s*\\|(?:concern|user|timestamp|help).*)+|' +
 					// various hatnote templates
 					'about|correct title|dablink|distinguish|for|other\\s?(?:hurricaneuses|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|the' +
 					// not a hatnote, but sometimes under a CSD or AfD


### PR DESCRIPTION
Add {{AfDM}} to the regex. {{AfDM}} is used by Twinkle's XFD module instead of
{{Article for deletion/dated}} when it's a 2nd/3rd/nth nomination.