### PR TITLE
morebits: overhaul action complete status messages

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -199,8 +199,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 };
 
 Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvaluate(event) {
-	Morebits.wiki.actionCompleted.notice = 'Status';
-	Morebits.wiki.actionCompleted.postfix = 'batch deletion is now complete';
+	Morebits.wiki.actionCompleted.notice = 'Batch deletion is now complete';
 
 	var numProtected = $(Morebits.quickForm.getElements(event.target, 'pages')).filter(function(index, element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -114,8 +114,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 };
 
 Twinkle.batchundelete.callback.evaluate = function( event ) {
-	Morebits.wiki.actionCompleted.notice = 'Status';
-	Morebits.wiki.actionCompleted.postfix = 'batch undeletion is now complete';
+	Morebits.wiki.actionCompleted.notice = 'Batch undeletion is now complete';
 
 	var numProtected = $(Morebits.quickForm.getElements(event.target, 'pages')).filter(function(index, element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -87,8 +87,6 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 	evt.initEvent( 'change', true, true );
 	result.actiontype[0].dispatchEvent( evt );
 
-	Morebits.wiki.actionCompleted.postfix = false;  // avoid Action: completed notice
-
 	// get current protection level asynchronously
 	Twinkle.protect.fetchProtectionLevel();
 };

--- a/morebits.js
+++ b/morebits.js
@@ -1316,7 +1316,9 @@ Morebits.wiki.actionCompleted = function( self ) {
 
 // Change per action wanted
 Morebits.wiki.actionCompleted.event = function() {
-	new Morebits.status( Morebits.wiki.actionCompleted.notice, Morebits.wiki.actionCompleted.postfix, 'info' );
+	if (Morebits.wiki.actionCompleted.notice) {
+		Morebits.status.actionCompleted( Morebits.wiki.actionCompleted.notice );
+	}
 	if( Morebits.wiki.actionCompleted.redirect ) {
 		// if it isn't a URL, make it one. TODO: This breaks on the articles 'http://', 'ftp://', and similar ones.
 		if( !( (/^\w+:\/\//).test( Morebits.wiki.actionCompleted.redirect ) ) ) {
@@ -1331,8 +1333,7 @@ Morebits.wiki.actionCompleted.event = function() {
 
 Morebits.wiki.actionCompleted.timeOut = ( typeof window.wpActionCompletedTimeOut === 'undefined' ? 5000 : window.wpActionCompletedTimeOut );
 Morebits.wiki.actionCompleted.redirect = null;
-Morebits.wiki.actionCompleted.notice = 'Action';
-Morebits.wiki.actionCompleted.postfix = 'completed';
+Morebits.wiki.actionCompleted.notice = null;
 
 Morebits.wiki.addCheckpoint = function() {
 	++Morebits.wiki.nbrOfCheckpointsLeft;
@@ -3604,6 +3605,20 @@ Morebits.status.warn = function( text, status ) {
 
 Morebits.status.error = function( text, status ) {
 	return new Morebits.status( text, status, 'error' );
+};
+
+/**
+ * For the action complete message at the end, create a status line without
+ * a colon separator.
+ * @param {String} text
+ */
+Morebits.status.actionCompleted = function(text) {
+	var node = document.createElement( 'div' );
+	node.appendChild( document.createElement('span') ).appendChild( document.createTextNode( text ) );
+	node.className = 'tw_status_info';
+	if (Morebits.status.root) {
+		Morebits.status.root.appendChild( node );
+	}
 };
 
 /**


### PR DESCRIPTION
(See #645, which adds docs for Morebits.status, if you're unfamiliar with the really convoluted Morebits.status system.)

The action complete status messages (the last line of status) in almost all Twinkle modules do not read correctly. Such as in Tag module, it says "Tagging complete: completed". In xfd, it says "Nomination complete, redirecting to discussion page: completed". None of the Twinkle modules make meaningful use of `Morebits.wiki.actionCompleted.postfix` (the part of the status message after the colon), allowing it to remain "completed" which is the default. There is no way to suppress the display of the colon and postfix.

This commit introduces a new function that creates a status line without a colon separator, and uses it for the action-completed message instead of using a normal Morebits.status object. This does away with `Morebits.wiki.actionCompleted.postfix`, which as described above, has no utility.

The default value of `Morebits.wiki.actionCompleted.notice` is changed from `Action`, which does not make much sense, to `null`. If it is not redefined in the module, the entire action-complete message is suppressed. This was not possible earlier, and was being achieved in RPP/PP through an ugly hack.