### PR TITLE
tag: add quick filtering functionality

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -86,9 +86,9 @@ Twinkle.tag.callback = function friendlytagCallback() {
 					// flush the DOM of all existing underline spans
 					$form.find('.search-hit').each(function(i,e) {
 						var label_element = e.parentElement;
-						var new_label = Morebits.htmlNode('label', label_element.textContent);
-						new_label.setAttribute('for', label_element.previousElementSibling.id);
-						$(label_element).replaceWith(new_label);
+						// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
+						// to <label>Hello world</label>
+						label_element.innerHTML = label_element.textContent;
 					});
 					// allCheckboxDivs and allHeaders are defined globally, rather than in
 					// this function, to avoid having to recompute them on every keydown.

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -612,6 +612,9 @@ Twinkle.tag.updateSortOrder = function(e) {
 	allCheckboxDivs = $workarea.find('[name=articleTags], [name=alreadyPresentArticleTags]').parent();
 	allHeaders = $workarea.find('h5, .quickformDescription');
 
+	// clear search, because the search results are not preserved over mode change
+	e.target.form.quickfilter.value = '';
+
 	// style adjustments
 	$workarea.find("h5").css({ 'font-size': '110%' });
 	$workarea.find("h5:not(:first-child)").css({ 'margin-top': '1em' });


### PR DESCRIPTION
This is gonna be popular! Now that finding tags has become so easy (closes #621), we can add more tags to Twinkle without fear of cluttering the interface. 

Tested on IE 11. Everything works. (Though it works a bit slow on IE.)

A question to be pondered on:  When there are no search results, should the work area be empty (as is now the case), or should it show all tags?