### PR TITLE
xfd: Update regex for removing already-present AfD tags

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -680,7 +680,7 @@ Twinkle.xfd.callbacks = {
 			}
 
 			// Check for existing AfD tag, for the benefit of new page patrollers
-			var textNoAfd = text.replace(/\{\{\s*(Article for deletion\/dated|AfDM)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, "");
+			var textNoAfd = text.replace(/<!--.*AfD.*\n\{\{(?:Article for deletion\/dated|AfDM).*\}\}\n<!--.*(?:\n<!--.*)?AfD.*(?:\s*\n)?/g, "");
 			if (text !== textNoAfd) {
 				if (confirm("An AfD tag was found on this article. Maybe someone beat you to it.  \nClick OK to replace the current AfD tag (not recommended), or Cancel to abandon your nomination.")) {
 					text = textNoAfd;


### PR DESCRIPTION
Basically just copy the regex from `friendlytag.js` after #642 and #579.  This was sorely out of date, last updated in 2011: https://github.com/azatoth/twinkle/commit/c97229cda5be87957f5f2c05afff3e78f56baea5#diff-9abab93ad76ea1bab110fe90748fb6eaR455.  Certainly an unlikely occurence.

Co-authored-by: Amory Meltzer <Amorymeltzer@gmail.com>
Co-authored-by: Siddharth VP <siddharthvp@gmail.com>