### PR TITLE
tag: rm Cleanup SVG, merged with/redirected to Cleanup image

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1112,18 +1112,10 @@ Twinkle.tag.file.cleanupList = [
 	{ label: '{{Bad GIF}}: GIF that should be PNG, JPEG, or SVG', value: 'Bad GIF' },
 	{ label: '{{Bad JPEG}}: JPEG that should be PNG or SVG', value: 'Bad JPEG' },
 	{ label: '{{Bad trace}}: auto-traced SVG requiring cleanup', value: 'Bad trace' },
-	{ 	label: '{{Cleanup image}}: general cleanup', value: 'Cleanup image',
+	{	label: '{{Cleanup image}}: general cleanup', value: 'Cleanup image',
 		subgroup: {
 			type: 'input',
 			name: 'cleanupimageReason',
-			label: 'Reason: ',
-			tooltip: 'Enter the reason for cleanup (required)'
-		}
-	},
-	{ 	label: '{{Cleanup SVG}}: SVG needing code and/or appearance cleanup', value: 'Cleanup SVG',
-		subgroup: {
-			type: 'input',
-			name: 'cleanupsvgReason',
 			label: 'Reason: ',
 			tooltip: 'Enter the reason for cleanup (required)'
 		}
@@ -1885,9 +1877,6 @@ Twinkle.tag.callbacks = {
 					case "Cleanup image":
 						currentTag += '|1=' + params.cleanupimageReason;
 						break;
-					case "Cleanup SVG":
-						currentTag += '|1=' + params.cleanupsvgReason;
-						break;
 					case "Image-Poor-Quality":
 						currentTag += '|1=' + params.ImagePoorQualityReason;
 						break;
@@ -2013,8 +2002,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 
 		case 'file':
 
-			if( (params.tags.indexOf('Cleanup image') !== -1 && params.cleanupimageReason === '') ||
-				(params.tags.indexOf('Cleanup svg') !== -1 && params.cleanupsvgReason === '') ) {
+			if( (params.tags.indexOf('Cleanup image') !== -1 && params.cleanupimageReason === '') ) {
 				alert( 'You must specify a reason for the cleanup tag.' );
 				return;
 			}


### PR DESCRIPTION
[Redirected](https://en.wikipedia.org/w/index.php?oldid=899944699#Unused_type_parameter_by_Template:Cleanup-SVG) after [merge from TfD](https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2019_April_3#Template:Cleanup-SVG)