### PR TITLE
fluff: Use $.escapeSelector for a better way of doing c0e100a

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -85,7 +85,7 @@ Twinkle.fluff = {
 			revVandNode.appendChild(revVandLink);
 
 			apiobj.params.list.each(function(key, current) {
-				var title = apiobj.params.titles[key].replace(/(['"])/g, '\\$1'); // Don't die on pages with ' or " in the title
+				var title = $.escapeSelector(apiobj.params.titles[key]); // Don't die on pages with ' or " in the title
 				var page = $(xmlDoc).find("page[title='" + title + "']");
 				var canEdit = page.find('actions').attr('edit');
 


### PR DESCRIPTION
Likely overkill, but probably a good idea per https://github.com/azatoth/twinkle/commit/c0e100aece5b75a844d3e2783ef4d3d6a4314298#r33823969

Co-authored-by: Amory Meltzer <Amorymeltzer@gmail.com>
Co-authored-by: Siddharth VP <siddharthvp@gmail.com>