### PR TITLE
Fluff partial 632 revert

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -580,7 +580,13 @@ Twinkle.fluff.init = function twinklefluffinit() {
 		];
 
 		if ( Morebits.queryString.exists( 'twinklerevert' ) ) {
-			Twinkle.fluff.auto();
+			// Return if the user can't edit the page in question
+			if (!mw.config.get('wgIsProbablyEditable')) {
+				alert("Unable to edit the page, it's probably protected.");
+				return;
+			} else {
+				Twinkle.fluff.auto();
+			}
 		} else if( mw.config.get('wgCanonicalSpecialPageName') === "Contributions" ) {
 			Twinkle.fluff.contributions();
 		} else if (mw.config.get('wgIsProbablyEditable')) {


### PR DESCRIPTION
Revert hiding of links for uneditable pages on contribs (partially revert #632). 
 `intestactions` is limited to 50 unique pages for most users, so this would short-circuit otherwise.  See discussion in #632.

2nd commit alerts and returns rather than attempt auto() if the page is not editable.

cc @siddharthvp and @pppery 