### PR TITLE
warn: make jquery.chosen based menu optional, via-opt-out

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -672,6 +672,14 @@ Twinkle.config.sections = [
 			type: "boolean"
 		},
 
+		// TwinkleConfig.oldSelect (boolean)
+		// if true, use the native select menu rather the jquery chosen-based one
+		{
+			name: "oldSelect",
+			label: "Use the non-searchable classic select menu",
+			type: "boolean"
+		},
+
 		{
 			name: "customWarningList",
 			label: "Custom warning templates to display",
@@ -1697,7 +1705,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 	text +=
 		";\n" +
 		"\n" +
-		"// </no" + "wiki>\n" + 
+		"// </no" + "wiki>\n" +
 		"// End of twinkleoptions.js\n";
 
 	pageobj.setPageText(text);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1071,7 +1071,9 @@ Twinkle.warn.prev_article = null;
 Twinkle.warn.prev_reason = null;
 
 Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCategory(e) {
-	$("select[name=sub_group]").chosen("destroy");
+	if (!Twinkle.getPref('oldSelect')) {
+		$("select[name=sub_group]").chosen("destroy");
+	}
 
 	var value = e.target.value;
 	var sub_group = e.target.root.sub_group;
@@ -1149,10 +1151,12 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		} );
 	}
 
-	$('select[name=sub_group]').chosen({width: '100%', search_contains: true});
+	if (!Twinkle.getPref('oldSelect')) {
+		$('select[name=sub_group]').chosen({width: '100%', search_contains: true});
 
-	// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
-	$('.chosen-results').css({'overflow': 'auto', 'max-height': '180px'});
+		// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
+		$('.chosen-results').css({'overflow': 'auto', 'max-height': '180px'});
+	}
 
 	// clear overridden label on article textbox
 	Morebits.quickForm.setElementTooltipVisibility(e.target.root.article, true);

--- a/twinkle.js
+++ b/twinkle.js
@@ -103,6 +103,7 @@ Twinkle.defaultConfig.twinkle = {
 	defaultWarningGroup: "1",
 	showSharedIPNotice: true,
 	watchWarnings: true,
+	oldSelect: false,
 	customWarningList: [],
 	autoMenuAfterRollback: false,
 
@@ -294,7 +295,7 @@ Twinkle.addPortlet = function( navigation, id, text, type, nextnodeid )
 		root.appendChild( outerDiv );
 	}
 
-	if( outerDivClass === "vectorMenu" ) {	
+	if( outerDivClass === "vectorMenu" ) {
 		// add invisible checkbox to make menu keyboard accessible
 		// similar to the p-cactions ("More") menu
 		var chkbox = document.createElement( "input" );
@@ -304,7 +305,7 @@ Twinkle.addPortlet = function( navigation, id, text, type, nextnodeid )
 		outerDiv.appendChild( chkbox );
 	}
 	var h5 = document.createElement( "h3" );
-	if(outerDivClass === "vectorMenu") { 
+	if(outerDivClass === "vectorMenu") {
 		h5.id = "p-twinkle-label";
 	}
 	if ( type === "menu" ) {


### PR DESCRIPTION
Per discussion at [[Wikipedia_talk:Twinkle#User_warning_dialog_dropdown_selector]]

The reason some folks don't like this is because chosen makes the select menu much less denser, requiring more scrolling to get to the templates, and this also seems to give undue focus to `{{uw-` part of the templates. 