### PR TITLE
warn: remove padding from chosen's li elements

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1161,11 +1161,15 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 
 	// Build select menu with jquery.chosen
 	if (!Twinkle.getPref('oldSelect')) {
-		$('select[name=sub_group]').chosen({width: '100%', search_contains: true}).change(function(e) {
-			Twinkle.warn.callback.change_subcategory(e);
-		});
+		$('select[name=sub_group]')
+			.chosen({width: '100%', search_contains: true})
+			.change(Twinkle.warn.callback.change_subcategory);
+
 		// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
 		$('.chosen-results').css({'overflow': 'auto', 'max-height': '180px'});
+
+		// Remove padding
+		mw.util.addCSS('.chosen-drop .chosen-results li { padding-top: 0px; padding-bottom: 0px; }');
 	}
 };
 


### PR DESCRIPTION
Increases the density of the select menu. Use padding of 1px on search results for clarity.

@Amorymeltzer Don't know what was happening earlier, but this seems to be working fine now with `mw.util.addCSS`. Tested on multiple browsers. The jquery css solution won't work because the `li` elements are not added into DOM until the select is clicked the first time, so the jquery selection is of 0 length. 

If this is working for you too, can you deploy this live immediately, so that people can try it out (and probably change their opinion about the new interface😎) ?