### PR TITLE
warn/xfd: force chosen select menu to display over the dialog; padding fix in xfd

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1165,11 +1165,15 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			.chosen({width: '100%', search_contains: true})
 			.change(Twinkle.warn.callback.change_subcategory);
 
-		// Limit the max height of select dropdown to prevent dialog box from becoming scrollable
-		$('.chosen-results').css({'overflow': 'auto', 'max-height': '180px'});
+		mw.util.addCSS(
+			// Force chosen select menu to display over the dialog while overflowing
+			// https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
+			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
+			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
 
-		// Remove padding
-		mw.util.addCSS('.chosen-drop .chosen-results li { padding-top: 0px; padding-bottom: 0px; }');
+			// Remove padding
+			'.morebits-dialog .chosen-drop .chosen-results li { padding-top: 0px; padding-bottom: 0px; }'
+		);
 	}
 };
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -258,6 +258,16 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			.attr('data-placeholder', 'Select delsort pages')
 			.chosen({width: "100%"});
 
+		mw.util.addCSS(
+			// Force chosen select menu to display over the dialog while overflowing
+			// based on https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
+			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
+			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
+
+			// Reduce padding
+			'.morebits-dialog .chosen-drop .chosen-results li { padding-top: 2px; padding-bottom: 2px; }'
+		);
+
 		break;
 	case 'tfd':
 		work_area = new Morebits.quickForm.element( {
@@ -318,7 +328,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 							name: 'noinclude',
 							tooltip: 'Will wrap the deletion tag in &lt;noinclude&gt; tags, so that it won\'t get substituted along with the template.',
 							disabled: templateOrModule === 'module',
-							checked: !!$('.box-Subst_only').length // Default to checked if page carries {{subst only}} 
+							checked: !!$('.box-Subst_only').length // Default to checked if page carries {{subst only}}
 						}
 					]
 			} );


### PR DESCRIPTION
Removes the need to set a max-height to it. Also enables more templates to be viewed without having to scroll.

Code credits: https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245

Would have added this to #662 hadn't it been merged by now.