### PR TITLE
warn: increase height of chosen select

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1167,9 +1167,13 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 
 		mw.util.addCSS(
 			// Force chosen select menu to display over the dialog while overflowing
-			// https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
+			// based on https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
 			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
 			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
+
+			// Increase height to match that of native select
+			'.morebits-dialog .chosen-drop .chosen-results { max-height: 300px; }' +
+			'.morebits-dialog .chosen-drop { height: 338px; }' +
 
 			// Remove padding
 			'.morebits-dialog .chosen-drop .chosen-results li { padding-top: 0px; padding-bottom: 0px; }'


### PR DESCRIPTION
To match the height of the native select menu. 

Just this one more. Exact same number of templates will now be displayed as the earlier select menu did. This aims at making the transition to the new menu as smooth as possible. Now the reasons why anyone would dislike the new menu are almost null.