### PR TITLE
warn/xfd: chosen menu css fixes

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1163,15 +1163,18 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	if (!Twinkle.getPref('oldSelect')) {
 		$('select[name=sub_group]')
 			.chosen({width: '100%', search_contains: true})
-			.change(Twinkle.warn.callback.change_subcategory);
+			.change(Twinkle.warn.callback.change_subcategory)
+			.on('chosen:showing_dropdown', function () {
+				$(this).parents('div').css('overflow', 'visible');
+				$('#twinklewarn-previewbox').css({ 'max-height': '100px', 'overflow': 'hidden' });
+			})
+			.on('chosen:hiding_dropdown', function () {
+				$(this).parents('div').css('overflow', '');
+				$('#twinklewarn-previewbox').css({ 'max-height': '', 'overflow': '' });
+			});
 
 		mw.util.addCSS(
-			// Force chosen select menu to display over the dialog while overflowing
-			// based on https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
-			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
-			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
-
-			// Increase height to match that of native select
+			// Increase height
 			'.morebits-dialog .chosen-drop .chosen-results { max-height: 300px; }' +
 			'.morebits-dialog .chosen-drop { height: 338px; }' +
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -256,15 +256,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 		$(work_area).find('[name=delsort]')
 			.attr('data-placeholder', 'Select delsort pages')
-			.chosen({width: "100%"});
+			.chosen({width: "100%"})
+			.on('chosen:showing_dropdown', function () {
+				$(this).parents('div').css('overflow', 'visible');
+				$('#twinklexfd-previewbox').css({ 'max-height': '100px', 'overflow': 'hidden' });
+			})
+			.on('chosen:hiding_dropdown', function () {
+				$(this).parents('div').css('overflow', '');
+				$('#twinklexfd-previewbox').css({ 'max-height': '', 'overflow': '' });
+			});
 
+		// Reduce padding
 		mw.util.addCSS(
-			// Force chosen select menu to display over the dialog while overflowing
-			// based on https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
-			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
-			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
-
-			// Reduce padding
 			'.morebits-dialog .chosen-drop .chosen-results li { padding-top: 2px; padding-bottom: 2px; }'
 		);
 


### PR DESCRIPTION
Solves #665. Uses chosen:showing_dropdown and chosen:hiding_dropdown events to dynamically manipulate css properties.

As discussed: https://github.com/azatoth/twinkle/issues/665#issuecomment-500077949 and https://github.com/azatoth/twinkle/issues/665#issuecomment-500099207