### PR TITLE
ARV: Allow linking to redirects

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -533,7 +533,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			if ( form.page.value !== '' ) {
 
 				// Allows linking to redirects, file and category links work as links by default
-				reason = 'On {{no redirect|' + form.page.value + '}}';
+				reason = 'On {{:no redirect|' + form.page.value + '}}';
 
 				if ( form.badid.value !== '' ) {
 					reason += ' ({{diff|' + form.page.value + '|' + form.badid.value + '|' + form.goodid.value + '|diff}})';

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -532,8 +532,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 
 			if ( form.page.value !== '' ) {
 
-				// add a leading : on linked page namespace to prevent transclusion
-				reason = 'On [[' + form.page.value.replace( /^(Image|Category|File):/i, ':$1:' ) + ']]';
+				// Allows linking to redirects, file and category links work as links by default
+				reason = 'On {{-r|' + form.page.value + '}}';
 
 				if ( form.badid.value !== '' ) {
 					reason += ' ({{diff|' + form.page.value + '|' + form.badid.value + '|' + form.goodid.value + '|diff}})';

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -533,7 +533,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			if ( form.page.value !== '' ) {
 
 				// Allows linking to redirects, file and category links work as links by default
-				reason = 'On {{-r|' + form.page.value + '}}';
+				reason = 'On {{no redirect|' + form.page.value + '}}';
 
 				if ( form.badid.value !== '' ) {
 					reason += ' ({{diff|' + form.page.value + '|' + form.badid.value + '|' + form.goodid.value + '|diff}})';


### PR DESCRIPTION
So that reports such as https://w.wiki/4mC can work properly. Also eliminates the need to process categories and images to ensure that they are linked. {{-r}} used rather than {{no redirect}} to simplify wikitext.