### PR TITLE
warn/xfd: a few fixes for chosen css

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1166,16 +1166,22 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		mw.util.addCSS(
 			// Force chosen select menu to display over the dialog while overflowing
 			// based on https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
-			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
+			'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important; }' +
 			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
 
 			// Increase height to match that of native select
 			'.morebits-dialog .chosen-drop .chosen-results { max-height: 300px; }' +
-			'.morebits-dialog .chosen-drop { height: 338px; }' +
+			'.morebits-dialog .chosen-drop { max-height: 338px; }' +
 
 			// Remove padding
 			'.morebits-dialog .chosen-drop .chosen-results li { padding-top: 0px; padding-bottom: 0px; }'
 		);
+		// (Hopefully) temporary fixes for visual issues caused by the above CSS, see #665 and #667
+		$('.ui-resizable-handle').remove();
+		// Jump to extend the dialog to include any previewing content
+		// without scrolling and prevent resizing
+		mw.util.addCSS('.ui-dialog.morebits-dialog .morebits-dialog-content { max-height: max-content !important; }');
+
 	}
 };
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -258,15 +258,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				.attr('data-placeholder', 'Select delsort pages')
 				.chosen({width: '100%'});
 
-			mw.util.addCSS(
-			// Force chosen select menu to display over the dialog while overflowing
-			// based on https://github.com/harvesthq/chosen/issues/1390#issuecomment-21397245
-				'.ui-dialog.morebits-dialog .morebits-dialog-content { overflow:visible !important;}' +
-			'.ui-dialog.morebits-dialog { overflow: inherit !important; }' +
-
 			// Reduce padding
-			'.morebits-dialog .chosen-drop .chosen-results li { padding-top: 2px; padding-bottom: 2px; }'
-			);
+			mw.util.addCSS('.morebits-dialog .chosen-drop .chosen-results li { padding-top: 2px; padding-bottom: 2px; }');
 
 			break;
 		case 'tfd':


### PR DESCRIPTION
- Fix typo (mising `max-`) from #664
- Extend the dialog to encompass the full preview box (https://github.com/azatoth/twinkle/issues/665#issuecomment-499905637)
- Hide the resize handles to prevent visual incongruities (https://github.com/azatoth/twinkle/issues/665#issuecomment-500230270)
- Don't overlay chosen menu in xfd

@siddharthvp I think this covers the fixes we've (you've) come up with lately, and leaves us at a presentable, stable situation.