### PR TITLE
speedy: Allow P1 when multiple

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -858,8 +858,7 @@ Twinkle.speedy.portalList = [
 			name: 'p1_criterion',
 			type: 'input',
 			label: 'Article criterion that would apply: '
-		},
-		hideWhenMultiple: true
+		}
 	},
 	{
 		label: 'P2: Underpopulated portal',


### PR DESCRIPTION
- Added to Twinkle with hideWhenMultiple March 2011: https://github.com/azatoth/twinkle/commit/f56b4a54c9a31bdf56c72e461486b8ce9bce50cf
- Supported in notice template as of June 2012 rewrite: https://en.wikipedia.org/w/index.php?title=Template:Db-notice-multiple&diff=496436903&oldid=418576312
- Supported in Template:Db-multiple/item as of June 2018 rewrite: https://en.wikipedia.org/w/index.php?title=Template:Db-multiple/item&diff=845605071&oldid=845604422
- Named criteria support as of March 2019: https://en.wikipedia.org/w/index.php?title=Template:Db-multiple&diff=prev&oldid=887125742