### PR TITLE
batchprotect: Fix bug from OOUI-ification of Special:PrefixIndex

### DIFF
--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -283,9 +283,9 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		query = {
 			'action': 'query',
 			'generator': 'allpages',
-			'gapnamespace': Morebits.queryString.exists('namespace') ? Morebits.queryString.get('namespace') : document.getElementById('namespace').value,
+			'gapnamespace': Morebits.queryString.exists('namespace') ? Morebits.queryString.get('namespace') : $('select[name=namespace]').val(),
 			'gapprefix': Morebits.queryString.exists('from') ? Morebits.string.toUpperCaseFirstChar(Morebits.queryString.get('from').replace('+', ' ')) :
-				Morebits.string.toUpperCaseFirstChar(document.getElementById('nsfrom').value),
+				Morebits.string.toUpperCaseFirstChar($('input[name=prefix]').val()),
 			'gaplimit': Twinkle.getPref('batchMax'), // the max for sysops
 			'prop': 'revisions',
 			'rvprop': 'size'


### PR DESCRIPTION
Form changed May 2018 in https://phabricator.wikimedia.org/T117726 as part of 1.32.0-wmf.5.  Inserting `.firstChild` would also have worked.