### PR TITLE
morebits: replace + in Morebits.queryString (fix longstanding bug)

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3390,7 +3390,7 @@ Morebits.queryString = function QueryString(qString) {
 		return;
 	}
 
-	qString.replace(/\+/, ' ');
+	qString = qString.replace(/\+/g, ' ');
 	var args = qString.split('&');
 
 	for (var i = 0; i < args.length; ++i) {


### PR DESCRIPTION
`replace` doesn't touch the original string, so this line has done nothing for years: https://github.com/azatoth/twinkle/blob/71267fd4f1a0057c01ddc9ec5eb8ea40cf2a75be/morebits.js#L1937

As an example, using the form on Special:PrefixIndex creates urls like `https://test.wikipedia.org/wiki/Special:PrefixIndex?prefix=Articles+for+deletion%2F&namespace=4`, on which `twinklebatchdelete` would open empty, seeing no pages starting with *Articles+for+deletion*