### PR TITLE
morebits: pass api object to failure handlers wherever possible

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2650,7 +2650,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		// force error to stay on the screen
 		++Morebits.wiki.numberOfActionsLeft;
 
-		ctx.onSaveFailure(this);
+		ctx.onSaveFailure.call(this, ctx.saveApi);
 	};
 
 	// callback from saveApi.post()
@@ -2709,9 +2709,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				ctx.statusElement.error('Failed to save edit: ' + ctx.saveApi.getErrorText());
 			}
 			ctx.editMode = 'all';  // cancel append/prepend/revert modes
-			if (ctx.onSaveFailure) {
-				ctx.onSaveFailure(this);  // invoke callback
-			}
+			ctx.onSaveFailure.call(this, ctx.saveApi);  // invoke callback
 		}
 	};
 

--- a/morebits.js
+++ b/morebits.js
@@ -2313,7 +2313,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		if (fnCanUseMwUserToken('delete')) {
-			fnProcessDelete.call(this, this);
+			fnProcessDelete.call(this);
 		} else {
 			var query = {
 				action: 'query',
@@ -2354,7 +2354,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		if (fnCanUseMwUserToken('undelete')) {
-			fnProcessUndelete.call(this, this);
+			fnProcessUndelete.call(this);
 		} else {
 			var query = {
 				action: 'query',
@@ -3901,11 +3901,11 @@ Morebits.batchOperation = function(currentAction) {
 		}
 
 		ctx.countFinishedSuccess++;
-		fnDoneOne(apiobj);
+		fnDoneOne();
 	};
 
-	this.workerFailure = function(apiobj) {
-		fnDoneOne(apiobj);
+	this.workerFailure = function() {
+		fnDoneOne();
 	};
 
 	// private functions

--- a/morebits.js
+++ b/morebits.js
@@ -2739,7 +2739,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		if ($(xml).find('page').attr('missing') === '') {
 			ctx.statusElement.error('Cannot move the page, because it no longer exists');
-			ctx.onMoveFailure(this);
+			ctx.onMoveFailure.call(this, ctx.moveApi);
 			return;
 		}
 
@@ -2751,7 +2751,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				(editprot.attr('expiry') === 'infinity' ? '" (protected indefinitely)' : '" (protection expiring ' + editprot.attr('expiry') + ')') +
 				'.  \n\nClick OK to proceed with the move, or Cancel to skip this move.')) {
 				ctx.statusElement.error('Move of fully protected page was aborted.');
-				ctx.onMoveFailure(this);
+				ctx.onMoveFailure.call(this, ctx.moveApi);
 				return;
 			}
 		}
@@ -2759,7 +2759,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		var moveToken = $(xml).find('page').attr('movetoken');
 		if (!moveToken) {
 			ctx.statusElement.error('Failed to retrieve move token.');
-			ctx.onMoveFailure(this);
+			ctx.onMoveFailure.call(this, ctx.moveApi);
 			return;
 		}
 
@@ -2774,7 +2774,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.movetalk = 'true';
 		}
 		if (ctx.moveSubpages) {
-			query.movesubpages = 'true';  // XXX don't know whether this works for non-admins
+			query.movesubpages = 'true';  
 		}
 		if (ctx.moveSuppressRedirect) {
 			query.noredirect = 'true';

--- a/morebits.js
+++ b/morebits.js
@@ -2774,7 +2774,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.movetalk = 'true';
 		}
 		if (ctx.moveSubpages) {
-			query.movesubpages = 'true';  
+			query.movesubpages = 'true';
 		}
 		if (ctx.moveSuppressRedirect) {
 			query.noredirect = 'true';
@@ -2954,12 +2954,12 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		var missing = $(xml).find('page').attr('missing') === '';
 		if ((ctx.protectEdit || ctx.protectMove) && missing) {
 			ctx.statusElement.error('Cannot protect the page, because it no longer exists');
-			ctx.onProtectFailure(this);
+			ctx.onProtectFailure.call(this, ctx.protectApi);
 			return;
 		}
 		if (ctx.protectCreate && !missing) {
 			ctx.statusElement.error('Cannot create protect the page, because it already exists');
-			ctx.onProtectFailure(this);
+			ctx.onProtectFailure.call(this, ctx.protectApi);
 			return;
 		}
 
@@ -2968,7 +2968,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		var protectToken = $(xml).find('page').attr('protecttoken');
 		if (!protectToken) {
 			ctx.statusElement.error('Failed to retrieve protect token.');
-			ctx.onProtectFailure(this);
+			ctx.onProtectFailure.call(this, ctx.protectApi);
 			return;
 		}
 

--- a/morebits.js
+++ b/morebits.js
@@ -2799,7 +2799,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 			if ($(xml).find('page').attr('missing') === '') {
 				ctx.statusElement.error('Cannot delete the page, because it no longer exists');
-				ctx.onDeleteFailure(this);
+				ctx.onDeleteFailure.call(this, ctx.deleteApi);
 				return;
 			}
 
@@ -2810,14 +2810,14 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				(editprot.attr('expiry') === 'infinity' ? '" (protected indefinitely)' : '" (protection expiring ' + editprot.attr('expiry') + ')') +
 				'.  \n\nClick OK to proceed with the deletion, or Cancel to skip this deletion.')) {
 				ctx.statusElement.error('Deletion of fully protected page was aborted.');
-				ctx.onDeleteFailure(this);
+				ctx.onDeleteFailure.call(this, ctx.deleteApi);
 				return;
 			}
 
 			token = $(xml).find('page').attr('deletetoken');
 			if (!token) {
 				ctx.statusElement.error('Failed to retrieve delete token.');
-				ctx.onDeleteFailure(this);
+				ctx.onDeleteFailure.call(this, ctx.deleteApi);
 				return;
 			}
 
@@ -2853,20 +2853,14 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			// this is pathetic, but given the current state of Morebits.wiki.page it would
 			// be a dog's breakfast to try and fix this
 			ctx.statusElement.error('Invalid token. Please refresh the page and try again.');
-			if (ctx.onDeleteFailure) {
-				ctx.onDeleteFailure.call(this, this, ctx.deleteProcessApi);
-			}
+			ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);
 		} else if (errorCode === 'missingtitle') {
 			ctx.statusElement.error('Cannot delete the page, because it no longer exists');
-			if (ctx.onDeleteFailure) {
-				ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
-			}
+			ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
 		// hard error, give up
 		} else {
 			ctx.statusElement.error('Failed to delete the page: ' + ctx.deleteProcessApi.getErrorText());
-			if (ctx.onDeleteFailure) {
-				ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
-			}
+			ctx.onDeleteFailure.call(this, ctx.deleteProcessApi);  // invoke callback
 		}
 	};
 

--- a/morebits.js
+++ b/morebits.js
@@ -2882,7 +2882,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 			if ($(xml).find('page').attr('missing') !== '') {
 				ctx.statusElement.error('Cannot undelete the page, because it already exists');
-				ctx.onUndeleteFailure(this);
+				ctx.onUndeleteFailure.call(this, ctx.undeleteApi);
 				return;
 			}
 
@@ -2893,7 +2893,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				(editprot.attr('expiry') === 'infinity' ? '" (protected indefinitely)' : '" (protection expiring ' + editprot.attr('expiry') + ')') +
 				'.  \n\nClick OK to proceed with the undeletion, or Cancel to skip this undeletion.')) {
 				ctx.statusElement.error('Undeletion of fully create protected page was aborted.');
-				ctx.onUndeleteFailure(this);
+				ctx.onUndeleteFailure.call(this, ctx.undeleteApi);
 				return;
 			}
 
@@ -2931,20 +2931,15 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			// this is pathetic, but given the current state of Morebits.wiki.page it would
 			// be a dog's breakfast to try and fix this
 			ctx.statusElement.error('Invalid token. Please refresh the page and try again.');
-			if (ctx.onUndeleteFailure) {
-				ctx.onUndeleteFailure.call(this, this, ctx.undeleteProcessApi);
-			}
+			ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);
+
 		} else if (errorCode === 'cantundelete') {
 			ctx.statusElement.error('Cannot undelete the page, either because there are no revisions to undelete or because it has already been undeleted');
-			if (ctx.onUndeleteFailure) {
-				ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);  // invoke callback
-			}
+			ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);  // invoke callback
 		// hard error, give up
 		} else {
 			ctx.statusElement.error('Failed to undelete the page: ' + ctx.undeleteProcessApi.getErrorText());
-			if (ctx.onUndeleteFailure) {
-				ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);  // invoke callback
-			}
+			ctx.onUndeleteFailure.call(this, ctx.undeleteProcessApi);  // invoke callback
 		}
 	};
 


### PR DESCRIPTION
Pass the `morebits.wiki.api` object (rather than the `morebits.wiki.page` object) to the failure callbacks wherever possible, except where the error is being handled before any API calls are made (such as when trying to protect without being admin or without setting the protection settings). The apiobj is more useful since it has the `errorCode`, using which the client script may choose to show customised error messages. The pageobj is anyway still accessible as it is set as the `parent` attribute of apiobj in all usages.

Regarding the success callbacks, `save()` is currently giving the pageobj (useful to allow further processing with the page) while the other functions are giving the apiobj. No changes made here.

See individual commit messages for more details. 

This does not break any existing code.