### PR TITLE
Tweak warning edit summary

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1026,7 +1026,7 @@ Twinkle.warn.messages = {
 		},
 		'uw-multipleIPs': {
 			label: 'Usage of multiple IPs',
-			summary: 'Warning: Usage of multiple IPs'
+			summary: 'Warning: Vandalism using multiple IPs'
 		},
 		'uw-pinfo': {
 			label: 'Personal info',


### PR DESCRIPTION
As [suggested on wiki](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&diff=909964659&oldid=909865323), tweak warning edit summary for using multiple IPs to edit