### PR TITLE
Show G14 on redirects

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1056,8 +1056,7 @@ Twinkle.speedy.generalList = [
 	{
 		label: 'G14: Unnecessary disambiguation page',
 		value: 'disambig',
-		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.  It also applies to orphan "Foo (disambiguation)" redirects that target pages that are not disambiguation or similar disambiguation-like pages (such as set index articles or lists)',
-		hideWhenRedirect: true
+		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.  It also applies to orphan "Foo (disambiguation)" redirects that target pages that are not disambiguation or similar disambiguation-like pages (such as set index articles or lists)'
 	}
 ];
 


### PR DESCRIPTION
G14 also applies to redirects per discussion at https://en.wikipedia.org/wiki/Wikipedia_talk:Criteria_for_speedy_deletion/Archive_74#Modified_proposal (and see https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#G14_speedy_deletion_criterion_(add_for_redirects?) )