### PR TITLE
warn/xfd: Replace jquery.chosen menus with select2

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1206,18 +1206,20 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	// Use select2 to make the select menu searchable
 	if (!Twinkle.getPref('oldSelect') && $.fn.select2) {
 		$('select[name=sub_group]')
-			.select2({ width: '100%' })
+			.select2({
+				width: '100%',
+				matcher: Morebits.select2.matcher,
+				templateResult: Morebits.select2.highlightSearchMatches,
+				language: {
+					searching: Morebits.select2.queryInterceptor
+				}
+			})
 			.change(Twinkle.warn.callback.change_subcategory);
 
-		// if main_group is level1/2/3/4/4im, the ul has option groups,
-		if ($('select[name=main_group]').val().indexOf('level') === 0) {
-			Morebits.select2SearchHighlights($('select[name=sub_group]'), true);
-		} else {
-			Morebits.select2SearchHighlights($('select[name=sub_group]'), false);
-		}
+		$('.select2-selection').keydown(Morebits.select2.autoStart);
 
 		mw.util.addCSS(
-			// prevent dropdown from appearing behind the dialog
+			// prevent dropdown from appearing behind the dialog, just in case
 			'.select2-container { z-index: 10000; }' +
 
 			// Increase height
@@ -1227,7 +1229,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			'.select2-results .select2-results__option { padding-top: 1px; padding-bottom: 1px; }' +
 			'.select2-results .select2-results__group { padding-top: 1px; padding-bottom: 1px; } ' +
 
-			// Reduce font size
+			// Adjust font size
 			'.select2-container .select2-dropdown .select2-results { font-size: 13px; }' +
 			'.select2-container .selection .select2-selection__rendered { font-size: 13px; }'
 		);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1158,7 +1158,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	// Trigger custom label/change on main category change
 	Twinkle.warn.callback.change_subcategory(e);
 
-	// Build select menu with select2
+	// Use select2 to make the select menu searchable
 	if (!Twinkle.getPref('oldSelect') && $.fn.select2) {
 		$('select[name=sub_group]')
 			.select2({ width: '100%' })
@@ -1166,11 +1166,10 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 
 		// if main_group is level1/2/3/4/4im, the ul has option groups,
 		if ($('select[name=main_group]').val().indexOf('level') === 0) {
-			mw.select2SearchHighlights($('select[name=sub_group]'), true);
+			Morebits.select2SearchHighlights($('select[name=sub_group]'), true);
 		} else {
-			mw.select2SearchHighlights($('select[name=sub_group]'), false);
+			Morebits.select2SearchHighlights($('select[name=sub_group]'), false);
 		}
-
 
 		mw.util.addCSS(
 			// prevent dropdown from appearing behind the dialog
@@ -1187,7 +1186,6 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			'.select2-container .select2-dropdown .select2-results { font-size: 13px; }' +
 			'.select2-container .selection .select2-selection__rendered { font-size: 13px; }'
 		);
-
 	}
 };
 

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -16,10 +16,6 @@
 
 Twinkle.warn = function twinklewarn() {
 
-	if (!$.fn.select2) {
-		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
-		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
-	}
 	if (mw.config.get('wgRelevantUserName')) {
 		Twinkle.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
 		if (Twinkle.getPref('autoMenuAfterRollback') &&

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -16,9 +16,10 @@
 
 Twinkle.warn = function twinklewarn() {
 
-	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
-	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
-
+	if (!$.fn.select2) {
+		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
+		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
+	}
 	if (mw.config.get('wgRelevantUserName')) {
 		Twinkle.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
 		if (Twinkle.getPref('autoMenuAfterRollback') &&
@@ -1162,52 +1163,18 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	Twinkle.warn.callback.change_subcategory(e);
 
 	// Build select menu with select2
-	if (!Twinkle.getPref('oldSelect')) {
+	if (!Twinkle.getPref('oldSelect') && $.fn.select2) {
 		$('select[name=sub_group]')
 			.select2({ width: '100%' })
-			.change(Twinkle.warn.callback.change_subcategory)
+			.change(Twinkle.warn.callback.change_subcategory);
 
-			// select2 natively doesn't support highlightening of search hits so we implement that here
-			.on('select2:open', function() {
-				$('.select2-search__field')[0].addEventListener('keyup', function() {
-					var $ul = $('.select2-results__options');
-					$ul.find('.search-hit').each(function(i, e) {
-						var li_element = e.parentElement;
-						// This would convert <li>Hello <span class=search-hit>wo</span>rld</li>
-						// to <label>Hello world</label>
-						li_element.innerHTML = li_element.textContent;
-					});
+		// if main_group is level1/2/3/4/4im, the ul has option groups,
+		if ($('select[name=main_group]').val().indexOf('level') === 0) {
+			mw.select2SearchHighlights($('select[name=sub_group]'), true);
+		} else {
+			mw.select2SearchHighlights($('select[name=sub_group]'), false);
+		}
 
-					if (this.value) {
-						var searchString = this.value;
-						var searchRegex = new RegExp(mw.RegExp.escape(searchString), 'i');
-
-						var $selector;
-						// if main_group is level1/2/3/4/4im, the ul has option groups,
-						// select the group header (li > strong) and the list elements (li > ul > li),
-						// the odd way in which select2 organises the ul necessitates this hack
-						if ($('select[name=main_group]').val().indexOf('level') === 0) { // can probably write as this.value.indexOf('level') === 0
-							$selector = 'li > strong, li > ul > li';
-						} else {
-							$selector = 'li';
-						}
-
-						$ul.find($selector).each(function() {
-							var li_text = this.textContent;
-							var searchHit = searchRegex.exec(li_text);
-							if (searchHit) {
-								var range = document.createRange();
-								var textnode = this.childNodes[0];
-								range.selectNodeContents(textnode);
-								range.setStart(textnode, searchHit.index);
-								range.setEnd(textnode, searchHit.index + searchString.length);
-								var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
-								range.surroundContents(underline_span);
-							}
-						});
-					}
-				});
-			});
 
 		mw.util.addCSS(
 			// prevent dropdown from appearing behind the dialog

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -21,8 +21,10 @@ Twinkle.xfd = function twinklexfd() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && document.getElementById('mw-sharedupload'))) {
 		return;
 	}
-	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
-	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
+	if (!jQuery.fn.select2) {
+		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
+		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
+	}
 
 	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a deletion discussion');
 };
@@ -257,57 +259,33 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			work_area = work_area.render();
 			old_area.parentNode.replaceChild(work_area, old_area);
 
-			$(work_area).find('[name=delsort]')
-				.attr('data-placeholder', 'Select delsort pages')
-				.select2({width: '100%'})
+			if ($.fn.select2) {
+				$(work_area).find('[name=delsort]')
+					.attr('data-placeholder', 'Select delsort pages')
+					.select2({width: '100%'});
 
-				// select2 natively doesn't support highlightening of search hits so we implement that here
-				.on('select2:open', function() {
-					$('.select2-search__field')[0].addEventListener('keyup', function() {
-						var $ul = $('.select2-results__options');
-						$ul.find('.search-hit').each(function(i, e) {
-							var li_element = e.parentElement;
-							// This would convert <li>Hello <span class=search-hit>wo</span>rld</li>
-							// to <label>Hello world</label>
-							li_element.innerHTML = li_element.textContent;
-						});
-
-						if (this.value) {
-							var searchString = this.value;
-							var searchRegex = new RegExp(mw.RegExp.escape(searchString), 'i');
-							$ul.find('li > strong, li > ul > li').each(function() {
-								var li_text = this.textContent;
-								var searchHit = searchRegex.exec(li_text);
-								if (searchHit) {
-									var range = document.createRange();
-									var textnode = this.childNodes[0];
-									range.selectNodeContents(textnode);
-									range.setStart(textnode, searchHit.index);
-									range.setEnd(textnode, searchHit.index + searchString.length);
-									var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
-									range.surroundContents(underline_span);
-								}
-							});
-						}
-					});
-				});
-
-			// Reduce padding
-			mw.util.addCSS(
-				// prevent dropdown from appearing behind the dialog
-				'.select2-container { z-index: 10000; }' +
-
-				// Remove black border
-				'.select2-container--default.select2-container--focus .select2-selection--multiple { border: 1px solid #aaa; }' +
+				mw.select2SearchHighlights($('[name=delsort]'), true);
 
 				// Reduce padding
-				'.select2-results .select2-results__option { padding-top: 1px; padding-bottom: 1px; }' +
-				'.select2-results .select2-results__group { padding-top: 1px; padding-bottom: 1px; } ' +
+				mw.util.addCSS(
+					// prevent dropdown from appearing behind the dialog
+					'.select2-container { z-index: 10000; }' +
 
-				// Reduce font size
-				'.select2-container .select2-dropdown .select2-results { font-size: 13px; }' +
-				'.select2-container .selection .select2-selection__rendered { font-size: 13px; }'
-			);
+					// Remove black border
+					'.select2-container--default.select2-container--focus .select2-selection--multiple { border: 1px solid #aaa; }' +
+
+					// Reduce padding
+					'.select2-results .select2-results__option { padding-top: 1px; padding-bottom: 1px; }' +
+					'.select2-results .select2-results__group { padding-top: 1px; padding-bottom: 1px; } ' +
+
+					// Reduce font size
+					'.select2-container .select2-dropdown .select2-results { font-size: 13px; }' +
+					'.select2-container .selection .select2-selection__rendered { font-size: 13px; }' +
+
+					// Make the tiny cross larger
+					'.select2-selection__choice__remove { font-size: 130%; }'
+				);
+			}
 
 			break;
 		case 'tfd':

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -21,10 +21,6 @@ Twinkle.xfd = function twinklexfd() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && document.getElementById('mw-sharedupload'))) {
 		return;
 	}
-	if (!jQuery.fn.select2) {
-		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
-		mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
-	}
 
 	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a deletion discussion');
 };

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -260,9 +260,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 					.attr('data-placeholder', 'Select delsort pages')
 					.select2({width: '100%'});
 
-				mw.select2SearchHighlights($('[name=delsort]'), true);
-
-				// Reduce padding
+				Morebits.select2SearchHighlights($('[name=delsort]'), true);
 				mw.util.addCSS(
 					// prevent dropdown from appearing behind the dialog
 					'.select2-container { z-index: 10000; }' +

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -21,6 +21,9 @@ Twinkle.xfd = function twinklexfd() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId') || (mw.config.get('wgNamespaceNumber') === 6 && document.getElementById('mw-sharedupload'))) {
 		return;
 	}
+	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
+	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
+
 	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a deletion discussion');
 };
 
@@ -256,10 +259,55 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			$(work_area).find('[name=delsort]')
 				.attr('data-placeholder', 'Select delsort pages')
-				.chosen({width: '100%'});
+				.select2({width: '100%'})
+
+				// select2 natively doesn't support highlightening of search hits so we implement that here
+				.on('select2:open', function() {
+					$('.select2-search__field')[0].addEventListener('keyup', function() {
+						var $ul = $('.select2-results__options');
+						$ul.find('.search-hit').each(function(i, e) {
+							var li_element = e.parentElement;
+							// This would convert <li>Hello <span class=search-hit>wo</span>rld</li>
+							// to <label>Hello world</label>
+							li_element.innerHTML = li_element.textContent;
+						});
+
+						if (this.value) {
+							var searchString = this.value;
+							var searchRegex = new RegExp(mw.RegExp.escape(searchString), 'i');
+							$ul.find('li > strong, li > ul > li').each(function() {
+								var li_text = this.textContent;
+								var searchHit = searchRegex.exec(li_text);
+								if (searchHit) {
+									var range = document.createRange();
+									var textnode = this.childNodes[0];
+									range.selectNodeContents(textnode);
+									range.setStart(textnode, searchHit.index);
+									range.setEnd(textnode, searchHit.index + searchString.length);
+									var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
+									range.surroundContents(underline_span);
+								}
+							});
+						}
+					});
+				});
 
 			// Reduce padding
-			mw.util.addCSS('.morebits-dialog .chosen-drop .chosen-results li { padding-top: 2px; padding-bottom: 2px; }');
+			mw.util.addCSS(
+				// prevent dropdown from appearing behind the dialog
+				'.select2-container { z-index: 10000; }' +
+
+				// Remove black border
+				'.select2-container--default.select2-container--focus .select2-selection--multiple { border: 1px solid #aaa; }' +
+
+				// Reduce padding
+				'.select2-results .select2-results__option { padding-top: 1px; padding-bottom: 1px; }' +
+				'.select2-results .select2-results__group { padding-top: 1px; padding-bottom: 1px; } ' +
+
+				// Reduce font size
+				'.select2-container .select2-dropdown .select2-results { font-size: 13px; }' +
+				'.select2-container .selection .select2-selection__rendered { font-size: 13px; }'
+			);
 
 			break;
 		case 'tfd':

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -262,11 +262,17 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			if ($.fn.select2) {
 				$(work_area).find('[name=delsort]')
 					.attr('data-placeholder', 'Select delsort pages')
-					.select2({width: '100%'});
+					.select2({
+						width: '100%',
+						matcher: Morebits.select2.matcher,
+						templateResult: Morebits.select2.highlightSearchMatches,
+						language: {
+							searching: Morebits.select2.queryInterceptor
+						}
+					});
 
-				Morebits.select2SearchHighlights($('[name=delsort]'), true);
 				mw.util.addCSS(
-					// prevent dropdown from appearing behind the dialog
+					// prevent dropdown from appearing behind the dialog, just in case
 					'.select2-container { z-index: 10000; }' +
 
 					// Remove black border
@@ -276,7 +282,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 					'.select2-results .select2-results__option { padding-top: 1px; padding-bottom: 1px; }' +
 					'.select2-results .select2-results__group { padding-top: 1px; padding-bottom: 1px; } ' +
 
-					// Reduce font size
+					// Adjust font size
 					'.select2-container .select2-dropdown .select2-results { font-size: 13px; }' +
 					'.select2-container .selection .select2-selection__rendered { font-size: 13px; }' +
 

--- a/morebits.js
+++ b/morebits.js
@@ -1159,7 +1159,7 @@ Morebits.array = {
  * @requires select2
  */
 Morebits.select2SearchHighlights = function select2SearchHighlights($select, hasOptionGroups) {
-	$select.on('select2:open', function() {
+	$select.off('select2:open').on('select2:open', function() {
 		$('.select2-search__field')[0].addEventListener('keyup', function() {
 			var $ul = $('.select2-results__options');
 			$ul.find('.search-hit').each(function(_, e) {
@@ -1171,7 +1171,7 @@ Morebits.select2SearchHighlights = function select2SearchHighlights($select, has
 
 			if (this.value) {
 				var searchString = this.value;
-				var searchRegex = new RegExp(mw.RegExp.escape(searchString), 'i');
+				var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
 
 				var selectorString;
 				// the odd way in which select2 organises the ul necessitates this hack

--- a/morebits.js
+++ b/morebits.js
@@ -1139,9 +1139,9 @@ Morebits.array = {
  * select2 doesn't natively support highlightening of search hits so we implement that here
  * @param {jQuery} $select
  * @param {boolean} [hasOptionGroups=false] - does the select menu have optgroups?
- * @requires {select2}
+ * @requires select2
  */
-mw.select2SearchHighlights = function select2SearchHighlights($select, hasOptionGroups) {
+Morebits.select2SearchHighlights = function select2SearchHighlights($select, hasOptionGroups) {
 	$select.on('select2:open', function() {
 		$('.select2-search__field')[0].addEventListener('keyup', function() {
 			var $ul = $('.select2-results__options');

--- a/morebits.js
+++ b/morebits.js
@@ -1160,8 +1160,8 @@ Morebits.array = {
  */
 Morebits.select2SearchHighlights = function select2SearchHighlights($select, hasOptionGroups) {
 	$select.off('select2:open').on('select2:open', function() {
+		var $ul = $('.select2-results__options');
 		$('.select2-search__field')[0].addEventListener('keyup', function() {
-			var $ul = $('.select2-results__options');
 			$ul.find('.search-hit').each(function(_, e) {
 				var li_element = e.parentElement;
 				// This would convert <li>Hello <span class=search-hit>wo</span>rld</li>

--- a/twinkle.js
+++ b/twinkle.js
@@ -438,10 +438,6 @@ Twinkle.load = function () {
 	// Set custom Api-User-Agent header, for server-side logging purposes
 	Morebits.wiki.api.setApiUserAgent('Twinkle/2.0 (' + mw.config.get('wgDBname') + ')');
 
-	// Load select2 library from Toolforge CDN, used in warn and xfd
-	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
-	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
-
 	// Load the modules in the order that the tabs should appear
 	// User/user talk-related
 	Twinkle.arv();

--- a/twinkle.js
+++ b/twinkle.js
@@ -449,6 +449,10 @@ Twinkle.load = function () {
 	// Set custom Api-User-Agent header, for server-side logging purposes
 	Morebits.wiki.api.setApiUserAgent('Twinkle/2.0 (' + mw.config.get('wgDBname') + ')');
 
+	// Load select2 library from Toolforge CDN, used in warn and xfd
+	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/js/select2.min.js');
+	mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.10/css/select2.min.css', 'text/css');
+
 	// Load the modules in the order that the tabs should appear
 	// User/user talk-related
 	Twinkle.arv();


### PR DESCRIPTION
Replace jQuery Chosen select menu with [select2](https://select2.org/). 

This fully fixes the bug [described here](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_41#Long_previews_overlap_and_block_%22Submit%22_button) (closes #665), also eliminating the stop-gap solution of removing the resize handles. The problems associated with using jquery.chosen within a modal dialog (like in all TW scripts) are not there in select2. Also, select2 is better both in terms of customizability and programmatic control, not to mention having a proper documentation (unlike chosen). Select2 unfortunately doesn't natively support highlighting of search results, so I have implemented that manually (as I did in Tag module).

Select2 is being loaded using the CDN, which is obviously non-ideal, especially since the support for loading of scripts from non-WMF sites may likely be removed in the future. Before that happens, we should get select2 added to the ResourceLoader, maybe as a replacement to chosen. 