### PR TITLE
tag: add {{short description}} to hatnotes regex

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1624,7 +1624,7 @@ Twinkle.tag.callbacks = {
 					// PROD
 					'(?:proposed deletion|prod blp)\\/dated(?:\\s*\\|(?:concern|user|timestamp|help).*)+|' +
 					// various hatnote templates
-					'about|correct title|dablink|distinguish|for|other\\s?(?:hurricaneuses|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|the' +
+					'about|correct title|dablink|distinguish|for|other\\s?(?:hurricaneuses|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|short description|the' +
 					// not a hatnote, but sometimes under a CSD or AfD
 					'|salt|proposed deletion endorsed' +
 					// end main template name, optionally with a number (such as redirect2)


### PR DESCRIPTION
This makes the tags get placed below the hatnotes on pages where {{short description}} is present at the top.

Bug was reported at [TW talk page](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Bug:_Failure_to_place_maintenance_tags_below_hatnotes_when_there's_also_a_short_description_template).