### PR TITLE
tag: re-add {{dead end}}, add {{sources exist}} per requests

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -754,6 +754,7 @@ Twinkle.tag.article.tags = {
 	'Rough translation': 'poor translation from another language',
 	'Sections': 'needs to be divided into sections by topic',
 	'Self-published': 'contains excessive or inappropriate references to self-published sources',
+	'Sources exist': 'notable topic, sources are available that could be added to article',
 	'Technical': 'too technical for most readers to understand',
 	'Third-party': 'relies too heavily on sources too closely associated with the subject',
 	'Tone': 'tone or style may not reflect the encyclopedic tone used on Wikipedia',
@@ -860,6 +861,7 @@ Twinkle.tag.article.tagCategories = {
 			'Original research',
 			'Primary sources',
 			'Self-published',
+			'Sources exist',
 			'Third-party',
 			'Unreferenced',
 			'Unreliable sources'

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -706,6 +706,7 @@ Twinkle.tag.article.tags = {
 	'Copy edit': 'requires copy editing for grammar, style, cohesion, tone, or spelling',
 	'Copypaste': 'appears to have been copied and pasted from another location',
 	'Current': 'documents a current event',
+	'Dead end': 'article has no links to other articles',
 	'Disputed': 'questionable factual accuracy',
 	'Essay-like': 'written like a personal reflection, personal essay, or argumentative essay',
 	'Expand language': 'should be expanded with text translated from a foreign-language article',
@@ -871,6 +872,7 @@ Twinkle.tag.article.tagCategories = {
 			'Expand language'
 		],
 		'Links': [
+			'Dead end',
 			'Orphan',
 			'Overlinked',
 			'Underlinked'


### PR DESCRIPTION
Now that the interface supports search, clutter is no longer a reason for removing templates.
Adding back {{dead end}} was requested [here](https://en.wikipedia.org/wiki/Wt:Twinkle/Archive_41#{{Dead_end}}_has_disappeared). Also adding {{sources exist}}, requested [here](https://en.wikipedia.org/wiki/Wt:Twinkle/Archive_39#Can_we_please_add_the_{{Sources_exist}}_Tag?)