### PR TITLE
update mw.RegExp.escape to mw.util.escapeRegex

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -94,7 +94,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 						allCheckboxDivs.hide();
 						allHeaders.hide();
 						var searchString = this.value;
-						var searchRegex = new RegExp(mw.RegExp.escape(searchString), 'i');
+						var searchRegex = new RegExp(mw.util.escapeRegex(searchString), 'i');
 
 						$form.find('label').each(function() {
 							var label_text = this.textContent;

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1080,7 +1080,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	var old_subvalue_re;
 	if (old_subvalue) {
 		old_subvalue = old_subvalue.replace(/\d*(im)?$/, '');
-		old_subvalue_re = new RegExp(mw.RegExp.escape(old_subvalue) + '(\\d*(?:im)?)$');
+		old_subvalue_re = new RegExp(mw.util.escapeRegex(old_subvalue) + '(\\d*(?:im)?)$');
 	}
 
 	while (sub_group.hasChildNodes()) {

--- a/morebits.js
+++ b/morebits.js
@@ -961,7 +961,7 @@ HTMLFormElement.prototype.getUnchecked = function(name, type) {
  */
 
 RegExp.escape = function(text, space_fix) {
-	text = mw.RegExp.escape(text);
+	text = mw.util.escapeRegex(text);
 
 	// Special MediaWiki escape - underscore/space are often equivalent
 	if (space_fix) {


### PR DESCRIPTION
Apparently, the former has now been deprecated in favour of the latter.

The `mediawiki.RegExp` dependency can be dropped now.