### PR TITLE
Correctly notify the creator of article, if it began as a redirect

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -204,6 +204,7 @@ Twinkle.prod.callbacks = {
 		var ts = new Morebits.wiki.page(mw.config.get('wgPageName'));
 		ts.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
 		ts.setCallbackParameters(params);
+		ts.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
 		ts.lookupCreation(Twinkle.prod.callbacks.creationInfo);
 	},
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -716,6 +716,7 @@ Twinkle.xfd.callbacks = {
 			if (params.usertalk) {
 				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
+				thispage.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
 				thispage.lookupCreation(Twinkle.xfd.callbacks.afd.userNotification);
 			}
 


### PR DESCRIPTION
I have tweaked Morebits.wiki.page.prototype.lookupCreation so that an option is now available which if set, the function would return the username/timestamp of the creation of the first non-redirect version of the article. 

I have then put this into use for AFD and PROD notifications, since in these cases we unambiguously want to notify the real article creator rather than the redirect creator. We should perhaps also try to incorporate this somehow to CSD, but I guess that it's a bit trickier. 

I guess this is long-requested feature, and should be very helpful to the project as now people who create articles from redirects would not remain in the dark when their work is sent to the gallows. Also, this should help us crush the upcoming competition from PageCuration! 