### PR TITLE
Convert mw.RegExp.escape to mw.util.escapeRegExp as the former is being deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are two ways to upload Twinkle scripts to Wikipedia or another destination
 
 After the files are synced, [MediaWiki:Gadgets-definition][] should contain the following lines:
 
-    * Twinkle[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.RegExp,mediawiki.notify,jquery.ui.dialog,jquery.tipsy,jquery.chosen,moment|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|morebits.js|morebits.css|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
+    * Twinkle[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.notify,jquery.ui.dialog,jquery.tipsy,jquery.chosen,moment|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|morebits.js|morebits.css|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
     * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
 
 `Twinkle-pagestyles` is a hidden [peer gadget](https://www.mediawiki.org/wiki/ResourceLoader/Migration_guide_(users)#Gadget_peers) of Twinkle. Before Twinkle has loaded, it adds space where the TW menu would go in the Vector skin, so that the top bar does not "jump".

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -94,7 +94,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 						allCheckboxDivs.hide();
 						allHeaders.hide();
 						var searchString = this.value;
-						var searchRegex = new RegExp(mw.RegExp.escape(searchString), 'i');
+						var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
 
 						$form.find('label').each(function() {
 							var label_text = this.textContent;

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1080,7 +1080,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 	var old_subvalue_re;
 	if (old_subvalue) {
 		old_subvalue = old_subvalue.replace(/\d*(im)?$/, '');
-		old_subvalue_re = new RegExp(mw.RegExp.escape(old_subvalue) + '(\\d*(?:im)?)$');
+		old_subvalue_re = new RegExp(mw.util.escapeRegExp(old_subvalue) + '(\\d*(?:im)?)$');
 	}
 
 	while (sub_group.hasChildNodes()) {

--- a/morebits.js
+++ b/morebits.js
@@ -19,7 +19,7 @@
  *   - Morebits.quickForm tooltips rely on Tipsy (ResourceLoader module name 'jquery.tipsy').
  *     For external installations, Tipsy is available at [http://onehackoranother.com/projects/jquery/tipsy].
  *   - To create a gadget based on morebits.js, use this syntax in MediaWiki:Gadgets-definition:
- *       * GadgetName[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.RegExp,jquery.ui.dialog,jquery.tipsy]|morebits.js|morebits.css|GadgetName.js
+ *       * GadgetName[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,jquery.ui.dialog,jquery.tipsy]|morebits.js|morebits.css|GadgetName.js
  *
  * Most of the stuff here doesn't work on IE < 9.  It is your script's responsibility to enforce this.
  *
@@ -961,7 +961,7 @@ HTMLFormElement.prototype.getUnchecked = function(name, type) {
  */
 
 RegExp.escape = function(text, space_fix) {
-	text = mw.RegExp.escape(text);
+	text = mw.util.escapeRegExp(text);
 
 	// Special MediaWiki escape - underscore/space are often equivalent
 	if (space_fix) {


### PR DESCRIPTION
See [T218339](https://phabricator.wikimedia.org/T218339); `mw.RegExp` has been deprecated and will be removed in MW-1.35, as the `escape` function was the only item in it (itself from a prior module).  The same function (different name) has since 2015 been already present in `mw.util`.

----
Tidied up from #708, cc @siddharthvp 