### PR TITLE
tag: Fix regression leaving generic {{merge}} instead of {{merge to}} or {{merge from}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1523,6 +1523,7 @@ Twinkle.tag.callbacks = {
 					case 'Merge':
 					case 'Merge to':
 					case 'Merge from':
+						params.mergeTag = tagName;
 						if (params.mergeTarget) {
 							// normalize the merge target for now and later
 							params.mergeTarget = Morebits.string.toUpperCaseFirstChar(params.mergeTarget.replace(/_/g, ' '));


### PR DESCRIPTION
As reported at [WT:TW](https://en.wikipedia.org/w/index.php?oldid=918480329#Merge_tags), Twinkle has been leaving `{{merge}}` on the other page when tagging with `{{merge to}}` or `{{merge from}}` (rather than `{{merge from}}` or `{{merge to}}`, respectively).

Stems from #485, where somewhere along the way the addition in [L1274](https://github.com/azatoth/twinkle/pull/485/commits/95eac797ab3b22d8bd63ecadc8fba8db226051ee#diff-03744d176dfd1e8a2178545886a87644R1606) at 95eac79 was removed but `params.mergeTag` remained.

I've added the line back when validating the various merge tags, since we're already evaluating them all.

\*cries in `.includes()`\*