### PR TITLE
tag: Indicate direction of merge in talk page notification header

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1240,15 +1240,15 @@ Twinkle.tag.callbacks = {
 			pageobj.save(function() {
 				// special functions for merge tags
 				if (params.mergeReason) {
+					// Use same language for talkpage header and edit summary
+					var direction = 'Proposing to merge [[:' + params.nonDiscussArticle + ']] ' + (params.mergeTag === 'Merge' ? 'with' : 'into') + ' [[:' + params.discussArticle + ']]';
 					// post the rationale on the talk page (only operates in main namespace)
-					var talkpageText = '\n\n== Proposed merge with [[' + params.nonDiscussArticle + ']] ==\n\n';
+					var talkpageText = '\n\n== ' + direction + '  ==\n\n';
 					talkpageText += params.mergeReason.trim() + ' ~~~~';
 
 					var talkpage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					talkpage.setAppendText(talkpageText);
-					talkpage.setEditSummary('Proposing to merge [[:' + params.nonDiscussArticle + ']] ' +
-						(params.mergeTag === 'Merge' ? 'with' : 'into') + ' [[:' + params.discussArticle + ']]' +
-						Twinkle.getPref('summaryAd'));
+					talkpage.setEditSummary(direction + Twinkle.getPref('summaryAd'));
 					talkpage.setWatchlist(Twinkle.getFriendlyPref('watchMergeDiscussions'));
 					talkpage.setCreateOption('recreate');
 					talkpage.append();

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1240,15 +1240,15 @@ Twinkle.tag.callbacks = {
 			pageobj.save(function() {
 				// special functions for merge tags
 				if (params.mergeReason) {
-					// Use same language for talkpage header and edit summary
-					var direction = 'Proposing to merge [[:' + params.nonDiscussArticle + ']] ' + (params.mergeTag === 'Merge' ? 'with' : 'into') + ' [[:' + params.discussArticle + ']]';
+					// Use similar language for talkpage header and edit summary
+					var direction = '[[:' + params.nonDiscussArticle + ']] ' + (params.mergeTag === 'Merge' ? 'with' : 'into') + ' [[:' + params.discussArticle + ']]';
 					// post the rationale on the talk page (only operates in main namespace)
-					var talkpageText = '\n\n== ' + direction + '  ==\n\n';
+					var talkpageText = '\n\n== Proposed merge of ' + direction + '  ==\n\n';
 					talkpageText += params.mergeReason.trim() + ' ~~~~';
 
 					var talkpage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					talkpage.setAppendText(talkpageText);
-					talkpage.setEditSummary(direction + Twinkle.getPref('summaryAd'));
+					talkpage.setEditSummary('Proposing to merge ' + direction + Twinkle.getPref('summaryAd'));
 					talkpage.setWatchlist(Twinkle.getFriendlyPref('watchMergeDiscussions'));
 					talkpage.setCreateOption('recreate');
 					talkpage.append();


### PR DESCRIPTION
[Requested at WT:TW](https://en.wikipedia.org/wiki/Special:Permalink/918911925#Merge_tags).  No reason not to match the edit summary, where we already did this, so let's just use the same language for everybody.