### PR TITLE
tag: Don't place {{current}} in MI

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -882,6 +882,7 @@ Twinkle.tag.article.tagCategories = {
 // Contains those article tags that *do not* work inside {{multiple issues}}.
 Twinkle.tag.multipleIssuesExceptions = [
 	'Copypaste',
+	'Current', // Works but not intended for use in MI
 	'Expand language',
 	'GOCEinuse',
 	'History merge',


### PR DESCRIPTION
Discussed/requested at [WT:TW](https://en.wikipedia.org/w/index.php?oldid=919009709#Feature_request:_exclude_Current_event_from_multiple_issues), seems reasonable.  `{{Current}}` was added in #416.

Doesn't address the related discussion on whether to undo #416 (see also [discussion at TfD](https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2017_April_20#Template:Recentism) on usage).