### PR TITLE
xfd: Add showontransclusion=1 to templatespace rfd noms

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1285,8 +1285,7 @@ Twinkle.xfd.callbacks = {
 		taggingRedirect: function(pageobj) {
 			var text = pageobj.getPageText();
 			var params = pageobj.getCallbackParameters();
-
-			pageobj.setPageText('{{subst:rfd|content=\n' + text + '\n}}');
+			pageobj.setPageText('{{subst:rfd|' + (mw.config.get('wgNamespaceNumber') === 10 ? 'showontransclusion=1|' : '') + 'content=\n' + text + '\n}}');
 			pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('nocreate');


### PR DESCRIPTION
Requested at [WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&diff=918184797&oldid=prev).  AFAICT it has no effects if the page isn't transcluded, so I don't think there's any harm in putting it in for every RfD tag, but it's non-standard and not (yet) documented at Template:rfd so probably best to leave it off if not necessary.