### PR TITLE
twinkle: remove bullets in vector menu; add monobook/modern menus

### DIFF
--- a/twinkle.css
+++ b/twinkle.css
@@ -5,3 +5,42 @@
 .skin-vector #p-twinkle {
 	width: 3.24em;
 }
+
+/**
+ * Styles for menus in monobook and modern skins
+ * Adapted from [[User:Haza-w/dropdown-menus]], code at [[MediaWiki:Gadget-dropdown-menus.css]]
+ */
+#ca-twinkle-menu {
+	background-color: #EEEEEE;
+	border: 1px solid #AAAAAA;
+	border-collapse: collapse;
+	color: #638C9C;
+	font: 14px/22px Arial, Helvetica, sans-serif;
+	padding: 0.3em 0em .3em 0em;
+	position: absolute;
+	width: 78px;
+	z-index: 1000;
+}
+#ca-twinkle-menu ul {
+	list-style: none;
+	margin: 0 0 0 0;
+}
+#ca-twinkle-menu ul li {
+	display: list-item;
+	width: 70px;
+	font-size: 14px;
+	margin: 0em;
+	padding: 0 0 0 0.5em;
+	border: 0;
+	background: none;
+}
+#ca-twinkle-menu ul li a {
+	color: #002BB8 !important;
+	text-decoration: none !important;
+	background-color: #EEEEEE !important;
+	padding: 0 0 0 0;
+	text-transform: none;
+}
+#ca-twinkle-menu ul li:hover a {
+	text-decoration: underline !important;
+}

--- a/twinkle.js
+++ b/twinkle.js
@@ -236,6 +236,7 @@ Twinkle.getFriendlyPref = function twinkleGetFriendlyPref(name) {
  *
  * @return Node -- the DOM node of the new item (a DIV element) or null
  */
+
 Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	// sanity checks, and get required DOM nodes
 	var root = document.getElementById(navigation);
@@ -260,26 +261,23 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	var skin = mw.config.get('skin');
 	type = skin === 'vector' && type === 'menu' && (navigation === 'left-navigation' || navigation === 'right-navigation') ? 'menu' : '';
 	var outerDivClass;
-	var innerDivClass;
 	switch (skin) {
 		case 'vector':
+			// XXX: portal doesn't work
 			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
 				navigation = 'mw-panel';
 			}
 			outerDivClass = navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'vectorMenu' : 'vectorTabs';
-			innerDivClass = navigation === 'mw-panel' ? 'body' : type === 'menu' ? 'menu' : '';
 			break;
 		case 'modern':
 			if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
 				navigation = 'mw_portlets';
 			}
 			outerDivClass = 'portlet';
-			innerDivClass = 'pBody';
 			break;
 		default:
 			navigation = 'column-one';
 			outerDivClass = 'portlet';
-			innerDivClass = 'pBody';
 			break;
 	}
 
@@ -329,13 +327,13 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	outerDiv.appendChild(h5);
 
 	var innerDiv = null;
+	var ul = document.createElement('ul');
 	if (type === 'menu') {
 		innerDiv = document.createElement('div');
-		innerDiv.className = innerDivClass;
 		outerDiv.appendChild(innerDiv);
+		ul.className = 'menu';
 	}
 
-	var ul = document.createElement('ul');
 	(innerDiv || outerDiv).appendChild(ul);
 
 	return outerDiv;

--- a/twinkle.js
+++ b/twinkle.js
@@ -456,12 +456,14 @@ Twinkle.addPortletLink = function(task, text, id, tooltip) {
 	}
 	var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
 	$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
-	if (typeof task === 'function') {
-		$(link).click(function (ev) {
+	$(link).click(function (ev) {
+		if (typeof task === 'function') {
 			task();
 			ev.preventDefault();
-		});
-	}
+		} else {
+			link.querySelector('a').click();
+		}
+	});
 	if ($.collapsibleTabs) {
 		$.collapsibleTabs.handleResize();
 	}

--- a/twinkle.js
+++ b/twinkle.js
@@ -362,86 +362,86 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 
 		return li;
 
-	} else { // Vector skin; and for other skins without menu
+	}
 
-		var outerDivClass;
-		switch (skin) {
-			case 'vector':
-				// XXX: portal doesn't work
-				if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
-					navigation = 'mw-panel';
-				}
-				outerDivClass = navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'vectorMenu' : 'vectorTabs';
-				break;
-			case 'modern':
-				if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
-					navigation = 'p-cactions';
-				}
-				outerDivClass = 'portlet';
-				break;
-			default:
-				navigation = 'column-one';
-				outerDivClass = 'portlet';
-				break;
-		}
+	// Else: Vector skin; and for other skins without menu
 
-		// Build the DOM elements.
-		var outerDiv = document.createElement('div');
-		outerDiv.className = outerDivClass + ' emptyPortlet';
-		outerDiv.id = id;
-		if (nextnode && nextnode.parentNode === root) {
-			root.insertBefore(outerDiv, nextnode);
-		} else {
-			root.appendChild(outerDiv);
-		}
+	var outerDivClass;
+	switch (skin) {
+		case 'vector':
+			// XXX: portal doesn't work
+			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
+				navigation = 'mw-panel';
+			}
+			outerDivClass = navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'vectorMenu' : 'vectorTabs';
+			break;
+		case 'modern':
+			if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
+				navigation = 'p-cactions';
+			}
+			outerDivClass = 'portlet';
+			break;
+		default:
+			navigation = 'column-one';
+			outerDivClass = 'portlet';
+			break;
+	}
 
-		if (outerDivClass === 'vectorMenu') {
-			// add invisible checkbox to make menu keyboard accessible
-			// similar to the p-cactions ("More") menu
-			var chkbox = document.createElement('input');
-			chkbox.className = 'vectorMenuCheckbox';
-			chkbox.setAttribute('type', 'checkbox');
-			chkbox.setAttribute('aria-labelledby', 'p-twinkle-label');
-			outerDiv.appendChild(chkbox);
-		}
-		var h5 = document.createElement('h3');
-		if (outerDivClass === 'vectorMenu') {
-			h5.id = 'p-twinkle-label';
-		}
-		if (type === 'menu') {
-			var span = document.createElement('span');
-			span.appendChild(document.createTextNode(text));
-			h5.appendChild(span);
+	// Build the DOM elements.
+	var outerDiv = document.createElement('div');
+	outerDiv.className = outerDivClass + ' emptyPortlet';
+	outerDiv.id = id;
+	if (nextnode && nextnode.parentNode === root) {
+		root.insertBefore(outerDiv, nextnode);
+	} else {
+		root.appendChild(outerDiv);
+	}
 
-			var a = document.createElement('a');
-			a.href = '#';
+	var h5 = document.createElement('h3');
+	var ul = document.createElement('ul');
 
-			$(a).click(function (e) {
-				e.preventDefault();
+	if (type === 'menu') {  // menu in vector skin
 
-				if (!Twinkle.userAuthorized) {
-					alert('Sorry, your account is too new to use Twinkle.');
-				}
-			});
+		// add invisible checkbox to keep menu when clicked
+		// similar to the p-cactions ("More") menu
+		var chkbox = document.createElement('input');
+		chkbox.className = 'vectorMenuCheckbox';
+		chkbox.setAttribute('type', 'checkbox');
+		chkbox.setAttribute('aria-labelledby', 'p-twinkle-label');
+		outerDiv.appendChild(chkbox);
 
-			h5.appendChild(a);
-		} else {
-			h5.appendChild(document.createTextNode(text));
-		}
+		h5.id = 'p-twinkle-label';
+		var span = document.createElement('span');
+		span.appendChild(document.createTextNode(text));
+		h5.appendChild(span);
+
+		var a = document.createElement('a');
+		a.href = '#';
+
+		$(a).click(function (e) {
+			e.preventDefault();
+			if (!Twinkle.userAuthorized) {
+				alert('Sorry, your account is too new to use Twinkle.');
+			}
+		});
+
+		h5.appendChild(a);
 		outerDiv.appendChild(h5);
 
-		var innerDiv = null;
-		var ul = document.createElement('ul');
-		if (type === 'menu') {
-			innerDiv = document.createElement('div');
-			outerDiv.appendChild(innerDiv);
-			ul.className = 'menu';
-		}
+		ul.className = 'menu';
+		var innerDiv = document.createElement('div');
+		innerDiv.appendChild(ul);
+		outerDiv.appendChild(innerDiv);
 
-		(innerDiv || outerDiv).appendChild(ul);
+	} else {
 
-		return outerDiv;
+		h5.appendChild(document.createTextNode(text));
+		outerDiv.appendChild(h5);
+		outerDiv.appendChild(ul);
+
 	}
+
+	return outerDiv;
 
 };
 


### PR DESCRIPTION
**Removal of bullets from vector menu:** (closes #713)
Per MusikAnimal's comments at https://github.com/azatoth/twinkle/issues/713#issue-499541613.

With this, `innerDivClass` becomes an unused variable, as it was being only applied to the innerdiv when `type === 'menu'`, and `type` is being normalised to be `menu` only if we're on vector skin (line 262). 

~~However, I've commented it out rather than removed because it may possibly be useful while working on  #716. (If not, I'll remove it then.)~~

**Addition of menus for monobook/modern skins:** (closes #716)
Added on October 9: see [comment below](https://github.com/azatoth/twinkle/pull/721#issuecomment-539843901).