### PR TITLE
morebits: Use custom message for spamblacklist

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2685,7 +2685,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				}
 			// check for blacklist hits
 			} else if (errorCode === 'spamblacklist') {
-				ctx.statusElement.error(ctx.saveApi.getErrorText());
+				// .find('matches') returns an array in case multiple items are blacklisted, we only return the first
+				var spam = $(ctx.saveApi.getXML()).find('spamblacklist').find('matches').children()[0].textContent;
+				ctx.statusElement.error('Could not save the page because the URL ' + spam + ' is on the spam blacklist');
 			} else {
 				ctx.statusElement.error('Failed to save edit: ' + ctx.saveApi.getErrorText());
 			}


### PR DESCRIPTION
Restores custom message removed in #707.  Custom messages as specified in MediaWiki:Spamprotectiontext and MediaWiki:Spamprotectionmatch get inserted into the response, which can lead to absurdly lengthy wikitext messages in Twinkle (see https://github.com/azatoth/twinkle/pull/707#issuecomment-539120184).