### PR TITLE
morebits: remove Morebits.queryString

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -15,8 +15,8 @@
  */
 
 Twinkle.welcome = function friendlywelcome() {
-	if (Morebits.queryString.exists('friendlywelcome')) {
-		if (Morebits.queryString.get('friendlywelcome') === 'auto') {
+	if (mw.util.getParamValue('friendlywelcome')) {
+		if (mw.util.getParamValue('friendlywelcome') === 'auto') {
 			Twinkle.welcome.auto();
 		} else {
 			Twinkle.welcome.semiauto();
@@ -27,7 +27,7 @@ Twinkle.welcome = function friendlywelcome() {
 };
 
 Twinkle.welcome.auto = function() {
-	if (Morebits.queryString.get('action') !== 'edit') {
+	if (mw.util.getParamValue('action') !== 'edit') {
 		// userpage not empty, aborting auto-welcome
 		return;
 	}
@@ -40,7 +40,7 @@ Twinkle.welcome.semiauto = function() {
 };
 
 Twinkle.welcome.normal = function() {
-	if (Morebits.queryString.exists('diff')) {
+	if (mw.util.getParamValue('diff')) {
 		// check whether the contributors' talk pages exist yet
 		var $oList = $('#mw-diff-otitle2').find('span.mw-usertoollinks a.new:contains(talk)').first();
 		var $nList = $('#mw-diff-ntitle2').find('span.mw-usertoollinks a.new:contains(talk)').first();
@@ -64,7 +64,7 @@ Twinkle.welcome.normal = function() {
 				var oHref = $oList.attr('href');
 
 				var oWelcomeNode = welcomeNode.cloneNode(true);
-				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + Morebits.queryString.create({
+				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + $.param({
 					'friendlywelcome': Twinkle.getFriendlyPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					'vanarticle': Morebits.pageNameNorm
 				}));
@@ -76,7 +76,7 @@ Twinkle.welcome.normal = function() {
 				var nHref = $nList.attr('href');
 
 				var nWelcomeNode = welcomeNode.cloneNode(true);
-				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + Morebits.queryString.create({
+				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + $.param({
 					'friendlywelcome': Twinkle.getFriendlyPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					'vanarticle': Morebits.pageNameNorm
 				}));
@@ -98,7 +98,7 @@ Twinkle.welcome.welcomeUser = function welcomeUser() {
 
 	var params = {
 		value: Twinkle.getFriendlyPref('quickWelcomeTemplate'),
-		article: Morebits.queryString.exists('vanarticle') ? Morebits.queryString.get('vanarticle') : '',
+		article: mw.util.getParamValue('vanarticle') || '',
 		mode: 'auto'
 	};
 
@@ -148,7 +148,7 @@ Twinkle.welcome.callback = function friendlywelcomeCallback(uid) {
 		type: 'input',
 		name: 'article',
 		label: '* Linked article (if supported by template):',
-		value: Morebits.queryString.exists('vanarticle') ? Morebits.queryString.get('vanarticle') : '',
+		value: mw.util.getParamValue('vanarticle') || '',
 		tooltip: 'An article might be linked from within the welcome if the template supports it. Leave empty for no article to be linked.  Templates that support a linked article are marked with an asterisk.'
 	});
 

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -109,7 +109,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				name: 'page',
 				label: 'Primary linked page: ',
 				tooltip: 'Leave blank to not link to the page in the report',
-				value: Morebits.queryString.exists('vanarticle') ? Morebits.queryString.get('vanarticle') : '',
+				value: mw.util.getParamValue('vanarticle') || '',
 				event: function(e) {
 					var value = e.target.value;
 					var root = e.target.form;
@@ -126,8 +126,8 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				name: 'badid',
 				label: 'Revision ID for target page when vandalised: ',
 				tooltip: 'Leave blank for no diff link',
-				value: Morebits.queryString.exists('vanarticlerevid') ? Morebits.queryString.get('vanarticlerevid') : '',
-				disabled: !Morebits.queryString.exists('vanarticle'),
+				value: mw.util.getParamValue('vanarticlerevid') || '',
+				disabled: !mw.util.getParamValue('vanarticle'),
 				event: function(e) {
 					var value = e.target.value;
 					var root = e.target.form;
@@ -139,8 +139,8 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				name: 'goodid',
 				label: 'Last good revision ID before vandalism of target page: ',
 				tooltip: 'Leave blank for diff link to previous revision',
-				value: Morebits.queryString.exists('vanarticlegoodrevid') ? Morebits.queryString.get('vanarticlegoodrevid') : '',
-				disabled: !Morebits.queryString.exists('vanarticle') || Morebits.queryString.exists('vanarticlerevid')
+				value: mw.util.getParamValue('vanarticlegoodrevid') || '',
+				disabled: !mw.util.getParamValue('vanarticle') || mw.util.getParamValue('vanarticlerevid')
 			});
 			work_area.append({
 				type: 'checkbox',

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -129,9 +129,9 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 
 		query.generator = 'allpages';
 		query.gaplimit = Twinkle.getPref('batchMax'); // the max for sysops
-		if (Morebits.queryString.exists('prefix')) {
-			query.gapnamespace = Morebits.queryString.get('namespace');
-			query.gapprefix = Morebits.string.toUpperCaseFirstChar(Morebits.queryString.get('prefix'));
+		if (mw.util.getParamValue('prefix')) {
+			query.gapnamespace = mw.util.getParamValue('namespace');
+			query.gapprefix = Morebits.string.toUpperCaseFirstChar(mw.util.getParamValue('prefix'));
 		} else {
 			var pathSplit = decodeURIComponent(location.pathname).split('/');
 			if (pathSplit.length < 3 || pathSplit[2] !== 'Special:PrefixIndex') {

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -131,7 +131,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		query.gaplimit = Twinkle.getPref('batchMax'); // the max for sysops
 		if (mw.util.getParamValue('prefix')) {
 			query.gapnamespace = mw.util.getParamValue('namespace');
-			query.gapprefix = Morebits.string.toUpperCaseFirstChar(mw.util.getParamValue('prefix'));
+			query.gapprefix = mw.util.getParamValue('prefix');
 		} else {
 			var pathSplit = decodeURIComponent(location.pathname).split('/');
 			if (pathSplit.length < 3 || pathSplit[2] !== 'Special:PrefixIndex') {

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -282,7 +282,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex') {
 		query.generator = 'allpages';
 		query.gapnamespace = mw.util.getParamValue('namespace') || $('select[name=namespace]').val();
-		query.gapprefix = Morebits.string.toUpperCaseFirstChar(mw.util.getParamValue('from') ? mw.util.getParamValue('from').replace('+', ' ') : $('input[name=prefix]').val());
+		query.gapprefix = mw.util.getParamValue('prefix') || $('input[name=prefix]').val();
 		query.gaplimit = Twinkle.getPref('batchMax'); // the max for sysops
 	} else {
 		query.generator = 'links';

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -281,9 +281,8 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		query.gcmlimit = Twinkle.getPref('batchMax'); // the max for sysops
 	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex') {
 		query.generator = 'allpages';
-		query.gapnamespace = Morebits.queryString.exists('namespace') ? Morebits.queryString.get('namespace') : $('select[name=namespace]').val();
-		query.gapprefix = Morebits.queryString.exists('from') ? Morebits.string.toUpperCaseFirstChar(Morebits.queryString.get('from').replace('+', ' ')) :
-			Morebits.string.toUpperCaseFirstChar($('input[name=prefix]').val());
+		query.gapnamespace = mw.util.getParamValue('namespace') || $('select[name=namespace]').val();
+		query.gapprefix = Morebits.string.toUpperCaseFirstChar(mw.util.getParamValue('from') ? mw.util.getParamValue('from').replace('+', ' ') : $('input[name=prefix]').val());
 		query.gaplimit = Twinkle.getPref('batchMax'); // the max for sysops
 	} else {
 		query.generator = 'links';

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -17,17 +17,10 @@ Twinkle.diff = function twinklediff() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId')) {
 		return;
 	}
-
-	var query = {
-		'title': mw.config.get('wgPageName'),
-		'diff': 'cur',
-		'oldid': 'prev'
-	};
-
-	Twinkle.addPortletLink(mw.util.wikiScript('index') + '?' + $.param(query), 'Last', 'tw-lastdiff', 'Show most recent diff');
+	Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: 'prev'}), 'Last', 'tw-lastdiff', 'Show most recent diff');
 
 	// Show additional tabs only on diff pages
-	if (Morebits.queryString.exists('diff')) {
+	if (mw.util.getParamValue('diff')) {
 		Twinkle.addPortletLink(function() {
 			Twinkle.diff.evaluate(false);
 		}, 'Since', 'tw-since', 'Show difference between last diff and the revision made by previous user');
@@ -36,12 +29,7 @@ Twinkle.diff = function twinklediff() {
 		}, 'Since mine', 'tw-sincemine', 'Show difference between last diff and my last revision');
 
 		var oldid = /oldid=(.+)/.exec($('#mw-diff-ntitle1').find('strong a').first().attr('href'))[1];
-		query = {
-			'title': mw.config.get('wgPageName'),
-			'diff': 'cur',
-			'oldid': oldid
-		};
-		Twinkle.addPortletLink(mw.util.wikiScript('index') + '?' + $.param(query), 'Current', 'tw-curdiff', 'Show difference to current revision');
+		Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: oldid}), 'Current', 'tw-curdiff', 'Show difference to current revision');
 	}
 };
 
@@ -82,12 +70,10 @@ Twinkle.diff.callbacks = {
 			self.statelem.error('no suitable earlier revision found, or ' + self.params.user + ' is the only contributor. Aborting.');
 			return;
 		}
-		var query = {
-			'title': mw.config.get('wgPageName'),
-			'oldid': revid,
-			'diff': mw.config.get('wgCurRevisionId')
-		};
-		window.location = mw.util.wikiScript('index') + '?' + Morebits.queryString.create(query);
+		window.location = mw.util.getUrl(mw.config.get('wgPageName'), {
+			diff: mw.config.get('wgCurRevisionId'),
+			oldid: revid
+		});
 	}
 };
 })(jQuery);

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -42,7 +42,7 @@ Twinkle.fluff = {
 
 		var vandal = $('#mw-diff-ntitle2').find('a.mw-userlink').text();
 
-		Twinkle.fluff.revert(Morebits.queryString.get('twinklerevert'), vandal, true);
+		Twinkle.fluff.revert(mw.util.getParamValue('twinklerevert'), vandal, true);
 	},
 
 	contributions: function() {
@@ -69,11 +69,11 @@ Twinkle.fluff = {
 					var href = $(current).find('.mw-changeslist-diff').attr('href');
 					current.appendChild(document.createTextNode(' '));
 					var tmpNode = revNode.cloneNode(true);
-					tmpNode.firstChild.setAttribute('href', href + '&' + Morebits.queryString.create({ 'twinklerevert': 'norm' }));
+					tmpNode.firstChild.setAttribute('href', href + '&twinklerevert=norm');
 					current.appendChild(tmpNode);
 					current.appendChild(document.createTextNode(' '));
 					tmpNode = revVandNode.cloneNode(true);
-					tmpNode.firstChild.setAttribute('href', href + '&' + Morebits.queryString.create({ 'twinklerevert': 'vand' }));
+					tmpNode.firstChild.setAttribute('href', href + '&twinklerevert=vand');
 					current.appendChild(tmpNode);
 				});
 			}
@@ -443,16 +443,16 @@ Twinkle.fluff.callbacks = {
 
 			switch (Twinkle.getPref('userTalkPageMode')) {
 				case 'tab':
-					window.open(mw.util.wikiScript('index') + '?' + Morebits.queryString.create(query), '_blank');
+					window.open(mw.util.getUrl('', query), '_blank');
 					break;
 				case 'blank':
-					window.open(mw.util.wikiScript('index') + '?' + Morebits.queryString.create(query), '_blank',
+					window.open(mw.util.getUrl('', query), '_blank',
 						'location=no,toolbar=no,status=no,directories=no,scrollbars=yes,width=1200,height=800');
 					break;
 				case 'window':
 				/* falls through */
 				default:
-					window.open(mw.util.wikiScript('index') + '?' + Morebits.queryString.create(query),
+					window.open(mw.util.getUrl('', query),
 						window.name === 'twinklewarnwindow' ? '_blank' : 'twinklewarnwindow',
 						'location=no,toolbar=no,status=no,directories=no,scrollbars=yes,width=1200,height=800');
 					break;
@@ -560,7 +560,7 @@ Twinkle.fluff.init = function twinklefluffinit() {
 			'SineBot'
 		];
 
-		if (Morebits.queryString.exists('twinklerevert')) {
+		if (mw.util.getParamValue('twinklerevert')) {
 			// Return if the user can't edit the page in question
 			if (!mw.config.get('wgIsProbablyEditable')) {
 				alert("Unable to edit the page, it's probably protected.");

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -102,7 +102,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		type: 'input',
 		name: 'article',
 		label: 'Linked page',
-		value: Morebits.queryString.exists('vanarticle') ? Morebits.queryString.get('vanarticle') : '',
+		value: mw.util.getParamValue('vanarticle') || '',
 		tooltip: 'A page can be linked within the notice, perhaps because it was a revert to said page that dispatched this notice. Leave empty for no page to be linked.'
 	});
 

--- a/morebits.js
+++ b/morebits.js
@@ -1380,11 +1380,20 @@ Morebits.wiki.api.prototype = {
 
 		++Morebits.wiki.numberOfActionsLeft;
 
+		var queryString = $.map(this.query, function(val, i) {
+			if (Array.isArray(val)) {
+				return encodeURIComponent(i) + '=' + val.map(encodeURIComponent).join('|');
+			} else if (val !== undefined) {
+				return encodeURIComponent(i) + '=' + encodeURIComponent(val);
+			}
+		}).join('&').replace(/^(.*?)(\btoken=[^&]*)&(.*)/, '$1$3&$2');
+		// token should always be the last item in the query string (bug TW-B-0013)
+
 		var ajaxparams = $.extend({}, {
 			context: this,
 			type: 'POST',
 			url: mw.util.wikiScript('api'),
-			data: Morebits.queryString.create(this.query),
+			data: queryString,
 			dataType: 'xml',
 			headers: {
 				'Api-User-Agent': morebitsWikiApiUserAgent
@@ -3343,147 +3352,6 @@ Morebits.wikitext.page.prototype = {
 	}
 };
 
-
-
-/**
- * **************** Morebits.queryString ****************
- * Maps the querystring to an JS object
- *
- * In static context, the value of location.search.substring(1), else the value given
- * to the constructor is going to be used. The mapped hash is saved in the object.
- *
- * Example:
- *
- * var value = Morebits.queryString.get('key');
- * var obj = new Morebits.queryString('foo=bar&baz=quux');
- * value = obj.get('foo');
- */
-
-/**
- * @constructor
- * @param {string} qString   The query string
- */
-Morebits.queryString = function QueryString(qString) {
-	this.string = qString;
-	this.params = {};
-
-	if (!qString.length) {
-		return;
-	}
-
-	qString = qString.replace(/\+/g, ' ');
-	var args = qString.split('&');
-
-	for (var i = 0; i < args.length; ++i) {
-		var pair = args[i].split('=');
-		var key = decodeURIComponent(pair[0]), value = key;
-
-		if (pair.length === 2) {
-			value = decodeURIComponent(pair[1]);
-		}
-
-		this.params[key] = value;
-	}
-};
-
-Morebits.queryString.staticstr = null;
-
-Morebits.queryString.staticInit = function() {
-	if (!Morebits.queryString.staticstr) {
-		Morebits.queryString.staticstr = new Morebits.queryString(location.search.substring(1));
-	}
-};
-
-Morebits.queryString.get = function(key) {
-	Morebits.queryString.staticInit();
-	return Morebits.queryString.staticstr.get(key);
-};
-
-Morebits.queryString.exists = function(key) {
-	Morebits.queryString.staticInit();
-	return Morebits.queryString.staticstr.exists(key);
-};
-
-Morebits.queryString.equals = function(key, value) {
-	Morebits.queryString.staticInit();
-	return Morebits.queryString.staticstr.equals(key, value);
-};
-
-Morebits.queryString.toString = function() {
-	Morebits.queryString.staticInit();
-	return Morebits.queryString.staticstr.toString();
-};
-
-Morebits.queryString.create = function(arr) {
-	var resarr = [];
-	var editToken;  // KLUGE: this should always be the last item in the query string (bug TW-B-0013)
-	for (var i in arr) {
-		if (arr[i] === undefined) {
-			continue;
-		}
-		var res;
-		if (Array.isArray(arr[i])) {
-			var v = [];
-			for (var j = 0; j < arr[i].length; ++j) {
-				v[j] = encodeURIComponent(arr[i][j]);
-			}
-			res = v.join('|');
-		} else {
-			res = encodeURIComponent(arr[i]);
-		}
-		if (i === 'token') {
-			editToken = res;
-		} else {
-			resarr.push(encodeURIComponent(i) + '=' + res);
-		}
-	}
-	if (editToken !== undefined) {
-		resarr.push('token=' + editToken);
-	}
-	return resarr.join('&');
-};
-
-/**
- * @returns {string} the value associated to the given `key`
- * @param {string} key
- */
-Morebits.queryString.prototype.get = function(key) {
-	return this.params[key] || null;
-};
-
-/**
- * @returns {boolean} true if the given `key` is set
- * @param {string} key
- */
-Morebits.queryString.prototype.exists = function(key) {
-	return !!this.params[key];
-};
-
-/**
- * @returns {boolean} true if the value associated with given `key` equals given `value`
- * @param {string} key
- * @param {string} value
- */
-Morebits.queryString.prototype.equals = function(key, value) {
-	return this.params[key] === value;
-};
-
-/**
- * @returns {string}
- */
-Morebits.queryString.prototype.toString = function() {
-	return this.string || null;
-};
-
-/**
- * Creates a querystring and encodes strings via `encodeURIComponent` and joins arrays with `|`
- * @param {Array} arr
- * @returns {string}
- */
-Morebits.queryString.prototype.create = Morebits.queryString.create;
-
-
-
 /**
  * **************** Morebits.status ****************
  */
@@ -4276,7 +4144,6 @@ if (typeof arguments === 'undefined') {  // typeof is here for a reason...
 	window.QuickForm = Morebits.quickForm;
 	window.Wikipedia = Morebits.wiki;
 	window.Status = Morebits.status;
-	window.QueryString = Morebits.queryString;
 }
 
 // </nowiki>


### PR DESCRIPTION
Morebits.queryString is redundant to mw.util.getParamValue(), mw.util.getUrl() and jQuery.param(). All existing usages are easily replaced.
Specifically,
- Morebits.queryString.get() and Morebits.queryString.exists() are redundant to mw.util.getParamValue()
- Morebits.queryString.create() is redundant to mw.util.getUrl() and jQuery.param()

While queryString can be also used for constructing query string objects and getting/setting param values in them, this functionality is not used anywhere, nor are there any reasonable potential usecases.

This is untested, for now.