### PR TITLE
tag: Move quick filter up, move patrol checkbox to bottom

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -43,7 +43,47 @@ Twinkle.tag.callback = function friendlytagCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#tag');
 
 	var form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
-	Twinkle.tag.quickFilter(form);
+
+	form.append({
+		type: 'input',
+		label: 'Quick filter: ',
+		name: 'quickfilter',
+		size: '30px',
+		event: function twinkletagquickfilter() {
+			// flush the DOM of all existing underline spans
+			$allCheckboxDivs.find('.search-hit').each(function(i, e) {
+				var label_element = e.parentElement;
+				// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
+				// to <label>Hello world</label>
+				label_element.innerHTML = label_element.textContent;
+			});
+
+			if (this.value) {
+				$allCheckboxDivs.hide();
+				$allHeaders.hide();
+				var searchString = this.value;
+				var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
+
+				$allCheckboxDivs.find('label').each(function () {
+					var label_text = this.textContent;
+					var searchHit = searchRegex.exec(label_text);
+					if (searchHit) {
+						var range = document.createRange();
+						var textnode = this.childNodes[0];
+						range.selectNodeContents(textnode);
+						range.setStart(textnode, searchHit.index);
+						range.setEnd(textnode, searchHit.index + searchString.length);
+						var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
+						range.surroundContents(underline_span);
+						this.parentElement.style.display = 'block'; // show
+					}
+				});
+			} else {
+				$allCheckboxDivs.show();
+				$allHeaders.show();
+			}
+		}
+	});
 
 	switch (Twinkle.tag.mode) {
 		case 'article':
@@ -241,54 +281,10 @@ Twinkle.tag.callback = function friendlytagCallback() {
 	}
 };
 
-// $allCheckboxDivs and $allHeaders are defined globally, rather than in
-// the event function, to avoid having to recompute them on every keydown.
+
+// $allCheckboxDivs and $allHeaders are defined globally, rather than in the
+// quickfilter event function, to avoid having to recompute them on every keydown
 var $allCheckboxDivs, $allHeaders;
-
-Twinkle.tag.quickFilter = function(form) {
-
-	form.append({
-		type: 'input',
-		label: 'Quick filter: ',
-		name: 'quickfilter',
-		size: '30px',
-		event: function twinkletagquickfilter() {
-			// flush the DOM of all existing underline spans
-			$allCheckboxDivs.find('.search-hit').each(function(i, e) {
-				var label_element = e.parentElement;
-				// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
-				// to <label>Hello world</label>
-				label_element.innerHTML = label_element.textContent;
-			});
-
-			if (this.value) {
-				$allCheckboxDivs.hide();
-				$allHeaders.hide();
-				var searchString = this.value;
-				var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
-
-				$allCheckboxDivs.find('label').each(function () {
-					var label_text = this.textContent;
-					var searchHit = searchRegex.exec(label_text);
-					if (searchHit) {
-						var range = document.createRange();
-						var textnode = this.childNodes[0];
-						range.selectNodeContents(textnode);
-						range.setStart(textnode, searchHit.index);
-						range.setEnd(textnode, searchHit.index + searchString.length);
-						var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
-						range.surroundContents(underline_span);
-						this.parentElement.style.display = 'block'; // show
-					}
-				});
-			} else {
-				$allCheckboxDivs.show();
-				$allHeaders.show();
-			}
-		}
-	});
-
-};
 
 Twinkle.tag.updateSortOrder = function(e) {
 	var form = e.target.form;

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -43,20 +43,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#tag');
 
 	var form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
-
-	if (document.getElementsByClassName('patrollink').length) {
-		form.append({
-			type: 'checkbox',
-			list: [
-				{
-					label: 'Mark the page as patrolled',
-					value: 'patrolPage',
-					name: 'patrolPage',
-					checked: Twinkle.getFriendlyPref('markTaggedPagesAsPatrolled')
-				}
-			]
-		});
-	}
+	Twinkle.tag.quickFilter(form);
 
 	switch (Twinkle.tag.mode) {
 		case 'article':
@@ -74,7 +61,6 @@ Twinkle.tag.callback = function friendlytagCallback() {
 				]
 			});
 
-			Twinkle.tag.quickFilter(form);
 
 			if (!Twinkle.tag.canRemove) {
 				var divElement = document.createElement('div');
@@ -112,8 +98,6 @@ Twinkle.tag.callback = function friendlytagCallback() {
 		case 'file':
 			Window.setTitle('File maintenance tagging');
 
-			Twinkle.tag.quickFilter(form);
-
 			form.append({ type: 'header', label: 'License and sourcing problem tags' });
 			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.licenseList });
 
@@ -138,8 +122,6 @@ Twinkle.tag.callback = function friendlytagCallback() {
 		case 'redirect':
 			Window.setTitle('Redirect tagging');
 
-			Twinkle.tag.quickFilter(form);
-
 			form.append({ type: 'header', label: 'Spelling, misspelling, tense and capitalization templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.spellingList });
 
@@ -160,6 +142,19 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			break;
 	}
 
+	if (document.getElementsByClassName('patrollink').length) {
+		form.append({
+			type: 'checkbox',
+			list: [
+				{
+					label: 'Mark the page as patrolled',
+					value: 'patrolPage',
+					name: 'patrolPage',
+					checked: Twinkle.getFriendlyPref('markTaggedPagesAsPatrolled')
+				}
+			]
+		});
+	}
 	form.append({ type: 'submit' });
 
 	var result = form.render();


### PR DESCRIPTION
The same quick filter line is called for each mode, but by putting it before the `switch (Twinkle.tag.mode)`, the quick filter will appear above the article sorting toggle, which should make more sense given its usefulness.  Also move the patrol checkbox to the bottom, near where the MI box would show up; birds of a feather and all that.

----
This occurred to me right after merging @siddharthvp's excellent changes in #724.  There's no need for `Window.setTitle` to be first, and the only other noticeable change is if the `switch` input is entirely broken, wherein the phantom Twinkle window would now have a quickfilter instead of being totally empty; not exactly a deal-breaker.