### PR TITLE
jquery.ui.dialog (and others) being moved within jquery.ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are two ways to upload Twinkle scripts to Wikipedia or another destination
 
 After the files are synced, [MediaWiki:Gadgets-definition][] should contain the following lines:
 
-    * Twinkle[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.notify,jquery.ui.dialog,jquery.tipsy,jquery.chosen,moment|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|morebits.js|morebits.css|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
+    * Twinkle[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.notify,jquery.ui,jquery.tipsy,jquery.chosen,moment|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|morebits.js|morebits.css|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
     * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
 
 `Twinkle-pagestyles` is a hidden [peer gadget](https://www.mediawiki.org/wiki/ResourceLoader/Migration_guide_(users)#Gadget_peers) of Twinkle. Before Twinkle has loaded, it adds space where the TW menu would go in the Vector skin, so that the top bar does not "jump".

--- a/morebits-test.js
+++ b/morebits-test.js
@@ -1,7 +1,8 @@
 /* global Twinkle, Morebits */
 
-// Script depends on jQuery dialog widget
-mw.loader.using('jquery.ui.dialog', function() {
+// Script depends on jQuery dialog widget, loaded through jquery.ui after
+// T219604 (1.35-wmf.2 circa 22 Oct 2019)
+mw.loader.using('jquery.ui', function() {
 	// Construct object (to prevent namespace conflicts)
 	Twinkle.morebitsTest = {
 

--- a/morebits.js
+++ b/morebits.js
@@ -15,11 +15,11 @@
  * Dependencies:
  *   - The whole thing relies on jQuery.  But most wikis should provide this by default.
  *   - Morebits.quickForm, Morebits.simpleWindow, and Morebits.status rely on the "morebits.css" file for their styling.
- *   - Morebits.simpleWindow relies on jquery UI Dialog (ResourceLoader module name 'jquery.ui.dialog').
+ *   - Morebits.simpleWindow relies on jquery UI Dialog (from ResourceLoader module name 'jquery.ui').
  *   - Morebits.quickForm tooltips rely on Tipsy (ResourceLoader module name 'jquery.tipsy').
  *     For external installations, Tipsy is available at [http://onehackoranother.com/projects/jquery/tipsy].
  *   - To create a gadget based on morebits.js, use this syntax in MediaWiki:Gadgets-definition:
- *       * GadgetName[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,jquery.ui.dialog,jquery.tipsy]|morebits.js|morebits.css|GadgetName.js
+ *       * GadgetName[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,jquery.ui,jquery.tipsy]|morebits.js|morebits.css|GadgetName.js
  *
  * Most of the stuff here doesn't work on IE < 9.  It is your script's responsibility to enforce this.
  *


### PR DESCRIPTION
See https://phabricator.wikimedia.org/T219604#5374960 and subsequent patches (e.g. https://gerrit.wikimedia.org/r/#/c/mediawiki/core/+/543736/)
Rearranging deck chairs before #414/https://phabricator.wikimedia.org/T49145

----
Assuming the train goes out on the 24th as planned, I'll merge this then.  Won't break anything not do so, just another console warning (*cough #384 cough*)