### PR TITLE
tag: Fix bug in redirect tag matching

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1807,8 +1807,8 @@ Twinkle.tag.callbacks = {
 
 		// Check for all Rcat shell redirects (from #433)
 		if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
-			// Regex courtesy [[User:Kephir/gadgets/sagittarius.js]] at [[Special:PermaLink/831402893]]
-			var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|)((?:[^|{}]*|{{[^|}]*}})+)(}})\s*/i);
+			// Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
+			var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|)((?:[^|{}]*|{{[^}]*}})+)(}})\s*/i);
 			pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
 		} else {
 			// Fold any pre-existing Rcats into taglist and under Rcatshell


### PR DESCRIPTION
Some redirect tags (e.g. {{R from alternative language}}) can take parameters (e.g. "|from=de|to=fr"), which would cause the regex to fail to match the entire pagetext.  Specifically, in:

(?:[^|{}]*|{{[^}]*}})+

the

{{[^}]*}}

portion matches individual redirect templates, and removing the pipe from [^|}] allows the content of that template to contain parameters.

Previously, the tag module would just fail, and the regex might just insert new tags in the middle of already-existing templates.

Not sure what the case theoretically was where not excluding a pipe here would cause an issue.