### PR TITLE
twinklebatchprotect: Add support for shift-clicking checkboxes

### DIFF
--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -352,6 +352,8 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 		var result = form.render();
 		Window.setContent(result);
+
+		Morebits.checkboxShiftClickSupport(Morebits.quickForm.getElements(result, 'pages'));
 	}, statelem);
 
 	wikipedia_api.post();


### PR DESCRIPTION
Missed in 1539f511 (cf. f7008119 (batchdelete), 8d4a8e65 (batchundelete), and 2aae77d1 (unlink))