### PR TITLE
arv: Fix bug in hours calculation in AN3 reporting

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -327,7 +327,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 					$diffs.find('.entry').remove();
 
 					var date = new Date();
-					date.setHours(-36); // all since 36 hours
+					date.setHours(date.getHours() - 48); // all since 48 hours
 
 					var api = new mw.Api();
 					api.get({


### PR DESCRIPTION
Since 2013 (70cc516f), we've attempted to show up to 500 edits made within the last 36 hours.  In actuality, we've been showing up to 500 edits made since 12 noon on two calendar days prior.  `.setHours` changes the hours *digit*, and while it doesn't do math it is smart enough to try to count backward for negative numbers.  `date.setHours(0)` changes the hours digit to 0, so 13:42 on the 17th would become 0:42 on the 17th; doing `date.setHours(-1)` will count back from 0, becoming 23:42 on the *16th*.

What we've really been doing for 6.5 years is showing edits within anything from 36 to 59 hours, depending on the local time when the user loaded the edits.  As such, I've changed the time frame to encompass 48 hours, since that's roughly approximate to actual current practice.