### PR TITLE
Unify api limits as max rather than have them hardcoded, except where intentionally limited

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1416,7 +1416,7 @@ Twinkle.tag.callbacks = {
 				'redirects': 1,  // follow redirect if the class name turns out to be a redirect page
 				'lhnamespace': '10',  // template namespace only
 				'lhshow': 'redirect',
-				'lhlimit': 'max'
+				'lhlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			}, function removeRedirectTag(apiobj) {
 
 				$(apiobj.responseXML).find('page').each(function(idx, page) {
@@ -1733,7 +1733,7 @@ Twinkle.tag.callbacks = {
 				'redirects': 1,
 				'lhnamespace': '10', // template namespace only
 				'lhshow': 'redirect',
-				'lhlimit': 'max'
+				'lhlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			}, function replaceRedirectTag(apiobj) {
 				$(apiobj.responseXML).find('page').each(function(idx, page) {
 					var found = false;

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -335,7 +335,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 						prop: 'revisions',
 						format: 'json',
 						rvprop: 'sha1|ids|timestamp|parsedcomment|comment',
-						rvlimit: 500,
+						rvlimit: 500, // intentionally limited
 						rvend: date.toISOString(),
 						rvuser: uid,
 						indexpageids: true,
@@ -372,7 +372,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 						prop: 'revisions',
 						format: 'json',
 						rvprop: 'sha1|ids|timestamp|parsedcomment|comment',
-						rvlimit: 500,
+						rvlimit: 500, // intentionally limited
 						rvend: date.toISOString(),
 						rvuser: mw.config.get('wgUserName'),
 						indexpageids: true,
@@ -414,7 +414,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 						prop: 'revisions',
 						format: 'json',
 						rvprop: 'sha1|ids|timestamp|parsedcomment|comment',
-						rvlimit: 500,
+						rvlimit: 500, // intentionally limited
 						rvend: date.toISOString(),
 						rvuser: mw.config.get('wgUserName'),
 						indexpageids: true,
@@ -823,7 +823,7 @@ Twinkle.arv.processAN3 = function(params) {
 		prop: 'revisions',
 		format: 'json',
 		rvprop: 'sha1|ids|timestamp|comment',
-		rvlimit: 100,
+		rvlimit: 100, // intentionally limited
 		rvstartid: minid,
 		rvexcludeuser: params.uid,
 		indexpageids: true,

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -122,13 +122,13 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	if (mw.config.get('wgNamespaceNumber') === 14) {
 		query.generator = 'categorymembers';
 		query.gcmtitle = mw.config.get('wgPageName');
-		query.gcmlimit = Twinkle.getPref('batchMax'); // the max for sysops
+		query.gcmlimit = Twinkle.getPref('batchMax');
 
 	// On Special:PrefixIndex
 	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex') {
 
 		query.generator = 'allpages';
-		query.gaplimit = Twinkle.getPref('batchMax'); // the max for sysops
+		query.gaplimit = Twinkle.getPref('batchMax');
 		if (Morebits.queryString.exists('prefix')) {
 			query.gapnamespace = Morebits.queryString.get('namespace');
 			query.gapprefix = Morebits.string.toUpperCaseFirstChar(Morebits.queryString.get('prefix'));
@@ -153,7 +153,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	} else {
 		query.generator = 'links';
 		query.titles = mw.config.get('wgPageName');
-		query.gpllimit = Twinkle.getPref('batchMax'); // the max for sysops
+		query.gpllimit = Twinkle.getPref('batchMax');
 	}
 
 	var statusdiv = document.createElement('div');
@@ -339,7 +339,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				inprop: 'protection',
 				gapprefix: pageTitle.title + '/',
 				gapnamespace: pageTitle.namespace,
-				gaplimit: 'max',
+				gaplimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				pageNameFull: pageName // Not used by API, but added for access in onSuccess()
 			}, function onSuccess(apiobj) {
 				var xml = apiobj.responseXML;
@@ -550,7 +550,7 @@ Twinkle.batchdelete.callbacks = {
 				'blfilterredir': 'nonredirects',
 				'blnamespace': [0, 100], // main space and portal space only
 				'bltitle': params.page,
-				'bllimit': 'max'  // 500 is max for normal users, 5000 for bots and sysops
+				'bllimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			};
 			wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.batchdelete.callbacks.unlinkBacklinksMain);
 			wikipedia_api.params = params;
@@ -562,7 +562,7 @@ Twinkle.batchdelete.callbacks = {
 				'action': 'query',
 				'list': 'imageusage',
 				'iutitle': params.page,
-				'iulimit': 'max'  // 500 is max for normal users, 5000 for bots and sysops
+				'iulimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			};
 			wikipedia_api = new Morebits.wiki.api('Grabbing file links', query, Twinkle.batchdelete.callbacks.unlinkImageInstancesMain);
 			wikipedia_api.params = params;
@@ -575,7 +575,7 @@ Twinkle.batchdelete.callbacks = {
 					'action': 'query',
 					'titles': params.page,
 					'prop': 'redirects',
-					'rdlimit': 'max'  // 500 is max for normal users, 5000 for bots and sysops
+					'rdlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 				};
 				wikipedia_api = new Morebits.wiki.api('Grabbing redirects', query, Twinkle.batchdelete.callbacks.deleteRedirectsMain);
 				wikipedia_api.params = params;

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -278,17 +278,17 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 	if (mw.config.get('wgNamespaceNumber') === 14) {  // categories
 		query.generator = 'categorymembers';
 		query.gcmtitle = mw.config.get('wgPageName');
-		query.gcmlimit = Twinkle.getPref('batchMax'); // the max for sysops
+		query.gcmlimit = Twinkle.getPref('batchMax');
 	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex') {
 		query.generator = 'allpages';
 		query.gapnamespace = Morebits.queryString.exists('namespace') ? Morebits.queryString.get('namespace') : $('select[name=namespace]').val();
 		query.gapprefix = Morebits.queryString.exists('from') ? Morebits.string.toUpperCaseFirstChar(Morebits.queryString.get('from').replace('+', ' ')) :
 			Morebits.string.toUpperCaseFirstChar($('input[name=prefix]').val());
-		query.gaplimit = Twinkle.getPref('batchMax'); // the max for sysops
+		query.gaplimit = Twinkle.getPref('batchMax');
 	} else {
 		query.generator = 'links';
 		query.titles = mw.config.get('wgPageName');
-		query.gpllimit = Twinkle.getPref('batchMax'); // the max for sysops
+		query.gpllimit = Twinkle.getPref('batchMax');
 	}
 
 	var statusdiv = document.createElement('div');

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -62,7 +62,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		'prop': 'info',
 		'inprop': 'protection',
 		'titles': mw.config.get('wgPageName'),
-		'gpllimit': Twinkle.getPref('batchMax') // the max for sysops
+		'gpllimit': Twinkle.getPref('batchMax')
 	};
 	var statelem = new Morebits.status('Grabbing list of pages');
 	var wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -45,7 +45,7 @@ Twinkle.deprod.callback = function() {
 		'action': 'query',
 		'generator': 'categorymembers',
 		'gcmtitle': mw.config.get('wgPageName'),
-		'gcmlimit': 5000, // the max for sysops
+		'gcmlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
 		'gcmnamespace': '0|6|108|2', // mostly to ignore categories
 		'prop': [ 'info', 'revisions' ],
 		'rvprop': [ 'content' ],
@@ -138,7 +138,7 @@ var callback_commit = function(event) {
 				'action': 'query',
 				'titles': pageName,
 				'prop': 'redirects',
-				'rdlimit': 5000  // 500 is max for normal users, 5000 for bots and sysops
+				'rdlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			};
 			var wikipedia_api = new Morebits.wiki.api('Grabbing redirects', query, callback_deleteRedirects);
 			wikipedia_api.params = params;

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -195,7 +195,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, autoRevert, rev, page) 
 		'action': 'query',
 		'prop': ['info', 'revisions', 'flagged'],
 		'titles': pagename,
-		'rvlimit': 50, // max possible
+		'rvlimit': 50, // intentionally limited
 		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
 		'intoken': 'edit'
 	};

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1351,7 +1351,7 @@ Twinkle.speedy.callbacks = {
 					'action': 'query',
 					'titles': mw.config.get('wgPageName'),
 					'prop': 'redirects',
-					'rdlimit': 5000  // 500 is max for normal users, 5000 for bots and sysops
+					'rdlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 				};
 				var wikipedia_api = new Morebits.wiki.api('getting list of redirects...', query, Twinkle.speedy.callbacks.sysop.deleteRedirectsMain,
 					new Morebits.status('Deleting redirects'));

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1408,7 +1408,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				'apprefix': 'Articles for deletion/' + Morebits.pageNameNorm,
 				'apnamespace': 4,
 				'apfilterredir': 'nonredirects',
-				'aplimit': Morebits.userIsInGroup('sysop') ? 5000 : 500
+				'aplimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			};
 			wikipedia_api = new Morebits.wiki.api('Tagging article with deletion tag', query, Twinkle.xfd.callbacks.afd.main);
 			wikipedia_api.params = { usertalk: usertalk, reason: reason, noinclude: noinclude,
@@ -1511,7 +1511,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				'apprefix': 'Miscellany for deletion/' + Morebits.pageNameNorm,
 				'apnamespace': 4,
 				'apfilterredir': 'nonredirects',
-				'aplimit': Morebits.userIsInGroup('sysop') ? 5000 : 500
+				'aplimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
 			};
 			wikipedia_api = new Morebits.wiki.api('Looking for prior nominations of this page', query, Twinkle.xfd.callbacks.mfd.main);
 			wikipedia_api.params = { usertalk: usertalk, notifyuserspace: notifyuserspace, reason: reason, noinclude: noinclude, xfdcat: xfdcat };


### PR DESCRIPTION
- Actual code changes are two in `twinkledeprod`, one in `twinklespeedy`, and two in `twinklexfd` (similar work done in #568 and #581)
- Exceptions are four `rvlimit`s in `twinklearv` and one `rvlimit` in `twinklefluff`, all related to sequentially processing revisions.
- Unified comments:
    - `max`: `// 500 is max for normal users, 5000 for bots and sysops`
    - non-max: `// intentionally limited`
    - Removed erroneous comments for `batchMax` (holdover from [2007](https://en.wikipedia.org/w/index.php?title=User%3AAzaToth%2Ftwinklebatchdelete.js&diff=prev&oldid=169056183))