### PR TITLE
protect: Remove PC option entirely on inappropriate namespaces

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -440,7 +440,8 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						{ label: 'Custom...', value: 'custom' }
 					]
 				});
-				if (mw.loader.getState('ext.flaggedRevs.review')) {
+				// Namespaces hardcoded until [[phab:T218479]]
+				if (mw.loader.getState('ext.flaggedRevs.review') && (mw.config.get('wgNamespaceNumber') === 0 || mw.config.get('wgNamespaceNumber') === 4)) {
 					field2.append({
 						type: 'checkbox',
 						name: 'pcmodify',
@@ -450,8 +451,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 								label: 'Modify pending changes protection',
 								value: 'pcmodify',
 								tooltip: 'If this is turned off, the pending changes level, and expiry time, will be left as is.',
-								checked: true,
-								disabled: mw.config.get('wgNamespaceNumber') !== 0 && mw.config.get('wgNamespaceNumber') !== 4 // Hardcoded until [[phab:T218479]]
+								checked: true
 							}
 						]
 					});


### PR DESCRIPTION
Was disabled ~six months ago in #560 as a transition, but like #451, we should remove inappropriate options from the interface