### PR TITLE
docs: Add CONTRIBUTING.md and DEVELOPER.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Twinkle
+
+:tada::tada: Thanks for taking the time to contribute! :tada::tada:
+
+There are many ways to help out!
+
+## Bug reports and feature requests
+
+If you think you've found a bug or have a great idea for a new feature, great!  You can [open a new GitHub issue here](https://github.com/azatoth/twinkle/issues/new) (GitHub account required) or report it at [Wikipedia talk:Twinkle][].  Bigger changes or more complicated requests should be made on-wiki so other users can take part in the discussion of your feature proposal.  If you're unsure if something is a bug, other editors may be able to help identify the issue.  Be sure to search the talk page archives and GitHub issues to see if your request has already been discussed in the past.
+
+Whatever the case, the more detailed your description the easier it will be to respond to your report or request.
+
+### Reporting a bug
+
+A good bug report will include:
+- A brief, descriptive title that mentions the module you were using (tag, CSD, xfd, etc.).
+- The steps leading up to the issue so we can replicate it.  This should include the page and revision you were on, the action you were performing, and the options you selected.
+- Any errors or messages that Twinkle reported an error when it got stuck.
+- What you think *should* have happened.
+- Anything you can find in your [browser's console window][jserrors].
+
+## Contributing a pull request
+### Getting started
+
+If you'd like to help with Twinkle's development, wonderful!  Anyone can contribute, and it's easy to get set up to do so.
+
+First, familiarize yourself with the code; most likely, the changes you want are to one of the [modules](./modules); you can also check out the [individual Gadget pages][twinkle_gadget] onwiki.  If you want to propose changes yourself, [fork the repository](https://help.github.com/articles/fork-a-repo/) to make sure you always have the latest versions.  If you're new to GitHub or Git in general, you probably want to read [Getting started with GitHub](https://help.github.com/en/github/getting-started-with-github) first.
+
+Once you've got a local fork up and running, commit your changes!
+
+
+### Testing your code
+
+Testing Twinkle can be tricky, but the most straightforward way to test your code is to open up your [browser's console window][jserrors] and paste in your new code.  You'll have to load the new version by running the corresponding function in your console, e.g., `Twinkle.protect()` for twinkleprotect.js.
+
+Some things to watch out for:
+- If your tests have any chance of making actual edits, consider making them in a sandbox; be aware that some things may not work properly outside the appropriate namespace.  An even better place to test is on the [test wiki](http://test.wikipedia.org)!  Some parts of Twinkle rely on specific template code or on certain wiki-preferences, so testing certain things outside of enWiki may be difficlut (e.g., pending changes).
+- The non-module scripts `morebits.js` and `twinkle.js` are usually more complicated to test.
+- The `twinkleconfig` pseudo-module holds the code to save and determine user preferences, while `twinkle.js` holds the defaults.
+- There is some variety in how the individual modules are written, in particular between the `friendly` family, as well as with `twinklefluff.js` and `twinkleconfig.js`.
+
+As Twinkle is used many thousands of times a day, changes to how Twinkle works may be confusing or disruptive to editors.  Significant or major changes to workflow, design, or functionality should gain some modicum of consensus before being proposed or suggested, either through discussion at [Wikipedia talk:Twinkle][] or elsewhere.
+
+
+### Submitting your pull request
+
+When you are ready to submit, commit your changes on a new branch, then [initiate a pull request (PR)](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).  The title of your pull request should be the module you are proposing changes to, followed by a brief but descriptive explanation of what the changes do, such as:
+
+    xfd: Prevent sysops from deleting the main page
+
+The usual rule of thumb is that a good subject line will complete the sentence "*If applied, this commit will...*"  The full commit message is a good place to explain further details, both for reviewers and anyone in the future, specifically focusing on *why* the changes are being made, not *how*.  There are many guides to writing good commit messages, one particularly helpful one is by @cbeams: https://chris.beams.io/posts/git-commit/
+
+If you made multiple commits while working on the same feature, it's a good idea to [squash and rebase your commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) before submitting your PR; a good policy is that every commit should be capable of replacing the live on-wiki Gadget file for all users.  Separate ideas or enhancements should be different commits, and entirely separate concepts should be different pull requests.  For example, if you made three commits while changing the pulldown options in `twinkleprotect.js` and `twinklebatchprotect.js`, those should be squashed into one commit, but if you also disabled loading `twinklespeedy.js` and `twinklexfd.js` on the mainpage, that should be a separate pull request.  See also [how to file a bug report or feature request](README.md#how-to-file-a-bug-report-or-feature-request).
+
+
+### Style guideline
+
+For consistency and to cut down on potential errors, we've recently decided to utilize a more coherent style throughout the code.  [eslint][eslint.org] can be used to check your code before submission and even repair many common issues.  To install via `npm`, just run `npm install` from the main Twinkle directory in your terminal.  You can then freely check your code by running `npm run lint`, and if you run `npm run lint:fix` then `eslint` will clean up some (but not all!) style differences.  More information on specific style rules can be seen in [issue #500][fivehundred] and in `.eslintrc.json`, but the best advice is to just follow the style of surrounding code!  Some specific examples and deviations are elucidated below.
+
+- Quotes: Single quotes should be used around strings, such as when using `mw.config.get('wgUserName')`
+- Spacing: `if (condition) {`
+- Each: The `array.forEach(function(item) {` method is preferable to `$.each(array, function(index, item) {`
+
+
+## Expectations of Participants
+
+Everyone is welcome and encouraged to join in, regardless of experience.  Anybody submitting issues, code, reviews, or comments to the repository is expected to do so while complying with the principles of Wikimedia's [Code of Conduct for technical spaces][conduct].
+
+[Wikipedia talk:Twinkle]: https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle
+[jserrors]: https://en.wikipedia.org/wiki/Wikipedia:Reporting_JavaScript_errors
+[twinkle_gadget]: https://en.wikipedia.org/wiki/Wikipedia:Twinkle/Gadget
+[Wikipedia:Twinkle]: https://en.wikipedia.org/wiki/Wikipedia:Twinkle
+[eslint.org]: https://eslint.org/
+[fivehundred]: https://github.com/azatoth/twinkle/issues/500
+[conduct]: https://www.mediawiki.org/wiki/Code_of_Conduct

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,134 @@
+## Reviewing and merging pull requests
+
+(WIP)
+
+Collaborators are encouraged to thoroughly review and [test](./CONTRIBUTING.md) each pull request, including their own.  Unless urgent or obvious, it can be helpful to leave PRs open for folks to opine.
+
+Things to watch out for:
+
+- Items and processes laid out in [CONTRIBUTING.md](./CONTRIBUTING.md) are followed.
+- The goal is for Twinkle and Morebits to support the same [browsers that MediaWiki supports](https://www.mediawiki.org/wiki/Browser_compatibility).  In particular, collaborators should look out for [unsupported additions](https://kangax.github.io/compat-table/es6/) from ES6 (aka ES2015); `.includes` and `.find` are among the most likely to show up, although the jQuery `$.find()` is fine.
+- Twinkle is meant to run on the latest weekly version of MediaWiki as rolled out every Thursday on the English Wikipedia.  Backwards compatibility is not guaranteed.
+
+## Updating scripts on Wikipedia
+
+There are two ways to upload Twinkle scripts to Wikipedia or another destination. You can do it with a [Perl script](#synchronization-using-syncpl) (recommended) or [manually](#manual-synchronization).
+
+After the files are synced, ensure that [MediaWiki:Gadgets-definition][] contains the following lines:
+
+    * Twinkle[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.notify,jquery.ui,jquery.tipsy,jquery.chosen,moment|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|morebits.js|morebits.css|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
+    * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
+
+`Twinkle-pagestyles` is a hidden [peer gadget](https://www.mediawiki.org/wiki/ResourceLoader/Migration_guide_(users)#Gadget_peers) of Twinkle. Before Twinkle has loaded, it adds space where the TW menu would go in the Vector skin, so that the top bar does not "jump".
+
+### Manual synchronization
+
+Each Twinkle module and dependency lives on the wiki as a separate file. The list of modules and what pages they should be on are as follows:
+
+* `twinkle.js` &rarr; [MediaWiki:Gadget-Twinkle.js][]
+* `twinkle.css` &rarr; [MediaWiki:Gadget-Twinkle.css][]
+* `twinkle-pagestyles.css` &rarr; [MediaWiki:Gadget-Twinkle-pagestyles.css][]
+* `morebits.js` &rarr; [MediaWiki:Gadget-morebits.js][]
+* `morebits.css` &rarr; [MediaWiki:Gadget-morebits.css][]
+* `modules/twinkleprod.js` &rarr; [MediaWiki:Gadget-twinkleprod.js][]
+* `modules/twinkleimage.js` &rarr; [MediaWiki:Gadget-twinkleimage.js][]
+* `modules/twinklebatchundelete.js` &rarr; [MediaWiki:Gadget-twinklebatchundelete.js][]
+* `modules/twinklewarn.js` &rarr; [MediaWiki:Gadget-twinklewarn.js][]
+* `modules/twinklespeedy.js` &rarr; [MediaWiki:Gadget-twinklespeedy.js][]
+* `modules/friendlyshared.js` &rarr; [MediaWiki:Gadget-friendlyshared.js][]
+* `modules/twinklediff.js` &rarr; [MediaWiki:Gadget-twinklediff.js][]
+* `modules/twinkleunlink.js` &rarr; [MediaWiki:Gadget-twinkleunlink.js][]
+* `modules/friendlytag.js` &rarr; [MediaWiki:Gadget-friendlytag.js][]
+* `modules/twinkledeprod.js` &rarr; [MediaWiki:Gadget-twinkledeprod.js][]
+* `modules/friendlywelcome.js` &rarr; [MediaWiki:Gadget-friendlywelcome.js][]
+* `modules/twinklexfd.js` &rarr; [MediaWiki:Gadget-twinklexfd.js][]
+* `modules/twinklebatchdelete.js` &rarr; [MediaWiki:Gadget-twinklebatchdelete.js][]
+* `modules/twinklebatchprotect.js` &rarr; [MediaWiki:Gadget-twinklebatchprotect.js][]
+* `modules/twinkleconfig.js` &rarr; [MediaWiki:Gadget-twinkleconfig.js][]
+* `modules/twinklefluff.js` &rarr; [MediaWiki:Gadget-twinklefluff.js][]
+* `modules/twinkleprotect.js` &rarr; [MediaWiki:Gadget-twinkleprotect.js][]
+* `modules/twinklearv.js` &rarr; [MediaWiki:Gadget-twinklearv.js][]
+* `modules/friendlytalkback.js` &rarr; [MediaWiki:Gadget-friendlytalkback.js][]
+* `modules/twinkleblock.js` &rarr; [MediaWiki:Gadget-twinkleblock.js][]
+
+### Synchronization using `sync.pl`
+
+There is a synchronization script called `sync.pl`, which can be used to update on-wiki gadgets, or update the repository based on on-wiki changes.
+
+The program depends on a few Perl modules, namely [`MediaWiki::API`][MediaWiki::API], [`Git::Repository`][Git::Repository], [`File::Slurper`][File::Slurper], and [`Getopt::Long::Descriptive`][Getopt::Long::Descriptive]. These can be installed easily using [`App::cpanminus`][App::cpanminus]:
+
+    cpanm --sudo install MediaWiki::API Git::Repository File::Slurper Getopt::Long::Descriptive
+
+You may prefer to install them through your operating system's packaing tool (e.g. `apt-get install libgetopt-long-descriptive-perl`) although you can install them through cpanm too.
+
+When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a file called `~/.twinklerc` using the following format:
+
+    username = username
+    password = password
+    lang     = en
+    family   = wikipedia
+    base     = User:Username
+
+where `base` is the wiki path to prefix the files for `pull` and `push`. The script ignores the `modules/` part of the file path when downloading/uploading.
+
+Note that your working directory **must** be clean; if not, either `stash` or `commit` your changes.
+
+To `pull` user Foobar's changes (i.e. `User:Foobar/morebits.js`) down from the wiki, do:
+
+    ./sync.pl --base User:Foobar --pull twinkle.js morebits.js ...
+
+To `push` your changes to user Foobar's wiki page, do:
+
+    ./sync.pl --base User:Foobar --push twinkle.js morebits.js ...
+
+#### Deploying to the sitewide gadget
+
+There is also a `deploy` command for [interface-admins][intadmin] to deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
+
+    ./sync.pl --deploy twinkle.js morebits.js ...
+
+You may also `deploy` all files via
+
+    make deploy
+
+Note that for syncing to a non-Enwiki project, you will also need to specify the --lang and/or --family parameters. For instance, to sync the files with `test.wmflabs.org` you should specify `--lang=test --family=wmflabs`. If you intend to use `make deploy` to deploy all the files at once, you may also need to pass the necessary parameters through the makefile to the sync script like this example:
+
+    make ARGS="--lang=test --family=wmflabs" deploy
+
+When `deploy`ing or `push`ing, the script will attempt to parse the latest on-wiki edit summary for the commit of the last update, and will use that to create an edit summary using the changes committed since then. If it cannot find anything that looks like a commit hash, it will give you the most recent commits for each file and prompt you to enter an edit summary manually.
+
+[MediaWiki:Gadgets-definition]: https://en.wikipedia.org/wiki/MediaWiki:Gadgets-definition
+[MediaWiki:Gadget-Twinkle.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.js
+[MediaWiki:Gadget-Twinkle.css]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.css
+[MediaWiki:Gadget-Twinkle-pagestyles.css]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle-pagestyles.css
+[MediaWiki:Gadget-morebits.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-morebits.js
+[MediaWiki:Gadget-morebits.css]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-morebits.css
+[MediaWiki:Gadget-twinkleprod.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleprod.js
+[MediaWiki:Gadget-twinkleimage.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleimage.js
+[MediaWiki:Gadget-twinklebatchundelete.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklebatchundelete.js
+[MediaWiki:Gadget-twinklewarn.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklewarn.js
+[MediaWiki:Gadget-twinklespeedy.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklespeedy.js
+[MediaWiki:Gadget-friendlyshared.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlyshared.js
+[MediaWiki:Gadget-twinklediff.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklediff.js
+[MediaWiki:Gadget-twinkleunlink.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleunlink.js
+[MediaWiki:Gadget-friendlytag.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlytag.js
+[MediaWiki:Gadget-twinkledeprod.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkledeprod.js
+[MediaWiki:Gadget-friendlywelcome.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlywelcome.js
+[MediaWiki:Gadget-twinklexfd.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklexfd.js
+[MediaWiki:Gadget-twinklebatchdelete.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklebatchdelete.js
+[MediaWiki:Gadget-twinklebatchprotect.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklebatchprotect.js
+[MediaWiki:Gadget-twinkleconfig.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleconfig.js
+[MediaWiki:Gadget-twinklefluff.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklefluff.js
+[MediaWiki:Gadget-twinkleprotect.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleprotect.js
+[MediaWiki:Gadget-twinklearv.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklearv.js
+[MediaWiki:Gadget-friendlytalkback.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlytalkback.js
+[MediaWiki:Gadget-twinkleblock.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleblock.js
+[User:AzaToth/twinkle.js]: https://en.wikipedia.org/wiki/User:AzaToth/twinkle.js
+[MediaWiki:Gadgets-definition]: https://en.wikipedia.org/wiki/MediaWiki:Gadgets-definition
+[MediaWiki::API]: https://metacpan.org/pod/MediaWiki::API
+[Git::Repository]: https://metacpan.org/pod/Git::Repository
+[File::Slurper]: https://metacpan.org/pod/File::Slurper
+[Getopt::Long::Descriptive]: https://metacpan.org/pod/Getopt::Long::Descriptive
+[App::cpanminus]: https://metacpan.org/pod/App::cpanminus
+[intadmin]: https://en.wikipedia.org/wiki/Wikipedia:Interface_administrators
+[special_botpass]: https://en.wikipedia.org/wiki/Special:BotPasswords

--- a/README.md
+++ b/README.md
@@ -1,152 +1,26 @@
-Twinkle [![Build Status](https://travis-ci.org/azatoth/twinkle.svg?branch=master)](https://travis-ci.org/azatoth/twinkle)
-=======
+# Twinkle [![Build Status](https://travis-ci.org/azatoth/twinkle.svg?branch=master)](https://travis-ci.org/azatoth/twinkle)
 
-Twinkle is a JavaScript library and application that gives Wikipedians a quick way of performing common maintenance tasks, such as nominating pages for deletion and cleaning up vandalism.
-
-It is based upon the `morebits.js` library, which forms the basis for many Wikipedia scripts and editing tools.
+Twinkle is a JavaScript application that gives Wikipedians a quick way of performing common maintenance tasks, such as nominating pages for deletion and cleaning up vandalism.
 
 See [Wikipedia:Twinkle][] on the English Wikipedia for more information.
 
-[AzaToth][] is the original author and maintainer of the tool, as well as the `morebits.js` library.
+[AzaToth][] is the original author and maintainer of the tool, as well as the `morebits.js` library, which forms the basis for many Wikipedia scripts and editing tools in addition to Twinkle.
 
-Layout of this repository
--------------------------
+## How to file a bug report or feature request
+
+If you're unsure whether you are experiencing a Twinkle-based bug, you should first try asking at [Wikipedia talk:Twinkle][], where other editors may assist you.  Bugs may be filed either here or at [Wikipedia talk:Twinkle][].  For simple feature requests or changes (e.g., a template was deleted or renamed) feel free to open an issue or pull request here, but for more significant changes, consider discussing the idea on [Wikipedia talk:Twinkle][] and any relevant pages first to ensure there is consensus for the change and to get broader community input.
+
+If you'd like to start contributing, awesome!  Check out [CONTRIBUTING.md](CONTRIBUTING.md) to get started!
+
+
+## Layout of this repository
 
 * `morebits.js`: The central library used by Twinkle and many other scripts. Contains code to interact with the MediaWiki API, display forms and dialogs, generate status logs, and do various other useful things. The vast majority of code in here is not Twinkle-specific.
-* `morebits.css`: Styling to accompany `morebits.js`. The portlet styles relating to the Modern skin are Twinkle-specific and should arguably be in a `twinkle.css` file.
-* `sync.pl`: A Perl script to update on-wiki gadgets, or update the repository based on on-wiki changes. See below for full documentation.
 * `twinkle.js`: General Twinkle-specific code, mostly related to preferences and exposing Twinkle in the UI. Significantly, it contains the default set of preferences of Twinkle.
 * `modules`: Contains the individual Twinkle modules. Descriptions for these can be found in header comments or in the [Twinkle documentation][]. The module `twinkleconfig.js` powers the [Twinkle preferences panel][WP:TWPREFS].
 
-Other files not mentioned here are probably obsolete.
-
-Updating scripts on Wikipedia
------------------------------
-
-There are two ways to upload Twinkle scripts to Wikipedia or another destination. You can do it [manually](#manual-synchronization) (recommended) or with a [Perl script](#synchronization-using-syncpl).
-
-After the files are synced, [MediaWiki:Gadgets-definition][] should contain the following lines:
-
-    * Twinkle[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.notify,jquery.ui,jquery.tipsy,jquery.chosen,moment|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|morebits.js|morebits.css|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
-    * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
-
-`Twinkle-pagestyles` is a hidden [peer gadget](https://www.mediawiki.org/wiki/ResourceLoader/Migration_guide_(users)#Gadget_peers) of Twinkle. Before Twinkle has loaded, it adds space where the TW menu would go in the Vector skin, so that the top bar does not "jump".
-
-### Manual synchronization
-
-Each Twinkle module and dependency lives on the wiki as a separate file. The list of modules and what pages they should be on are as follows:
-
-* `twinkle.js` &rarr; [MediaWiki:Gadget-Twinkle.js][]
-* `twinkle.css` &rarr; [MediaWiki:Gadget-Twinkle.css][]
-* `twinkle-pagestyles.css` &rarr; [MediaWiki:Gadget-Twinkle-pagestyles.css][]
-* `morebits.js` &rarr; [MediaWiki:Gadget-morebits.js][]
-* `morebits.css` &rarr; [MediaWiki:Gadget-morebits.css][]
-* `modules/twinkleprod.js` &rarr; [MediaWiki:Gadget-twinkleprod.js][]
-* `modules/twinkleimage.js` &rarr; [MediaWiki:Gadget-twinkleimage.js][]
-* `modules/twinklebatchundelete.js` &rarr; [MediaWiki:Gadget-twinklebatchundelete.js][]
-* `modules/twinklewarn.js` &rarr; [MediaWiki:Gadget-twinklewarn.js][]
-* `modules/twinklespeedy.js` &rarr; [MediaWiki:Gadget-twinklespeedy.js][]
-* `modules/friendlyshared.js` &rarr; [MediaWiki:Gadget-friendlyshared.js][]
-* `modules/twinklediff.js` &rarr; [MediaWiki:Gadget-twinklediff.js][]
-* `modules/twinkleunlink.js` &rarr; [MediaWiki:Gadget-twinkleunlink.js][]
-* `modules/friendlytag.js` &rarr; [MediaWiki:Gadget-friendlytag.js][]
-* `modules/twinkledeprod.js` &rarr; [MediaWiki:Gadget-twinkledeprod.js][]
-* `modules/friendlywelcome.js` &rarr; [MediaWiki:Gadget-friendlywelcome.js][]
-* `modules/twinklexfd.js` &rarr; [MediaWiki:Gadget-twinklexfd.js][]
-* `modules/twinklebatchdelete.js` &rarr; [MediaWiki:Gadget-twinklebatchdelete.js][]
-* `modules/twinklebatchprotect.js` &rarr; [MediaWiki:Gadget-twinklebatchprotect.js][]
-* `modules/twinkleconfig.js` &rarr; [MediaWiki:Gadget-twinkleconfig.js][]
-* `modules/twinklefluff.js` &rarr; [MediaWiki:Gadget-twinklefluff.js][]
-* `modules/twinkleprotect.js` &rarr; [MediaWiki:Gadget-twinkleprotect.js][]
-* `modules/twinklearv.js` &rarr; [MediaWiki:Gadget-twinklearv.js][]
-* `modules/friendlytalkback.js` &rarr; [MediaWiki:Gadget-friendlytalkback.js][]
-* `modules/twinkleblock.js` &rarr; [MediaWiki:Gadget-twinkleblock.js][]
-
-### Synchronization using `sync.pl`
-
-There is a synchronization script called `sync.pl`, which can be used to pull and push files to Wikipedia.
-
-The program depends on a few modules, namely [`MediaWiki::API`][MediaWiki::API], [`Git::Repository`][Git::Repository], [`File::Slurper`][File::Slurper], and [`Getopt::Long::Descriptive`][Getopt::Long::Descriptive]. These can be installed easily using [`App::cpanminus`][App::cpanminus]:
-
-    cpanm --sudo install MediaWiki::API Git::Repository File::Slurper Getopt::Long::Descriptive
-
-You may prefer to install them through your operating system's packaing tool (e.g. `apt-get install libgetopt-long-descriptive-perl`) although you can install them through cpanm too.
-
-When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a file called `~/.twinklerc` using the following format:
-
-    username = username
-    password = password
-    lang     = en
-    family   = wikipedia
-    base     = User:Username
-
-where `base` is the wiki path to prefix the files for `pull` and `push`. The script ignores the `modules/` part of the file path when downloading/uploading.
-
-Notice that your working directory **must** be clean; if not, either `stash` or `commit` your changes.
-
-To `pull` user Foobar's changes (i.e. `User:Foobar/morebits.js`), do:
-
-    ./sync.pl --base User:Foobar --pull twinkle.js morebits.js ...
-
-To `push` your changes to Foobar's wiki page, do:
-
-    ./sync.pl --base User:Foobar --push twinkle.js morebits.js ...
-
-There is also a `deploy` command for interface-admins to deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
-
-    ./sync.pl --deploy twinkle.js morebits.js ...
-
-You may also `deploy` all files via
-
-    make deploy
-
-Note that for syncing to a custom wiki (read: not the English Wikipedia), you will also need to specify the --lang and --family parameters too. For instance, to sync the files with `test.wmflabs.org` you should specify `--lang=test --family=wmflabs`. If you intend to use `make deploy` to deploy all the files at once, you may also need to pass the necessary parameters through the makefile to the sync script like this example:
-
-    make ARGS="--lang=test --family=wmflabs" deploy
-
-When `deploy`ing or `push`ing, the script will attempt to parse the latest on-wiki edit summary to find the most recently used commit, and will use that to create an edit summary from the commits since then. If it cannot find anything that looks like a commit hash, it will prompt you to enter one for each file.
-
-Style guideline
----------------
-
-While old legacy code previously had many different and incoherent styles, it has been decided to utilize a more coherent style throughout the code, both for consistency and to cut down on potential errors.  [eslint][eslint.org] can be used to check your code before submission and even repair many common issues.  To install via `npm`, just run `npm install` from the main Twinkle directory in your terminal.  You can then freely check your code by running `npm run lint`, and if you run `npm run lint -- --fix` then `eslint` will clean up some (but not all!) style differences.  More information on specific style rules can be seen in [issue #500][fivehundred] and in `.eslintrc.json`, but the best advice is to just follow the style of surrounding code!
-
 [Wikipedia:Twinkle]: https://en.wikipedia.org/wiki/Wikipedia:Twinkle
 [AzaToth]: https://en.wikipedia.org/wiki/User:AzaToth
+[Wikipedia talk:Twinkle]: https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle
 [Twinkle documentation]: https://en.wikipedia.org/wiki/Wikipedia:Twinkle/doc
 [WP:TWPREFS]: https://en.wikipedia.org/wiki/Wikipedia:Twinkle/Preferences
-[MediaWiki:Gadget-Twinkle.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.js
-[MediaWiki:Gadget-Twinkle.css]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.css
-[MediaWiki:Gadget-Twinkle-pagestyles.css]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle-pagestyles.css
-[MediaWiki:Gadget-morebits.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-morebits.js
-[MediaWiki:Gadget-morebits.css]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-morebits.css
-[MediaWiki:Gadget-twinkleprod.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleprod.js
-[MediaWiki:Gadget-twinkleimage.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleimage.js
-[MediaWiki:Gadget-twinklebatchundelete.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklebatchundelete.js
-[MediaWiki:Gadget-twinklewarn.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklewarn.js
-[MediaWiki:Gadget-twinklespeedy.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklespeedy.js
-[MediaWiki:Gadget-friendlyshared.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlyshared.js
-[MediaWiki:Gadget-twinklediff.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklediff.js
-[MediaWiki:Gadget-twinkleunlink.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleunlink.js
-[MediaWiki:Gadget-friendlytag.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlytag.js
-[MediaWiki:Gadget-twinkledeprod.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkledeprod.js
-[MediaWiki:Gadget-friendlywelcome.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlywelcome.js
-[MediaWiki:Gadget-twinklexfd.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklexfd.js
-[MediaWiki:Gadget-twinklebatchdelete.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklebatchdelete.js
-[MediaWiki:Gadget-twinklebatchprotect.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklebatchprotect.js
-[MediaWiki:Gadget-twinkleconfig.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleconfig.js
-[MediaWiki:Gadget-twinklefluff.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklefluff.js
-[MediaWiki:Gadget-twinkleprotect.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleprotect.js
-[MediaWiki:Gadget-twinklearv.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinklearv.js
-[MediaWiki:Gadget-friendlytalkback.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-friendlytalkback.js
-[MediaWiki:Gadget-twinkleblock.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-twinkleblock.js
-[User:AzaToth/twinkle.js]: https://en.wikipedia.org/wiki/User:AzaToth/twinkle.js
-[MediaWiki:Gadgets-definition]: https://en.wikipedia.org/wiki/MediaWiki:Gadgets-definition
-[MediaWiki::API]: https://metacpan.org/pod/MediaWiki::API
-[Git::Repository]: https://metacpan.org/pod/Git::Repository
-[File::Slurper]: https://metacpan.org/pod/File::Slurper
-[Getopt::Long::Descriptive]: https://metacpan.org/pod/Getopt::Long::Descriptive
-[App::cpanminus]: https://metacpan.org/pod/App::cpanminus
-[special_botpass]: https://en.wikipedia.org/wiki/Special:BotPasswords
-[eslint.org]: https://eslint.org/
-[fivehundred]: https://github.com/azatoth/twinkle/issues/500

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "repository": "azatoth/twinkle",
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
     "eslint": "5.16.0"


### PR DESCRIPTION
Hopefully helpful for new users who want to know how to get involved or report bugs, and should lead to some level of continuity.  Most of the content has been moved and expanded from what was originally in the README.md.  Still largely a WIP, especially as concerns developer/maintainer/collaborator instructions.

Some potential references for further expansion:
- https://github.com/atom/atom/blob/master/CONTRIBUTING.md
- https://github.com/jaywcjlove/awesome-mac/blob/master/contributing.md
- https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md
- https://github.com/angular/angular/blob/master/docs/DEVELOPER.md
- https://github.com/zendframework/maintainers/blob/master/MAINTAINERS.md

Closes #477 

----
cc @azatoth @MusikAnimal @atlight @kevinji @UncleDouggie @ioeth and also @siddharthvp 
My goal here is not to be comprehensive right now but to just get this up now so it can be added to with comparatively minimal effort.  A copyediting lookover 👀 would be much appreciated, as this was done piecemeal.