### PR TITLE
xfd: Fix bug in notification checkbox when changing modes

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -150,8 +150,6 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	result.category.dispatchEvent(evt);
 };
 
-Twinkle.xfd.previousNotify = true;
-
 Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory(e) {
 	var value = e.target.value;
 	var form = e.target.form;
@@ -543,13 +541,12 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			break;
 	}
 
-	// No creator notification for CFDS or RM
+	// Return to checked state when switching, but no creator notification for CFDS or RM
 	if (value === 'cfds' || value === 'rm') {
-		Twinkle.xfd.previousNotify = form.notify.checked;
 		form.notify.checked = false;
 		form.notify.disabled = true;
 	} else {
-		form.notify.checked = Twinkle.xfd.previousNotify;
+		form.notify.checked = true;
 		form.notify.disabled = false;
 	}
 };


### PR DESCRIPTION
Added in 9d6818a along with CfD/S, presumably intended to allow the user to return to their previous state after "visiting" CfD/S.

Current behavior: Changing modes (e.g. AfD->TfD) resets the state of the "Notify page creator" checkbox, so that after loading a new XfD venue, it is always checked, unless switching to CfD/S, where the box is unchecked (and disabled).  If switching *away* from CfD/S, the default state of the checkbox will be set to whatever the checkbox was before moving to CfD/S; that is, if the checkbox was *unchecked* in AfD mode, then the user switched to CfD/S, every subsequent switch would uncheck the box, until of course they return CfD/S.

This commit: Does away with the whole damn thing, just sets the box unchecked (and disabled) for CfD/S and RM, and checked for everybody else.