### PR TITLE
Use server time rather than client time wherever possible 

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1230,7 +1230,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 	var text = pageobj.getPageText(),
 		params = pageobj.getCallbackParameters(),
 		messageData = params.messageData,
-		date = new Date();
+		date = new Date(pageobj.getLoadTime());
 
 	var dateHeaderRegex = new RegExp('^==+\\s*(?:' + date.getUTCMonthName() + '|' + date.getUTCMonthNameAbbrev() +
 		')\\s+' + date.getUTCFullYear() + '\\s*==+', 'mg');

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -241,8 +241,7 @@ Twinkle.prod.callbacks = {
 
 		// Alert if article is at least three days old, not in Category:Living people, and BLPPROD is selected
 		if (params.blp) {
-			var now = new Date().toISOString();
-			var timeDiff = (new Date(now) - new Date(params.creation)) / 1000 / 60 / 60 / 24; // days from milliseconds
+			var timeDiff = (new Date(pageobj.getLoadTime()).getTime() - new Date(params.creation).getTime()) / 1000 / 60 / 60 / 24; // days from milliseconds
 			var blpcheck_re = /\[\[Category:Living people\]\]/i;
 			if (!blpcheck_re.test(text) && timeDiff > 3) {
 				if (!confirm('Please note that the article is not in Category:Living people and hence may be ineligible for BLPPROD. Are you sure you want to continue? \n\nYou may wish to add the category if you proceed, unless the article is about a recently deceased person.')) {
@@ -371,7 +370,7 @@ Twinkle.prod.callbacks = {
 		}
 
 		// create monthly header if it doesn't exist already
-		var date = new Date();
+		var date = new Date(pageobj.getLoadTime());
 		var headerRe = new RegExp('^==+\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm');
 		if (!headerRe.exec(text)) {
 			text += '\n\n=== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ===';

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1547,7 +1547,7 @@ Twinkle.speedy.callbacks = {
 			}
 
 			// create monthly header
-			var date = new Date();
+			var date = new Date(pageobj.getLoadTime());
 			var headerRe = new RegExp('^==+\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm');
 			if (!headerRe.exec(text)) {
 				appendText += '\n\n=== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ===';

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1296,7 +1296,7 @@ Twinkle.warn.callbacks = {
 			}
 		}
 
-		var date = new Date();
+		var date = new Date(pageobj.getLoadTime());
 
 		if (params.sub_group in history) {
 			var temp_time = new Date(history[params.sub_group]);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1232,7 +1232,8 @@ Twinkle.xfd.callbacks = {
 				var query = {
 					'action': 'query',
 					'titles': mw.config.get('wgPageName'),
-					'redirects': true
+					'redirects': true,
+					'curtimestamp': true
 				};
 				var wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
 				wikipedia_api.params = params;
@@ -1242,20 +1243,22 @@ Twinkle.xfd.callbacks = {
 		// This is a closure for the callback from the above API request, which gets the target of the redirect
 		findTargetCallback: function(callback) {
 			return function(apiobj) {
-				var xmlDoc = apiobj.responseXML;
-				var target = $(xmlDoc).find('redirects r').first().attr('to');
+				var $xmlDoc = $(apiobj.responseXML);
+				var curtimestamp = $xmlDoc.find('api').attr('curtimestamp');
+				var target = $xmlDoc.find('redirects r').first().attr('to');
 				if (!target) {
 					apiobj.statelem.error('This page is currently not a redirect, aborting');
 					return;
 				}
+				var section = $xmlDoc.find('redirects r').first().attr('tofragment');
+				apiobj.params.curtimestamp = curtimestamp;
 				apiobj.params.target = target;
-				var section = $(xmlDoc).find('redirects r').first().attr('tofragment');
 				apiobj.params.section = section;
 				callback(apiobj.params);
 			};
 		},
 		main: function(params) {
-			var date = new Date();
+			var date = new Date(params.curtimestamp);
 			params.logpage = 'Wikipedia:Redirects for discussion/Log/' + date.getUTCFullYear() + ' ' + date.getUTCMonthName() + ' ' + date.getUTCDate();
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -705,7 +705,7 @@ Twinkle.xfd.callbacks = {
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.discussionPage);
 
 			// Today's list
-			var date = new Date();
+			var date = new Date(pageobj.getLoadTime());
 			wikipedia_page = new Morebits.wiki.page('Wikipedia:Articles for deletion/Log/' + date.getUTCFullYear() + ' ' +
 				date.getUTCMonthName() + ' ' + date.getUTCDate(), "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
@@ -982,7 +982,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var date = new Date();
+			var date = new Date(pageobj.getLoadTime());
 			var date_header = '===' + date.getUTCMonthName() + ' ' + date.getUTCDate() + ', ' + date.getUTCFullYear() + '===\n';
 			var date_header_regex = new RegExp('(===\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCDate() + ',\\s+' + date.getUTCFullYear() + '\\s*===)');
 			var new_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
@@ -1398,7 +1398,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 	}
 
 	var query, wikipedia_page, wikipedia_api, logpage, params;
-	var date = new Date();
+	var date = new Date(); // XXX: avoid use of client clock, still used by TfD, FfD and CfD
 	switch (type) {
 
 		case 'afd': // AFD

--- a/morebits.js
+++ b/morebits.js
@@ -2137,6 +2137,13 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
+	 * @returns {string} ISO 8601 timestamp at which the page was last loaded
+	 */
+	this.getLoadTime = function() {
+		return ctx.loadTime;
+	};
+
+	/**
 	 * @returns {string} the user who created the page following lookupCreation()
 	 */
 	this.getCreator = function() {
@@ -2517,6 +2524,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			return;
 		}
 		ctx.loadTime = $(xml).find('page').attr('starttimestamp');
+		// XXX: starttimestamp is present because of intoken=edit parameter in the API call.
+		// When replacing that with meta=tokens (#615), add the curtimestamp parameter to the API call
+		// and change 'starttimestamp' here to 'curtimestamp'
 		if (!ctx.loadTime) {
 			ctx.statusElement.error('Failed to retrieve start timestamp.');
 			ctx.onLoadFailure(this);


### PR DESCRIPTION
Largely addresses #6. Per https://github.com/azatoth/twinkle/issues/6#issuecomment-1304315, the server time is available to us whenever we are in a `.load()` callback, via the starttimestamp attribute in load API output which is stored in Morebits.wiki.page as `ctx.loadTime`, publicly exposed via `.getLoadTime()`.

In case of RFD, the curtimestamp parameter is added to the API request while finding the target of the redirect, so that the server time is available while determining the log page.

The only remaining usages of client clock is in:
- an3 - not important to fix as it is only used for deciding what revisions to retrieve from which user can select reverts.
- in determining daily log page name for CFD, FFD and TFD. The code that does is sitting outside of any load callback, because unlike in AfD, tagging of the page is occurring after the discussion is posted. Maybe the order can be changed in a future Great XfD De-Duplication Project.