### PR TITLE
twinkle.js: Add Special:Block to whitelisted special pages

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -9,7 +9,7 @@
  *** friendlytalkback.js: Talkback module
  ****************************************
  * Mode of invocation:     Tab ("TB")
- * Active on:              Existing user talk pages
+ * Active on:              Any page with relevant user name (userspace, contribs, etc.)
  * Config directives in:   FriendlyConfig
  */
 

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -9,7 +9,7 @@
  *** twinklearv.js: ARV module
  ****************************************
  * Mode of invocation:     Tab ("ARV")
- * Active on:              Existing and non-existing user pages, user talk pages, contributions pages
+ * Active on:              Any page with relevant user name (userspace, contribs, etc.)
  * Config directives in:   TwinkleConfig
  */
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -10,12 +10,12 @@ var api = new mw.Api(), relevantUserName;
  *** twinkleblock.js: Block module
  ****************************************
  * Mode of invocation:     Tab ("Block")
- * Active on:              any page with relevant user name (userspace, contribs, etc.)
+ * Active on:              Any page with relevant user name (userspace, contribs, etc.)
  * Config directives in:   [soon to be TwinkleConfig]
  */
 
 Twinkle.block = function twinkleblock() {
-	// should show on Contributions pages, anywhere there's a relevant user
+	// should show on Contributions or Block pages, anywhere there's a relevant user
 	if (Morebits.userIsInGroup('sysop') && mw.config.get('wgRelevantUserName')) {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}

--- a/twinkle-pagestyles.css
+++ b/twinkle-pagestyles.css
@@ -4,6 +4,7 @@
  * Vector skin, so that the top bar does not "jump".
  */
 .client-js > body.skin-vector:not(.ns-special) #p-cactions,
+.client-js > body.skin-vector.mw-special-Block #p-cactions,
 .client-js > body.skin-vector.mw-special-Contributions #p-cactions,
 .client-js > body.skin-vector.mw-special-DeletedContributions #p-cactions,
 .client-js > body.skin-vector.mw-special-Prefixindex #p-cactions {

--- a/twinkle.js
+++ b/twinkle.js
@@ -427,7 +427,7 @@ $.ajax({
 Twinkle.load = function () {
 	// Don't activate on special pages other than those on the whitelist so that
 	// they load faster, especially the watchlist.
-	var specialPageWhitelist = [ 'Contributions', 'DeletedContributions', 'Prefixindex' ];
+	var specialPageWhitelist = [ 'Block', 'Contributions', 'DeletedContributions', 'Prefixindex' ];
 	var isSpecialPage = mw.config.get('wgNamespaceNumber') === -1 &&
 		specialPageWhitelist.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1;
 


### PR DESCRIPTION
Allows users to use Twinkle modules there if desired.  As of now, it loads: arv, warn, welcome, and talkback, as well as block if the user is a sysop.

Also updated/unified headers describing where some modules that use `wgRelevantUserName` that weren't changed (#208).

----
IMO this solves the concern expressed in #699.