### PR TITLE
twinkle/morebits/config: remove antique IE 9 stuff

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1178,11 +1178,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 					resetlink.setAttribute('href', '#tw-reset');
 					resetlink.setAttribute('id', 'twinkle-config-reset-' + pref.name);
 					resetlink.addEventListener('click', Twinkle.config.resetPrefLink, false);
-					if (resetlink.style.styleFloat) {  // IE (inc. IE9)
-						resetlink.style.styleFloat = 'right';
-					} else {  // standards
-						resetlink.style.cssFloat = 'right';
-					}
+					resetlink.style.cssFloat = 'right';
 					resetlink.style.margin = '0 0.6em';
 					resetlink.appendChild(document.createTextNode('Reset'));
 					cell.appendChild(resetlink);

--- a/morebits.js
+++ b/morebits.js
@@ -24,7 +24,7 @@
  *       * morebits[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,jquery.ui,jquery.tipsy|hidden]|morebits.js|morebits.css
  *     and then load ext.gadget.morebits as one of the dependencies for the new gadget
  *
- * Most of the stuff here doesn't work on IE < 9.  It is your script's responsibility to enforce this.
+ * All the stuff here works on all browsers for which MediaWiki provides JavaScript support.
  *
  * This library is maintained by the maintainers of Twinkle.
  * For queries, suggestions, help, etc., head to [[Wikipedia talk:Twinkle]] on English Wikipedia [http://en.wikipedia.org].

--- a/twinkle.js
+++ b/twinkle.js
@@ -431,13 +431,8 @@ Twinkle.load = function () {
 	var isSpecialPage = mw.config.get('wgNamespaceNumber') === -1 &&
 		specialPageWhitelist.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1;
 
-	// Also, Twinkle is incompatible with Internet Explorer versions 8 or lower,
-	// so don't load there either.
-	var isOldIE = $.client.profile().name === 'msie' &&
-		$.client.profile().versionNumber < 9;
-
 	// Prevent users that are not autoconfirmed from loading Twinkle as well.
-	if (isSpecialPage || isOldIE || !Twinkle.userAuthorized) {
+	if (isSpecialPage || !Twinkle.userAuthorized) {
 		return;
 	}
 


### PR DESCRIPTION
JavaScript no longer loads in MediaWiki in IE <11, so there's no point in keeping old IE version checks or special cases.