### PR TITLE
warn: Note if user attempting to warn for an old edit 

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -30,6 +30,7 @@ Twinkle.warn = function twinklewarn() {
 			$vandalTalkLink.css('font-weight', 'bold');
 			$vandalTalkLink.wrapInner($('<span/>').attr('title', 'If appropriate, you can use Twinkle to warn the user about their edits to this page.'));
 
+			// Can't provide vanarticlerevid as only wgCurRevisionId is provided
 			var extraParam = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm);
 			var href = $vandalTalkLink.attr('href');
 			if (href.indexOf('?') === -1) {
@@ -41,9 +42,14 @@ Twinkle.warn = function twinklewarn() {
 	} else if (mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId')) {
 		// Autofill user talk links on diffs with vanarticle for easy
 		// warning, but don't autowarn
-		var warnFromTalk = function(talkLink) {
+		var warnFromTalk = function(xtitle) {
+			var talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
 			if (talkLink.length) {
 				var extraParams = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm) + '&' + 'noautowarn=true';
+				// diffIDs for vanarticlerevid
+				extraParams += '&vanarticlerevid=';
+				extraParams += xtitle === 'otitle' ? mw.config.get('wgDiffOldId') : mw.config.get('wgDiffNewId');
+
 				var href = talkLink.attr('href');
 				if (href.indexOf('?') === -1) {
 					talkLink.attr('href', href + '?' + extraParams);
@@ -53,8 +59,8 @@ Twinkle.warn = function twinklewarn() {
 			}
 		};
 
-		warnFromTalk($('#mw-diff-otitle2 .mw-usertoollinks a').first());
-		warnFromTalk($('#mw-diff-ntitle2 .mw-usertoollinks a').first());
+		warnFromTalk('otitle'); // Older diff
+		warnFromTalk('ntitle'); // Newer diff
 	}
 };
 
@@ -109,6 +115,34 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		value: Morebits.queryString.exists('vanarticle') ? Morebits.queryString.get('vanarticle') : '',
 		tooltip: 'A page can be linked within the notice, perhaps because it was a revert to said page that dispatched this notice. Leave empty for no page to be linked.'
 	});
+
+	form.append({
+		type: 'div',
+		label: '',
+		style: 'color: red',
+		id: 'twinkle-warn-olddiff-message'
+	});
+
+	// Confirm edit wasn't too old for a warning
+	var vanrevid = mw.util.getParamValue('vanarticlerevid');
+	if (vanrevid) {
+		var query = {
+			action: 'query',
+			prop: 'revisions',
+			rvprop: 'timestamp',
+			revids: vanrevid
+		};
+		new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
+			var vantimestamp = $(apiobj.getResponse()).find('revisions rev').attr('timestamp');
+			var revDate = new Date(vantimestamp);
+			if (vantimestamp && !isNaN(revDate)) {
+				revDate.setUTCHours(revDate.getUTCHours() + 24);
+				if (revDate.getTime() < new Date().getTime()) {
+					$('#twinkle-warn-olddiff-message').text('Note: This edit was made more than 24 hours ago so a warning may be stale.');
+				}
+			}
+		}).post();
+	}
 
 	var more = form.append({ type: 'field', name: 'reasonGroup', label: 'Warning information' });
 	more.append({ type: 'textarea', label: 'Optional message:', name: 'reason', tooltip: 'Perhaps a reason, or that a more detailed notice must be appended' });
@@ -1332,10 +1366,10 @@ Twinkle.warn.callbacks = {
 
 		while ((current = history_re.exec(text)) !== null) {
 			var current_date = new Date(current[2] + current[3] + ' UTC');
-			if (!(current[1] in history) || history[current[1]] < current_date) {
+			if (!(current[1] in history) || history[current[1]].getTime() < current_date.getTime()) {
 				history[current[1]] = current_date;
 			}
-			if (current_date >= latest.date) {
+			if (current_date.getTime() >= latest.date.getTime()) {
 				latest.date = current_date;
 				latest.type = current[1];
 			}
@@ -1347,7 +1381,7 @@ Twinkle.warn.callbacks = {
 			var temp_time = new Date(history[params.sub_group]);
 			temp_time.setUTCHours(temp_time.getUTCHours() + 24);
 
-			if (temp_time > date) {
+			if (temp_time.getTime() > date.getTime()) {
 				if (!confirm('An identical ' + params.sub_group + ' has been issued in the last 24 hours.  \nWould you still like to add this warning/notice?')) {
 					statelem.error('aborted per user request');
 					return;
@@ -1357,7 +1391,7 @@ Twinkle.warn.callbacks = {
 
 		latest.date.setUTCMinutes(latest.date.getUTCMinutes() + 1); // after long debate, one minute is max
 
-		if (latest.date > date) {
+		if (latest.date.getTime() > date.getTime()) {
 			if (!confirm('A ' + latest.type + ' has been issued in the last minute.  \nWould you still like to add this warning/notice?')) {
 				statelem.error('aborted per user request');
 				return;


### PR DESCRIPTION
<s>This is something that Huggle already does, with a [limit of 1 day](https://github.com/huggle/huggle3-qt-lx/blob/f44d4f7ea0f7b83fb16e4d14e9bedf3c18b09f15/src/huggle_core/warnings.cpp#L73) for the alert.  24 hours is also the window in which Twinkle warns users that they are attempting to provide an identical warning to one already present, so the parallel "staleness" is nice.

We can do this by adding a `vantimestamp` parameter to the user warning links opened by `twinklefluff` and merely checks that against the current date when issuing a warning to an editor.  I've also added it to the additional parameters we tack onto the user talkpage links on diffs; <s>doing so requires parsing the text of the "revision as of" text, since of the four formats users can select in Special:Preferences, only one is actually a valid `Date` format.  That text is also language-dependent, and this won't pass muster on RTL languages.</s>  doing so requires an API hit since the actual timestamps aren't available (T239439).

The time of the edit in question isn't exposed on the rollback success page, so we can't add add `vantimestamp` to that link.</s>

----

New commit message taking the below in account:

This will show a message in red to the user if they are considering issuing a warning older than 24 hours, and may thus be stale.  This is something that Huggle already does, with a [limit of 1 day](https://github.com/huggle/huggle3-qt-lx/blob/f44d4f7ea0f7b83fb16e4d14e9bedf3c18b09f15/src/huggle_core/warnings.cpp#L73) for the alert.  24 hours is also the window in which Twinkle warns users that they are attempting to provide an identical warning to one already present, so the parallel "staleness" is nice.

We can do this by using the `vanarticlerevid` from `twinklefluff` on diffs to query for the timestamp; ideally, diff timestamps would be available without an API call (T239439).  The rollback success page exposes neither the revision or time of the edit in question, nor does the url, so we can't check for old diff from the user talk link; this is comparatively rare anyway.

Also use .getTime() throughout when comparing date objects.