### PR TITLE
docs: Note deprecation of certain jQuery positional selectors

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -7,8 +7,9 @@ Collaborators are encouraged to thoroughly review and [test](./CONTRIBUTING.md) 
 Things to watch out for:
 
 - Items and processes laid out in [CONTRIBUTING.md](./CONTRIBUTING.md) are followed.
-- The goal is for Twinkle and Morebits to support the same [browsers that MediaWiki supports](https://www.mediawiki.org/wiki/Browser_compatibility).  In particular, collaborators should look out for [unsupported additions](https://kangax.github.io/compat-table/es6/) from ES6 (aka ES2015); `.includes` and `.find` are among the most likely to show up, although the jQuery `$.find()` is fine.
 - Twinkle is meant to run on the latest weekly version of MediaWiki as rolled out every Thursday on the English Wikipedia.  Backwards compatibility is not guaranteed.
+- The goal is for Twinkle and Morebits to support the same [browsers that MediaWiki supports](https://www.mediawiki.org/wiki/Browser_compatibility).  In particular, collaborators should look out for [unsupported additions](https://kangax.github.io/compat-table/es6/) from ES6 (aka ES2015); `.includes` and `.find` are among the most likely to show up, although the jQuery `$.find()` is fine.
+- Certain positional jQuery selectors like `:first`, `:last`, and `:eq` were [deprecated in jQuery version 3.4.0](https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/) and should probably not be reintroduced.  Instead, use methods like `.first()`, `.last()`, or `.eq()`.
 
 ## Updating scripts on Wikipedia
 


### PR DESCRIPTION
The full list of selectors being deprecated is at https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/ but they are `:first`, `:last`, `:eq`, `:even`, `:odd`, `:lt`, `:gt`, and `:nth`.  These were officially deprectated as of jQuery 3.4, and the MediaWiki jQuery 3.3.1 -> 3.4.1 update is slated for MW-1.35-wmf.8 (see [T233027](https://phabricator.wikimedia.org/T233027)).  Twinkle doesn't appear to currently use any of these, but we have in the past (e.g. a4b47de) and probably shouldn't reintroduce them.  Others, like `:first-child` or `:last-child`, remain (for now?), and of course the corresponding methods (e.g. `.first()` or `.eq()`) may be used.