### PR TITLE
warn: Move uw-wrongsummary from warning to notice list

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -958,6 +958,10 @@ Twinkle.warn.messages = {
 		'uw-warn': {
 			label: 'Place user warning templates when reverting vandalism',
 			summary: 'Notice: You can use user warning templates when reverting vandalism'
+		},
+		'uw-wrongsummary': {
+			label: 'Using inaccurate or inappropriate edit summaries',
+			summary: 'Warning: Using inaccurate or inappropriate edit summaries'
 		}
 	},
 
@@ -1065,10 +1069,6 @@ Twinkle.warn.messages = {
 		'uw-userpage': {
 			label: 'Userpage or subpage is against policy',
 			summary: 'Warning: Userpage or subpage is against policy'
-		},
-		'uw-wrongsummary': {
-			label: 'Using inaccurate or inappropriate edit summaries',
-			summary: 'Warning: Using inaccurate or inappropriate edit summaries'
 		}
 	}
 };


### PR DESCRIPTION
The tone of [{{uw-wrongsummary}}](https://en.wikipedia.org/wiki/Template:Uw-wrongsummary) is much more of a notice than a warning.  It has been in Twinkle's list since [its inception](https://en.wikipedia.org/w/index.php?title=User%3AAzaToth%2Ftwinklewarn.js&diff=prev&oldid=162345357) but in 2012 was moved on the [WP:SLT lists](https://en.wikipedia.org/w/index.php?title=Wikipedia:Template_messages/User_talk_namespace/Single-level_templates&diff=496637706&oldid=496636956).

----

This should probably be discussed at WT:TW beforehand, as it might annoy folks who expect it to be in one place, although that should be mitigated by #759.  We're not in sync with that list (nor should we be necessarily) but this is the most glaring error AFAICT (another is agf-sock, but I think that belongs as a warning).  It'd probably be better to deal with these holistically (#533) rather than piecemeal, but this one just seems flat-out wrong.

ETA: Asked at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Questions_on_potential_changes_to_warn_module