### PR TITLE
Unify twinkleconfig and friendlyconfig

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("Shared")
  * Active on:              Existing IP user talk pages
- * Config directives in:   FriendlyConfig
  */
 
 Twinkle.shared = function friendlyshared() {
@@ -159,7 +158,7 @@ Twinkle.shared.callbacks = {
 		var summaryText = 'Added {{[[Template:' + params.value + '|' + params.value + ']]}} template.';
 		pageobj.setPageText(text + pageText);
 		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
-		pageobj.setMinorEdit(Twinkle.getFriendlyPref('markSharedIPAsMinor'));
+		pageobj.setMinorEdit(Twinkle.getPref('markSharedIPAsMinor'));
 		pageobj.setCreateOption('recreate');
 		pageobj.save();
 	}

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -10,7 +10,6 @@
  * Mode of invocation:     Tab ("Tag")
  * Active on:              Existing articles and drafts; file pages with a corresponding file
  *                         which is local (not on Commons); all redirects
- * Config directives in:   FriendlyConfig
  */
 
 Twinkle.tag = function friendlytag() {
@@ -96,8 +95,8 @@ Twinkle.tag.callback = function friendlytagCallback() {
 				tooltip: 'You can change the default view order in your Twinkle preferences (WP:TWPREFS).',
 				event: Twinkle.tag.updateSortOrder,
 				list: [
-					{ type: 'option', value: 'cat', label: 'By categories', selected: Twinkle.getFriendlyPref('tagArticleSortOrder') === 'cat' },
-					{ type: 'option', value: 'alpha', label: 'In alphabetical order', selected: Twinkle.getFriendlyPref('tagArticleSortOrder') === 'alpha' }
+					{ type: 'option', value: 'cat', label: 'By categories', selected: Twinkle.getPref('tagArticleSortOrder') === 'cat' },
+					{ type: 'option', value: 'alpha', label: 'In alphabetical order', selected: Twinkle.getPref('tagArticleSortOrder') === 'alpha' }
 				]
 			});
 
@@ -127,7 +126,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 						value: 'group',
 						name: 'group',
 						tooltip: 'If applying two or more templates supported by {{multiple issues}} and this box is checked, all supported templates will be grouped inside a {{multiple issues}} template.',
-						checked: Twinkle.getFriendlyPref('groupByDefault')
+						checked: Twinkle.getPref('groupByDefault')
 					}
 				]
 			}
@@ -153,9 +152,9 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			form.append({ type: 'header', label: 'Replacement tags' });
 			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.replacementList });
 
-			if (Twinkle.getFriendlyPref('customFileTagList').length) {
+			if (Twinkle.getPref('customFileTagList').length) {
 				form.append({ type: 'header', label: 'Custom tags' });
-				form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.getFriendlyPref('customFileTagList') });
+				form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.getPref('customFileTagList') });
 			}
 			break;
 
@@ -171,9 +170,9 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			form.append({ type: 'header', label: 'Miscellaneous and administrative redirect templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.administrativeList });
 
-			if (Twinkle.getFriendlyPref('customRedirectTagList').length) {
+			if (Twinkle.getPref('customRedirectTagList').length) {
 				form.append({ type: 'header', label: 'Custom tags' });
-				form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.getFriendlyPref('customRedirectTagList') });
+				form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.getPref('customRedirectTagList') });
 			}
 			break;
 
@@ -190,7 +189,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 					label: 'Mark the page as patrolled',
 					value: 'patrolPage',
 					name: 'patrolPage',
-					checked: Twinkle.getFriendlyPref('markTaggedPagesAsPatrolled')
+					checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
 				}
 			]
 		});
@@ -591,10 +590,10 @@ Twinkle.tag.updateSortOrder = function(e) {
 	}
 
 	// append any custom tags
-	if (Twinkle.getFriendlyPref('customTagList').length) {
+	if (Twinkle.getPref('customTagList').length) {
 		container.append({ type: 'header', label: 'Custom tags' });
 		container.append({ type: 'checkbox', name: 'articleTags',
-			list: Twinkle.getFriendlyPref('customTagList').map(function(el) {
+			list: Twinkle.getPref('customTagList').map(function(el) {
 				el.checked = Twinkle.tag.checkedTags.indexOf(el.value) !== -1;
 				return el;
 			})
@@ -1241,8 +1240,8 @@ Twinkle.tag.callbacks = {
 
 			pageobj.setPageText(pageText);
 			pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
-			pageobj.setWatchlist(Twinkle.getFriendlyPref('watchTaggedPages'));
-			pageobj.setMinorEdit(Twinkle.getFriendlyPref('markTaggedPagesAsMinor'));
+			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+			pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 			pageobj.setCreateOption('nocreate');
 			pageobj.save(function() {
 				// special functions for merge tags
@@ -1256,7 +1255,7 @@ Twinkle.tag.callbacks = {
 					var talkpage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					talkpage.setAppendText(talkpageText);
 					talkpage.setEditSummary('Proposing to merge ' + direction + Twinkle.getPref('summaryAd'));
-					talkpage.setWatchlist(Twinkle.getFriendlyPref('watchMergeDiscussions'));
+					talkpage.setWatchlist(Twinkle.getPref('watchMergeDiscussions'));
 					talkpage.setCreateOption('recreate');
 					talkpage.append();
 				}
@@ -1828,8 +1827,8 @@ Twinkle.tag.callbacks = {
 
 		pageobj.setPageText(pageText);
 		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
-		pageobj.setWatchlist(Twinkle.getFriendlyPref('watchTaggedPages'));
-		pageobj.setMinorEdit(Twinkle.getFriendlyPref('markTaggedPagesAsMinor'));
+		pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 		pageobj.setCreateOption('nocreate');
 		pageobj.save();
 
@@ -1929,8 +1928,8 @@ Twinkle.tag.callbacks = {
 
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summary.substring(0, summary.length - 2) + Twinkle.getPref('summaryAd'));
-		pageobj.setWatchlist(Twinkle.getFriendlyPref('watchTaggedPages'));
-		pageobj.setMinorEdit(Twinkle.getFriendlyPref('markTaggedPagesAsMinor'));
+		pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 		pageobj.setCreateOption('nocreate');
 		pageobj.save();
 

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("TB")
  * Active on:              Any page with relevant user name (userspace, contribs, etc.)
- * Config directives in:   FriendlyConfig
  */
 
 Twinkle.talkback = function() {
@@ -366,7 +365,7 @@ var callback_evaluate = function(e) {
 				talkpage.setEditSummary('You have replies at the [[Wikipedia:AFCHD|Articles for Creation Help Desk]]' + Twinkle.getPref('summaryAd'));
 				break;
 			case 'an':
-				text = '\n\n== ' + Twinkle.getFriendlyPref('adminNoticeHeading') + ' ==\n';
+				text = '\n\n== ' + Twinkle.getPref('adminNoticeHeading') + ' ==\n';
 				text += '{{subst:ANI-notice|thread=' + section + "|noticeboard=Wikipedia:Administrators' noticeboard}} ~~~~";
 				talkpage.setEditSummary("Notice of discussion at [[Wikipedia:Administrators' noticeboard]]" + Twinkle.getPref('summaryAd'));
 				break;
@@ -375,7 +374,7 @@ var callback_evaluate = function(e) {
 				talkpage.setEditSummary("Notice of discussion at [[Wikipedia:Administrators' noticeboard/Edit warring]]" + Twinkle.getPref('summaryAd'));
 				break;
 			case 'ani':
-				text = '\n\n== ' + Twinkle.getFriendlyPref('adminNoticeHeading') + ' ==\n';
+				text = '\n\n== ' + Twinkle.getPref('adminNoticeHeading') + ' ==\n';
 				text += '{{subst:ANI-notice|thread=' + section + "|noticeboard=Wikipedia:Administrators' noticeboard/Incidents}} ~~~~";
 				talkpage.setEditSummary("Notice of discussion at [[Wikipedia:Administrators' noticeboard/Incidents]]" + Twinkle.getPref('summaryAd'));
 				break;
@@ -405,12 +404,12 @@ var callback_evaluate = function(e) {
 		}
 
 	} else if (tbtarget === 'mail') {
-		text = '\n\n==' + Twinkle.getFriendlyPref('mailHeading') + "==\n{{you've got mail|subject=";
+		text = '\n\n==' + Twinkle.getPref('mailHeading') + "==\n{{you've got mail|subject=";
 		text += section + '|ts=~~~~~}}';
 
 		if (message) {
 			text += '\n' + message.trim() + '  ~~~~';
-		} else if (Twinkle.getFriendlyPref('insertTalkbackSignature')) {
+		} else if (Twinkle.getPref('insertTalkbackSignature')) {
 			text += '\n~~~~';
 		}
 
@@ -427,7 +426,7 @@ var callback_evaluate = function(e) {
 
 	} else {  // tbtarget one of mytalk, usertalk, other
 		// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
-		text = '\n\n==' + Twinkle.getFriendlyPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n{{talkback|';
+		text = '\n\n==' + Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n{{talkback|';
 		text += tbPageName;
 
 		if (section) {
@@ -438,7 +437,7 @@ var callback_evaluate = function(e) {
 
 		if (message) {
 			text += '\n' + message.trim() + ' ~~~~';
-		} else if (Twinkle.getFriendlyPref('insertTalkbackSignature')) {
+		} else if (Twinkle.getPref('insertTalkbackSignature')) {
 			text += '\n~~~~';
 		}
 
@@ -452,7 +451,7 @@ var callback_evaluate = function(e) {
 
 	talkpage.setAppendText(text);
 	talkpage.setCreateOption('recreate');
-	talkpage.setMinorEdit(Twinkle.getFriendlyPref('markTalkbackAsMinor'));
+	talkpage.setMinorEdit(Twinkle.getPref('markTalkbackAsMinor'));
 	talkpage.setFollowRedirect(true);
 	talkpage.append();
 };

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -10,6 +10,7 @@
  ****************************************
  * Mode of invocation:     Tab ("TB")
  * Active on:              Any page with relevant user name (userspace, contribs, etc.)
+ * Config directives in:   FriendlyConfig
  */
 
 Twinkle.talkback = function() {
@@ -289,7 +290,7 @@ Twinkle.talkback.changeTarget = function(e) {
 Twinkle.talkback.noticeboards = {
 	'an': {
 		label: "WP:AN (Administrators' noticeboard)",
-		text: '== ' + Twinkle.getFriendlyPref('adminNoticeHeading') + ' ==\n' +
+		text: '== ' + Twinkle.getPref('adminNoticeHeading') + ' ==\n' +
 		"{{subst:ANI-notice|thread=$SECTION|noticeboard=Wikipedia:Administrators' noticeboard}} ~~~~",
 		editSummary: 'Notice of discussion at [[Wikipedia:Administrators\' noticeboard]]'
 	},
@@ -300,7 +301,7 @@ Twinkle.talkback.noticeboards = {
 	},
 	'ani': {
 		label: "WP:ANI (Administrators' noticeboard/Incidents)",
-		text: '== ' + Twinkle.getFriendlyPref('adminNoticeHeading') + ' ==\n' +
+		text: '== ' + Twinkle.getPref('adminNoticeHeading') + ' ==\n' +
 		"{{subst:ANI-notice|thread=$SECTION|noticeboard=Wikipedia:Administrators' noticeboard/Incidents}} ~~~~",
 		editSummary: 'Notice of discussion at [[Wikipedia:Administrators\' noticeboard/Incidents]]',
 		defaultSelected: true
@@ -384,7 +385,7 @@ Twinkle.talkback.evaluate = function(e) {
 
 	} else if (tbtarget === 'mail') {
 		text +=
-			'==' + Twinkle.getFriendlyPref('mailHeading') + '==\n' +
+			'==' + Twinkle.getPref('mailHeading') + '==\n' +
 			"{{You've got mail|subject=" + section + '|ts=~~~~~}}';
 
 		if (message) {
@@ -404,7 +405,7 @@ Twinkle.talkback.evaluate = function(e) {
 	} else {  // tbtarget one of mytalk, usertalk, other
 		// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
 		text +=
-			'==' + Twinkle.getFriendlyPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n' +
+			'==' + Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n' +
 			'{{talkback|' + tbPageName + (section ? '|' + section : '') + '|ts=~~~~~}}';
 
 		if (message) {

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -11,7 +11,6 @@
  * Mode of invocation:     Tab ("Wel"), or from links on diff pages
  * Active on:              Any page with relevant user name (userspace,
  *                         contribs, etc.) and diff pages
- * Config directives in:   FriendlyConfig
  */
 
 Twinkle.welcome = function friendlywelcome() {
@@ -65,7 +64,7 @@ Twinkle.welcome.normal = function() {
 
 				var oWelcomeNode = welcomeNode.cloneNode(true);
 				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + Morebits.queryString.create({
-					'friendlywelcome': Twinkle.getFriendlyPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
+					'friendlywelcome': Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					'vanarticle': Morebits.pageNameNorm
 				}));
 				$oList[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
@@ -77,7 +76,7 @@ Twinkle.welcome.normal = function() {
 
 				var nWelcomeNode = welcomeNode.cloneNode(true);
 				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + Morebits.queryString.create({
-					'friendlywelcome': Twinkle.getFriendlyPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
+					'friendlywelcome': Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					'vanarticle': Morebits.pageNameNorm
 				}));
 				$nList[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
@@ -97,7 +96,7 @@ Twinkle.welcome.welcomeUser = function welcomeUser() {
 	$('#catlinks').remove();
 
 	var params = {
-		value: Twinkle.getFriendlyPref('quickWelcomeTemplate'),
+		value: Twinkle.getPref('quickWelcomeTemplate'),
 		article: Morebits.queryString.exists('vanarticle') ? Morebits.queryString.get('vanarticle') : '',
 		mode: 'auto'
 	};
@@ -177,12 +176,12 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 
 	var container = new Morebits.quickForm.element({ type: 'fragment' });
 
-	if ((type === 'standard' || type === 'anonymous') && Twinkle.getFriendlyPref('customWelcomeList').length) {
+	if ((type === 'standard' || type === 'anonymous') && Twinkle.getPref('customWelcomeList').length) {
 		container.append({ type: 'header', label: 'Custom welcome templates' });
 		container.append({
 			type: 'radio',
 			name: 'template',
-			list: Twinkle.getFriendlyPref('customWelcomeList'),
+			list: Twinkle.getPref('customWelcomeList'),
 			event: Twinkle.welcome.selectTemplate
 		});
 	}
@@ -711,13 +710,13 @@ Twinkle.welcome.getTemplateWikitext = function(template, article) {
 	var properties = Twinkle.welcome.templates[template];
 	if (properties) {
 		return properties.syntax.
-			replace('$USERNAME$', Twinkle.getFriendlyPref('insertUsername') ? mw.config.get('wgUserName') : '').
+			replace('$USERNAME$', Twinkle.getPref('insertUsername') ? mw.config.get('wgUserName') : '').
 			replace('$ARTICLE$', article ? article : '').
 			replace(/\$HEADER\$\s*/, '== Welcome ==\n\n').
 			replace('$EXTRA$', '');  // EXTRA is not implemented yet
 	}
 	return '{{subst:' + template + (article ? '|art=' + article : '') + '}}' +
-			(Twinkle.getFriendlyPref('customWelcomeSignature') ? ' ~~~~' : '');
+			(Twinkle.getPref('customWelcomeSignature') ? ' ~~~~' : '');
 };
 
 Twinkle.welcome.callbacks = {
@@ -759,7 +758,7 @@ Twinkle.welcome.callbacks = {
 
 		var welcomeText = Twinkle.welcome.getTemplateWikitext(params.value, params.article);
 
-		if (Twinkle.getFriendlyPref('topWelcomes')) {
+		if (Twinkle.getPref('topWelcomes')) {
 			text = welcomeText + '\n\n' + text;
 		} else {
 			text += '\n' + welcomeText;
@@ -768,7 +767,7 @@ Twinkle.welcome.callbacks = {
 		var summaryText = 'Welcome to Wikipedia!';
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
-		pageobj.setWatchlist(Twinkle.getFriendlyPref('watchWelcomes'));
+		pageobj.setWatchlist(Twinkle.getPref('watchWelcomes'));
 		pageobj.setCreateOption('recreate');
 		pageobj.save();
 	}

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("ARV")
  * Active on:              Any page with relevant user name (userspace, contribs, etc.)
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.arv = function twinklearv() {

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("D-batch")
  * Active on:              Existing non-articles, and Special:PrefixIndex
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.batchdelete = function twinklebatchdelete() {

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -11,7 +11,6 @@
  * Mode of invocation:     Tab ("P-batch")
  * Active on:              Existing project pages and user pages; existing and
  *                         non-existing categories; Special:PrefixIndex
- * Config directives in:   TwinkleConfig
  */
 
 

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("Und-batch")
  * Active on:              Existing user and project pages
- * Config directives in:   TwinkleConfig
  */
 
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -11,7 +11,6 @@ var api = new mw.Api(), relevantUserName;
  ****************************************
  * Mode of invocation:     Tab ("Block")
  * Active on:              Any page with relevant user name (userspace, contribs, etc.)
- * Config directives in:   [soon to be TwinkleConfig]
  */
 
 Twinkle.block = function twinkleblock() {

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -12,7 +12,6 @@
                            subpages named "/Twinkle preferences", and adds an ad box to the top of user
                            subpages belonging to the currently logged-in user which end in '.js'
  * Active on:              What I just said.  Yeah.
- * Config directives in:   TwinkleConfig
 
  I, [[User:This, that and the other]], originally wrote this.  If the code is misbehaving, or you have any
  questions, don't hesitate to ask me.  (This doesn't at all imply [[WP:OWN]]ership - it's just meant to

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -132,7 +132,6 @@ Twinkle.config.commonSets = {
  *   title: <human-readable section title>,
  *   adminOnly: <true for admin-only sections>,
  *   hidden: <true for advanced preferences that rarely need to be changed - they can still be modified by manually editing twinkleoptions.js>,
- *   inFriendlyConfig: <true for preferences located under FriendlyConfig rather than TwinkleConfig>,
  *   preferences: [
  *     {
  *       name: <TwinkleConfig property name>,
@@ -376,7 +375,6 @@ Twinkle.config.sections = [
 
 	{
 		title: 'Shared IP tagging',
-		inFriendlyConfig: true,
 		preferences: [
 			{
 				name: 'markSharedIPAsMinor',
@@ -525,7 +523,6 @@ Twinkle.config.sections = [
 
 	{
 		title: 'Tag',
-		inFriendlyConfig: true,
 		preferences: [
 			{
 				name: 'watchTaggedPages',
@@ -587,7 +584,6 @@ Twinkle.config.sections = [
 
 	{
 		title: 'Talkback',
-		inFriendlyConfig: true,
 		preferences: [
 			{
 				name: 'markTalkbackAsMinor',
@@ -693,7 +689,6 @@ Twinkle.config.sections = [
 
 	{
 		title: 'Welcome user',
-		inFriendlyConfig: true,
 		preferences: [
 			{
 				name: 'topWelcomes',
@@ -965,13 +960,6 @@ Twinkle.config.init = function twinkleconfigInit() {
 				return true;  // i.e. "continue" in this context
 			}
 
-			var configgetter;  // retrieve the live config values
-			if (section.inFriendlyConfig) {
-				configgetter = Twinkle.getFriendlyPref;
-			} else {
-				configgetter = Twinkle.getPref;
-			}
-
 			// add to TOC
 			var tocli = document.createElement('li');
 			tocli.className = 'toclevel-1';
@@ -1020,7 +1008,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						input.setAttribute('type', 'checkbox');
 						input.setAttribute('id', pref.name);
 						input.setAttribute('name', pref.name);
-						if (configgetter(pref.name) === true) {
+						if (Twinkle.getPref(pref.name) === true) {
 							input.setAttribute('checked', 'checked');
 						}
 						label.appendChild(input);
@@ -1051,8 +1039,8 @@ Twinkle.config.init = function twinkleconfigInit() {
 							input.setAttribute('type', 'number');
 							input.setAttribute('step', '1');  // integers only
 						}
-						if (configgetter(pref.name)) {
-							input.setAttribute('value', configgetter(pref.name));
+						if (Twinkle.getPref(pref.name)) {
+							input.setAttribute('value', Twinkle.getPref(pref.name));
 						}
 						cell.appendChild(input);
 						break;
@@ -1077,7 +1065,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						$.each(pref.enumValues, function(enumvalue, enumdisplay) {
 							var option = document.createElement('option');
 							option.setAttribute('value', enumvalue);
-							if (configgetter(pref.name) === enumvalue) {
+							if (Twinkle.getPref(pref.name) === enumvalue) {
 								option.setAttribute('selected', 'selected');
 							}
 							option.appendChild(document.createTextNode(enumdisplay));
@@ -1103,12 +1091,12 @@ Twinkle.config.init = function twinkleconfigInit() {
 							check.setAttribute('type', 'checkbox');
 							check.setAttribute('id', pref.name + '_' + itemkey);
 							check.setAttribute('name', pref.name + '_' + itemkey);
-							if (configgetter(pref.name) && configgetter(pref.name).indexOf(itemkey) !== -1) {
+							if (Twinkle.getPref(pref.name) && Twinkle.getPref(pref.name).indexOf(itemkey) !== -1) {
 								check.setAttribute('checked', 'checked');
 							}
 							// cater for legacy integer array values for unlinkNamespaces (this can be removed a few years down the track...)
 							if (pref.name === 'unlinkNamespaces') {
-								if (configgetter(pref.name) && configgetter(pref.name).indexOf(parseInt(itemkey, 10)) !== -1) {
+								if (Twinkle.getPref(pref.name) && Twinkle.getPref(pref.name).indexOf(parseInt(itemkey, 10)) !== -1) {
 									check.setAttribute('checked', 'checked');
 								}
 							}
@@ -1148,9 +1136,8 @@ Twinkle.config.init = function twinkleconfigInit() {
 						button.addEventListener('click', Twinkle.config.listDialog.display, false);
 						// use jQuery data on the button to store the current config value
 						$(button).data({
-							value: configgetter(pref.name),
-							pref: pref,
-							inFriendlyConfig: section.inFriendlyConfig
+							value: Twinkle.getPref(pref.name),
+							pref: pref
 						});
 						button.appendChild(document.createTextNode('Edit items'));
 						cell.appendChild(button);
@@ -1431,7 +1418,7 @@ Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset(button, 
 	var $button = $(button);
 	var curpref = $button.data('pref');
 	var oldvalue = $button.data('value');
-	Twinkle.config.resetPref(curpref, $button.data('inFriendlyConfig'));
+	Twinkle.config.resetPref(curpref);
 
 	// reset form
 	var $tbody = $(tbody);
@@ -1480,7 +1467,7 @@ Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
 			if (pref.name !== wantedpref) {
 				return true;  // continue
 			}
-			Twinkle.config.resetPref(pref, section.inFriendlyConfig);
+			Twinkle.config.resetPref(pref);
 			foundit = true;
 			return false;  // break
 		});
@@ -1492,33 +1479,29 @@ Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
 	return false;  // stop link from scrolling page
 };
 
-Twinkle.config.resetPref = function twinkleconfigResetPref(pref, inFriendlyConfig) {
+Twinkle.config.resetPref = function twinkleconfigResetPref(pref) {
 	switch (pref.type) {
 
 		case 'boolean':
-			document.getElementById(pref.name).checked = inFriendlyConfig ?
-				Twinkle.defaultConfig.friendly[pref.name] : Twinkle.defaultConfig.twinkle[pref.name];
+			document.getElementById(pref.name).checked = Twinkle.defaultConfig[pref.name];
 			break;
 
 		case 'string':
 		case 'integer':
 		case 'enum':
-			document.getElementById(pref.name).value = inFriendlyConfig ?
-				Twinkle.defaultConfig.friendly[pref.name] : Twinkle.defaultConfig.twinkle[pref.name];
+			document.getElementById(pref.name).value = Twinkle.defaultConfig[pref.name];
 			break;
 
 		case 'set':
 			$.each(pref.setValues, function(itemkey) {
 				if (document.getElementById(pref.name + '_' + itemkey)) {
-					document.getElementById(pref.name + '_' + itemkey).checked = (inFriendlyConfig ?
-						Twinkle.defaultConfig.friendly[pref.name] : Twinkle.defaultConfig.twinkle[pref.name]).indexOf(itemkey) !== -1;
+					document.getElementById(pref.name + '_' + itemkey).checked = Twinkle.defaultConfig[pref.name].indexOf(itemkey) !== -1;
 				}
 			});
 			break;
 
 		case 'customList':
-			$(document.getElementById(pref.name)).data('value', inFriendlyConfig ?
-				Twinkle.defaultConfig.friendly[pref.name] : Twinkle.defaultConfig.twinkle[pref.name]);
+			$(document.getElementById(pref.name)).data('value', Twinkle.defaultConfig[pref.name]);
 			break;
 
 		default:
@@ -1535,7 +1518,7 @@ Twinkle.config.resetAllPrefs = function twinkleconfigResetAllPrefs() {
 		}
 		$(section.preferences).each(function(prefkey, pref) {
 			if (!pref.adminOnly || Morebits.userIsInGroup('sysop')) {
-				Twinkle.config.resetPref(pref, section.inFriendlyConfig);
+				Twinkle.config.resetPref(pref);
 			}
 		});
 		return true;
@@ -1560,16 +1543,13 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 	var form = pageobj.getCallbackParameters();
 
 	// this is the object which gets serialized into JSON
-	var newConfig = {
-		twinkle: {},
-		friendly: {}
-	};
+	var newConfig = {};
 
 	// keeping track of all preferences that we encounter
 	// any others that are set in the user's current config are kept
 	// this way, preferences that this script doesn't know about are not lost
 	// (it does mean obsolete prefs will never go away, but... ah well...)
-	var foundTwinklePrefs = [], foundFriendlyPrefs = [];
+	var foundPrefs = [];
 
 	// a comparison function is needed later on
 	// it is just enough for our purposes (i.e. comparing strings, numbers, booleans,
@@ -1657,29 +1637,18 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 			}
 
 			// only save those preferences that are *different* from the default
-			if (section.inFriendlyConfig) {
-				if (userValue !== undefined && !compare(userValue, Twinkle.defaultConfig.friendly[pref.name])) {
-					newConfig.friendly[pref.name] = userValue;
-				}
-				foundFriendlyPrefs.push(pref.name);
-			} else {
-				if (userValue !== undefined && !compare(userValue, Twinkle.defaultConfig.twinkle[pref.name])) {
-					newConfig.twinkle[pref.name] = userValue;
-				}
-				foundTwinklePrefs.push(pref.name);
+			if (userValue !== undefined && !compare(userValue, Twinkle.defaultConfig[pref.name])) {
+				newConfig[pref.name] = userValue;
 			}
+			foundPrefs.push(pref.name);
 		});
 	});
 
+	// Retain the hidden preferences that may have customised by the user from twinkleoptions.js
 	if (Twinkle.prefs) {
-		$.each(Twinkle.prefs.twinkle, function(tkey, tvalue) {
-			if (foundTwinklePrefs.indexOf(tkey) === -1) {
-				newConfig.twinkle[tkey] = tvalue;
-			}
-		});
-		$.each(Twinkle.prefs.friendly, function(fkey, fvalue) {
-			if (foundFriendlyPrefs.indexOf(fkey) === -1) {
-				newConfig.friendly[fkey] = fvalue;
+		$.each(Twinkle.prefs, function(tkey, tvalue) {
+			if (foundPrefs.indexOf(tkey) === -1) {
+				newConfig[tkey] = tvalue;
 			}
 		});
 	}

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -10,7 +10,6 @@
 ****************************************
 * Mode of invocation:     Tab ("Deprod")
 * Active on:              Categories whose name contains "proposed_deletion"
-* Config directives in:   TwinkleConfig
 */
 
 Twinkle.deprod = function() {

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab on non-diff pages ("Last"); tabs on diff pages ("Since", "Since mine", "Current")
  * Active on:              Existing non-special pages
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.diff = function twinklediff() {

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Links on history, contributions, and diff pages
  * Active on:              Diff pages, history pages, contributions pages
- * Config directives in:   TwinkleConfig
  */
 
 /**

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("DI")
  * Active on:              Local nonredirect file pages (not on Commons)
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.image = function twinkleimage() {

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -11,7 +11,6 @@
  * Mode of invocation:     Tab ("PROD")
  * Active on:              Existing articles, files, books which are not redirects,
  *                         and user pages in [[:Category:Wikipedia books (user books)]]
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.prod = function twinkleprod() {

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("PP"/"RPP")
  * Active on:              Non-special, non-MediaWiki pages
- * Config directives in:   TwinkleConfig
  */
 
 // Note: a lot of code in this module is re-used/called by batchprotect.

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("CSD")
  * Active on:              Non-special, existing pages
- * Config directives in:   TwinkleConfig
  *
  * NOTE FOR DEVELOPERS:
  *   If adding a new criterion, add it to the appropriate places at the top of

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("Unlink")
  * Active on:              Non-special pages, except Wikipedia:Sandbox
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.unlink = function twinkleunlink() {

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -11,7 +11,6 @@
  * Mode of invocation:     Tab ("Warn")
  * Active on:              Any page with relevant user name (userspace, contribs,
  *                         etc.), as well as diffs and the rollback success page
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.warn = function twinklewarn() {

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -10,7 +10,6 @@
  ****************************************
  * Mode of invocation:     Tab ("XFD")
  * Active on:              Existing, non-special pages, except for file pages with no local (non-Commons) file which are not redirects
- * Config directives in:   TwinkleConfig
  */
 
 Twinkle.xfd = function twinklexfd() {

--- a/twinkle.js
+++ b/twinkle.js
@@ -176,12 +176,10 @@ if (mw.config.get('skin') === 'vector') {
 
 
 Twinkle.getPref = function twinkleGetPref(name) {
-	if (typeof Twinkle.prefs === 'object') {
-		if (Twinkle.prefs[name]) {
-			return Twinkle.prefs[name];
-		}
+	if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name]) {
+		return Twinkle.prefs[name];
 	}
-	// Old preferences format:
+	// Old preferences format, used before twinkleoptions.js was a thing
 	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name]) {
 		return window.TwinkleConfig[name];
 	}
@@ -383,7 +381,7 @@ $.ajax({
 		try {
 			var options = JSON.parse(optionsText);
 			if (options) {
-				if (options.twinkle || options.friendly) {
+				if (options.twinkle || options.friendly) { // Old preferences format
 					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
 				} else {
 					Twinkle.prefs = options;

--- a/twinkle.js
+++ b/twinkle.js
@@ -125,7 +125,7 @@ Twinkle.defaultConfig = {
 
 	// Formerly defaultConfig.friendly:
 
-  // Tag
+	// Tag
 	groupByDefault: true,
 	watchTaggedPages: true,
 	watchMergeDiscussions: true,
@@ -158,7 +158,7 @@ Twinkle.defaultConfig = {
 	// Shared
 	markSharedIPAsMinor: true
 };
-  
+
 // now some skin dependent config.
 switch (mw.config.get('skin')) {
 	case 'vector':

--- a/twinkle.js
+++ b/twinkle.js
@@ -20,7 +20,7 @@
 
 /* global Morebits */
 
-(function (window, document, $, undefined) { // Wrap with anonymous function
+(function (window, document, $) { // Wrap with anonymous function
 
 var Twinkle = {};
 window.Twinkle = Twinkle;  // allow global access
@@ -38,12 +38,12 @@ Twinkle.defaultConfig = {};
 /**
  * Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
  *
- * This holds the default set of preferences used by Twinkle. (The |friendly| object holds preferences stored in the FriendlyConfig object.)
+ * This holds the default set of preferences used by Twinkle.
  * It is important that all new preferences added here, especially admin-only ones, are also added to
  * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
  * For help on the actual preferences, see the comments in twinkleconfig.js.
  */
-Twinkle.defaultConfig.twinkle = {
+Twinkle.defaultConfig = {
 	// General
 	summaryAd: ' ([[WP:TW|TW]])',
 	deletionSummaryAd: ' ([[WP:TW|TW]])',
@@ -121,25 +121,10 @@ Twinkle.defaultConfig.twinkle = {
 	batchMax: 5000,
 	batchProtectChunks: 50,
 	batchundeleteChunks: 50,
-	proddeleteChunks: 50
-};
+	proddeleteChunks: 50,
 
-// now some skin dependent config.
-if (mw.config.get('skin') === 'vector') {
-	Twinkle.defaultConfig.twinkle.portletArea = 'right-navigation';
-	Twinkle.defaultConfig.twinkle.portletId = 'p-twinkle';
-	Twinkle.defaultConfig.twinkle.portletName = 'TW';
-	Twinkle.defaultConfig.twinkle.portletType = 'menu';
-	Twinkle.defaultConfig.twinkle.portletNext = 'p-search';
-} else {
-	Twinkle.defaultConfig.twinkle.portletArea = null;
-	Twinkle.defaultConfig.twinkle.portletId = 'p-cactions';
-	Twinkle.defaultConfig.twinkle.portletName = null;
-	Twinkle.defaultConfig.twinkle.portletType = null;
-	Twinkle.defaultConfig.twinkle.portletNext = null;
-}
+	// Formerly FriendlyConfig:
 
-Twinkle.defaultConfig.friendly = {
 	// Tag
 	groupByDefault: true,
 	watchTaggedPages: true,
@@ -174,38 +159,37 @@ Twinkle.defaultConfig.friendly = {
 	markSharedIPAsMinor: true
 };
 
+// now some skin dependent config.
+if (mw.config.get('skin') === 'vector') {
+	Twinkle.defaultConfig.portletArea = 'right-navigation';
+	Twinkle.defaultConfig.portletId = 'p-twinkle';
+	Twinkle.defaultConfig.portletName = 'TW';
+	Twinkle.defaultConfig.portletType = 'menu';
+	Twinkle.defaultConfig.portletNext = 'p-search';
+} else {
+	Twinkle.defaultConfig.portletArea = null;
+	Twinkle.defaultConfig.portletId = 'p-cactions';
+	Twinkle.defaultConfig.portletName = null;
+	Twinkle.defaultConfig.portletType = null;
+	Twinkle.defaultConfig.portletNext = null;
+}
+
+
 Twinkle.getPref = function twinkleGetPref(name) {
-	var result;
-	if (typeof Twinkle.prefs === 'object' && typeof Twinkle.prefs.twinkle === 'object') {
-		// look in Twinkle.prefs (twinkleoptions.js)
-		result = Twinkle.prefs.twinkle[name];
-	} else if (typeof window.TwinkleConfig === 'object') {
-		// look in TwinkleConfig
-		result = window.TwinkleConfig[name];
+	if (typeof Twinkle.prefs === 'object') {
+		if (Twinkle.prefs[name]) {
+			return Twinkle.prefs[name];
+		}
 	}
-
-	if (result === undefined) {
-		return Twinkle.defaultConfig.twinkle[name];
+	// Old preferences format:
+	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name]) {
+		return window.TwinkleConfig[name];
 	}
-	return result;
+	if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name]) {
+		return window.FriendlyConfig[name];
+	}
+	return Twinkle.defaultConfig[name];
 };
-
-Twinkle.getFriendlyPref = function twinkleGetFriendlyPref(name) {
-	var result;
-	if (typeof Twinkle.prefs === 'object' && typeof Twinkle.prefs.friendly === 'object') {
-		// look in Twinkle.prefs (twinkleoptions.js)
-		result = Twinkle.prefs.friendly[name];
-	} else if (typeof window.FriendlyConfig === 'object') {
-		// look in FriendlyConfig
-		result = window.FriendlyConfig[name];
-	}
-
-	if (result === undefined) {
-		return Twinkle.defaultConfig.friendly[name];
-	}
-	return result;
-};
-
 
 
 /**
@@ -398,20 +382,12 @@ $.ajax({
 
 		try {
 			var options = JSON.parse(optionsText);
-
-			// Assuming that our options evolve, we will want to transform older versions:
-			// if ( options.optionsVersion === undefined ) {
-			// ...
-			// options.optionsVersion = 1;
-			// }
-			// if ( options.optionsVersion === 1 ) {
-			// ...
-			// options.optionsVersion = 2;
-			// }
-			// At the same time, twinkleconfig.js needs to be adapted to write a higher version number into the options.
-
 			if (options) {
-				Twinkle.prefs = options;
+				if (options.twinkle || options.friendly) {
+					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
+				} else {
+					Twinkle.prefs = options;
+				}
 			}
 		} catch (e) {
 			mw.notify('Could not parse twinkleoptions.js');


### PR DESCRIPTION
- Unify the Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly to Twinkle.defaultConfig.
- Twinkle.getPref() can now retrieve friendly preferences also. Twinkle.getFriendlyPref() is removed.
- Now onwards, changes to WP:TWPREFS will save the preferences in twinkleoptions.js without separating them between twinkle and friendly. But the old format will still be acceptable.

A single config object is easier to work with, and would be helpful as far as i18n/l10n is concerned. This also simplifies a lot of code in twinkleconfig.