### PR TITLE
morebits.wiki.api: enable promise support

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1497,6 +1497,11 @@ Twinkle.speedy.callbacks = {
 				editsummary = 'Requesting speedy deletion ([[WP:CSD#' + params.normalizeds[0].toUpperCase() + '|CSD ' + params.normalizeds[0].toUpperCase() + ']]).';
 			}
 
+			// Set the correct value for |ts= parameter in {{db-g13}}
+			if (params.normalizeds.indexOf('g13') !== -1) {
+				code = code.replace('$TIMESTAMP', pageobj.getLastEditTime());
+			}
+
 			pageobj.setPageText(code + (params.normalizeds.indexOf('g10') !== -1 ? '' : '\n' + text)); // cause attack pages to be blanked
 			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 			pageobj.setWatchlist(params.watch);
@@ -1789,24 +1794,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				break;
 
 			case 'afc':  // G13
-				var query = {
-						action: 'query',
-						titles: mw.config.get('wgPageName'),
-						prop: 'revisions',
-						rvprop: 'timestamp'
-					},
-					api = new Morebits.wiki.api('Grabbing the last revision timestamp', query, function(apiobj) {
-						var xmlDoc = apiobj.getXML(),
-							isoDateString = $(xmlDoc).find('rev').attr('timestamp');
-
-						currentParams.ts = isoDateString;
-					});
-
-				// Wait for API call to finish
-				api.post({
-					async: false
-				});
-
+				currentParams.ts = '$TIMESTAMP'; // to be replaced by the last revision timestamp when page is saved
 				break;
 
 			case 'redundantimage':  // F1

--- a/morebits.js
+++ b/morebits.js
@@ -2152,6 +2152,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		return ctx.revertUser;
 	};
 
+	/** @returns {string} ISO 8601 timestamp at which the page was last edited. */
+	this.getLastEditTime = function() {
+		return ctx.lastEditTime;
+	};
+
 	// Miscellaneous getters/setters:
 
 	/**


### PR DESCRIPTION
Morebits.wiki.api.prototype.post() now returns a jQuery promise object, on which done/then/fail/catch/always handlers can be attached, as an alternative to giving the success and failure callbacks as arguments in the constructor.

On the output of $.ajax(), `done` and `fail` are changed to `then`. This makes it possible to specify exactly what arguments (and `this` context) should be available to the handlers. We specify these to match the ones used in the callbacks, (`apiobj.parent` as `this` context, and the `apiobj` as the first and only argument). This makes it easy to transition existing code using callbacks to use promises.

Tested, confirmed working!