### PR TITLE
warn: Prefer bottom warning for latest if dates are the same

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1298,7 +1298,7 @@ Twinkle.warn.callbacks = {
 			if (!(current[1] in history) || history[current[1]] < current_date) {
 				history[current[1]] = current_date;
 			}
-			if (current_date > latest.date) {
+			if (current_date >= latest.date) {
 				latest.date = current_date;
 				latest.type = current[1];
 			}


### PR DESCRIPTION
The [ancient](https://en.wikipedia.org/w/index.php?title=User%3AAzaToth%2Ftwinklewarn.js&diff=prev&oldid=138028399) check for the latest warning template present has held up pretty well (excepting #676), but if it finds multiple warnings given within the same minute - wikitext signatures don't have second-level specificity - it will choose the first one.  We should instead prefer the last one, as it's more likely to have been placed *after* its higher-up siblings.