### PR TITLE
arv: Remove moment dependency

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -16,7 +16,7 @@ There are two ways to upload Twinkle scripts to Wikipedia or another destination
 
 After the files are synced, ensure that [MediaWiki:Gadgets-definition][] contains the following lines:
 
-    * Twinkle[ResourceLoader|dependencies=mediawiki.notify,jquery.chosen,moment,ext.gadget.morebits|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
+    * Twinkle[ResourceLoader|dependencies=mediawiki.notify,jquery.chosen,ext.gadget.morebits|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
     * morebits[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,jquery.ui,jquery.tipsy|hidden]|morebits.js|morebits.css
     * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
 

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -329,6 +329,16 @@ Twinkle.arv.callback.changeCategory = function (e) {
 					var date = new Date();
 					date.setHours(date.getHours() - 48); // all since 48 hours
 
+					// Format date display for diff picker
+					var localeDiffOptions = {
+						hour: 'numeric',
+						minute: 'numeric',
+						weekday: 'short',
+						day: 'numeric',
+						month: 'short',
+						year: 'numeric'
+					};
+
 					var api = new mw.Api();
 					api.get({
 						action: 'query',
@@ -359,7 +369,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							});
 							$input.data('revinfo', rev);
 							$input.appendTo($entry);
-							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + moment(rev.timestamp).calendar() + '</a></span>').appendTo($diffs);
+							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + new Date(rev.timestamp).toLocaleDateString(undefined, localeDiffOptions) + '</a></span>').appendTo($diffs);
 						}
 					}).fail(function(data) {
 						console.log('API failed :(', data); // eslint-disable-line no-console
@@ -396,7 +406,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							});
 							$input.data('revinfo', rev);
 							$input.appendTo($entry);
-							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + moment(rev.timestamp).calendar() + '</a></span>').appendTo($warnings);
+							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + new Date(rev.timestamp).toLocaleDateString(undefined, localeDiffOptions) + '</a></span>').appendTo($warnings);
 						}
 					}).fail(function(data) {
 						console.log('API failed :(', data); // eslint-disable-line no-console
@@ -438,7 +448,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							});
 							$input.data('revinfo', rev);
 							$input.appendTo($entry);
-							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + moment(rev.timestamp).calendar() + '</a></span>').appendTo($resolves);
+							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + new Date(rev.timestamp).toLocaleDateString(undefined, localeDiffOptions) + '</a></span>').appendTo($resolves);
 						}
 
 						// add free form input
@@ -884,30 +894,41 @@ Twinkle.arv.processAN3 = function(params) {
 			grouped_diffs[lastid].push(cur);
 		}
 
+		// Define some nice display options for the diff timestamp
+		var localeOptions = {
+			hour: 'numeric',
+			hour12: false,
+			minute: 'numeric',
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric',
+			timeZone: 'UTC',
+			timeZoneName: 'short'
+		};
 		var difftext = $.map(grouped_diffs, function(sub) {
 			var ret = '';
 			if (sub.length >= 2) {
 				var last = sub[0];
 				var first = sub.slice(-1)[0];
-				var label = 'Consecutive edits made from ' + moment(first.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + ' to ' + moment(last.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]');
+				var label = 'Consecutive edits made from ' + new Date(first.timestamp).toLocaleString(undefined, localeOptions) + ' to ' + new Date(last.timestamp).toLocaleString(undefined, localeOptions);
 				ret = '# {{diff|oldid=' + first.parentid + '|diff=' + last.revid + '|label=' + label + '}}\n';
 			}
 			ret += sub.reverse().map(function(v) {
-				return (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + moment(v.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + '}} "' + v.comment + '"';
+				return (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + new Date(v.timestamp).toLocaleString(undefined, localeOptions) + '}} "' + v.comment + '"';
 			}).join('\n');
 			return ret;
 		}).reverse().join('\n');
 		var warningtext = params.warnings.reverse().map(function(v) {
-			return '# ' + ' {{diff2|' + v.revid + '|' + moment(v.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + '}} "' + v.comment + '"';
+			return '# ' + ' {{diff2|' + v.revid + '|' + new Date(v.timestamp).toLocaleString(undefined, localeOptions) + '}} "' + v.comment + '"';
 		}).join('\n');
 		var resolvetext = params.resolves.reverse().map(function(v) {
-			return '# ' + ' {{diff2|' + v.revid + '|' + moment(v.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + '}} "' + v.comment + '"';
+			return '# ' + ' {{diff2|' + v.revid + '|' + new Date(v.timestamp).toLocaleString(undefined, localeOptions) + '}} "' + v.comment + '"';
 		}).join('\n');
 
 		if (params.free_resolves) {
 			var page = params.free_resolves;
 			var rev = page.revisions[0];
-			resolvetext += '\n# ' + ' {{diff2|' + rev.revid + '|' + moment(rev.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + ' on ' + page.title + '}} "' + rev.comment + '"';
+			resolvetext += '\n# ' + ' {{diff2|' + rev.revid + '|' + new Date(rev.timestamp).toLocaleString(undefined, localeOptions) + ' on ' + page.title + '}} "' + rev.comment + '"';
 		}
 
 		var comment = params.comment.replace(/~*$/g, '').trim();


### PR DESCRIPTION
See #769 for the rationale, but tl;dr the only uses of [momentjs](https://momentjs.com/) are in `twinklearv` and are cosmetic, so loading moment is wasteful.  There are two functions we need to replace, `.format()` and `.calendar()`; this uses `.toLocaleString()` and `.toLocaleDateString()`, respectively.

Regarding formatting, doing:

```javascript
var localeOptions = {
    hour: 'numeric',
    hour12: false,
    minute: 'numeric',
    day: 'numeric',
    month: 'long',
    year: 'numeric',
    timeZone: 'UTC',
    timeZoneName: 'short'
};
new Date().toLocaleString(undefined, localeOptions);
```

produces:
>November 25, 2019, 21:36 UTC

This doesn't fully recpitulate `moment().utc().format('HH:mm, D MMMM YYYY [(UTC)]')`, which produces:
>21:36, 25 November 2019 (UTC)

The difference is negligible, and although it was chosen (0beacc07) to match on-wiki formats, that's a user preference and, notably, *not* a valid date format (see #757).  A more exact reproduction can be achieved by combining some strings, doing something like:

```javascript
var localeTimeOptions = {
    timeStyle: 'short',
    hour12: false,
    timeZone: 'UTC'
};
var d = new Date();
d.toLocaleTimeString(undefined, localeTimeOptions) + ', ' + d.toLocaleDateString(undefined, {day: 'numeric', timeZone: 'UTC'}) + ' ' + new Date().toLocaleDateString(undefined, {month: 'long', year: 'numeric', timeZone: 'UTC'}) + ' (UTC)';
```

We could place this in a function, but hardly seems necessary, especially since, depending on their selected user preference, not all users are used to the same formats.

As for the relative dates from the `.calendar()` function, they simply can't be easily replaced.  This implementation uses `.toLocaleDateString()` to produce `Fri, Nov 22, 2019, 2:03 PM`, whereas `.calendar()` would have produced `Last Friday at 2:03 PM`.  The short month and weekday names are used to declutter the window as compared to a long string.