### PR TITLE
prod: trim talk page edit summary

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -318,7 +318,7 @@ Twinkle.prod.callbacks = {
 			var talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
 			var talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
 			talkpage.setPrependText(oldprodfull);
-			talkpage.setEditSummary('Placing {{Old prod}} on the talk page' + Twinkle.getPref('summaryAd'));
+			talkpage.setEditSummary('Adding {{Old prod}}' + Twinkle.getPref('summaryAd'));
 			talkpage.setFollowRedirect(true);  // match behavior for page tagging
 			talkpage.setCreateOption('recreate');
 			talkpage.prepend();


### PR DESCRIPTION
The removed part really isn't needed since it's clear that the edit is being made to the talk page.