### PR TITLE
warn: Add option to show a list with all template warnings

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -650,7 +650,8 @@ Twinkle.config.sections = [
 					'5': 'Level 4im',
 					'6': 'Single-issue notices',
 					'7': 'Single-issue warnings',
-					'9': 'Custom warnings'
+					'9': 'Custom warnings',
+					'10': 'All warning templates',
 				}
 			},
 


### PR DESCRIPTION
Mentioned in https://github.com/azatoth/twinkle/issues/673#issuecomment-501858213.  While this makes use of 10 for `defaultWarningGroup`, I considered reusing 8, which was until the addition of the block module in #260 (well, also 430e2258) reserved for sysops to select blocking templates, to cut down on bloat.  There are a handful of users, some still active sysops, with the option set, but while that's a trivial barrier, I think it's better list it below the individual items, reinforcing the "all-of-the-above"-ness of the option.

This also tweaks the process by which `twinklewarn` tries to select the template that corresponds to what was selected in the previous menu.  As it has every item, the new kitchensink menu should always match exactly, but since the process was previously only relevant for levels 1-4im, the highest level would always be selected upon moving to the kitchensink menu (i.e., vandalism1 -> vandalism4im).  Now, in addition to doing an exact match in the kitchensink, it also won't keep searching once it has found the match.  Part of this is from #592.

Also removed a comment made incorrect by #641.