### PR TITLE
eslint: Enforce dot-notation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
 		"block-scoped-var": "error",
 		"curly": "error",
 		"default-case": "error",
+		"dot-notation": "error",
 		"eqeqeq": "error",
 		"guard-for-in": "error",
 		"no-caller": "error",

--- a/morebits-test.js
+++ b/morebits-test.js
@@ -61,18 +61,18 @@ mw.loader.using('jquery.ui', function() {
 		loadCallbackInsert: function(page) {
 			var params = page.getCallbackParameters();
 			var text = page.getPageText();
-			var pos = text.indexOf(params['beforeText']);
+			var pos = text.indexOf(params.beforeText);
 			if (pos === -1) {
-				alert('Search text "' + params['beforeText'] + '" not found!');
+				alert('Search text "' + params.beforeText + '" not found!');
 				return;
 			}
-			page.setPageText(text.substr(0, pos) + params['newText'] + text.substr(pos));
+			page.setPageText(text.substr(0, pos) + params.newText + text.substr(pos));
 			page.save(Twinkle.morebitsTest.finalSaveCallback);
 		},
 
 		loadCallbackReplace: function(page) {
 			var params = page.getCallbackParameters();
-			page.setPageText(params['newText']);
+			page.setPageText(params.newText);
 			page.save(Twinkle.morebitsTest.finalSaveCallback);
 		},
 


### PR DESCRIPTION
https://eslint.org/docs/rules/dot-notation
Best practices, fixable

----

Noted at https://github.com/azatoth/twinkle/pull/773#discussion_r352202964 that we legitimately don't use this *anywhere*, so given that we have a clear house style, might as well enforce it, especially since it's automatically fixable.