### PR TITLE
warn: Add option to autoselect warning level 1-4

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -682,7 +682,8 @@ Twinkle.config.sections = [
 					'7': 'Single-issue warnings',
 					// 8 was used for block templates before #260
 					'9': 'Custom warnings',
-					'10': 'All warning templates'
+					'10': 'All warning templates',
+					'11': 'Auto-select level (1-4)'
 				}
 			},
 
@@ -876,6 +877,13 @@ Twinkle.config.sections = [
 			// twinklefluff.js: defines how many revision to query maximum, maximum possible is 50, default is 50
 			{
 				name: 'revertMaxRevisions',
+				type: 'integer'
+			},
+			// twinklewarn.js: When using the autolevel select option, how many days makes a prior warning stale
+			// Huggle is three days ([[Special:Diff/918980316]] and [[Special:Diff/919417999]]) while ClueBotNG is two:
+			// https://github.com/DamianZaremba/cluebotng/blob/4958e25d6874cba01c75f11debd2e511fd5a2ce5/bot/action_functions.php#L62
+			{
+				name: 'autolevelStaleDays',
 				type: 'integer'
 			},
 			// twinklebatchdelete.js: How many pages should be processed maximum

--- a/twinkle.js
+++ b/twinkle.js
@@ -121,6 +121,7 @@ Twinkle.defaultConfig = {
 
 	// Hidden preferences
 	revertMaxRevisions: 50,
+	autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
 	batchMax: 5000,
 	batchdeleteChunks: 50,
 	batchProtectChunks: 50,


### PR DESCRIPTION
Edit April 2020: Very different, see https://github.com/azatoth/twinkle/pull/777#issuecomment-616898576

----

*Original message*

Full commit messages are below, but this will most certainly conflict with #759 and #773 so <s>opened as a draft</s> should wait on those; still, I wanted to discuss a few things here while testing/etc.:

* How long should elapse before a previous warning is considered stale and we reset the level rather than increment higher?
	* AFAICT, the default for Huggle is 30 days ([noted on enwiki](https://en.wikipedia.org/wiki/Wikipedia:Huggle/Feedback/Archive_21#Autowarn_and_stale_warnings), present in code at [1](https://github.com/huggle/huggle3-qt-lx/blob/13df16adf5744825f8a27d70b3bab998ad19f4b0/src/huggle_core/configuration.cpp#L187) and [2](https://github.com/huggle/huggle3-qt-lx/blob/13df16adf5744825f8a27d70b3bab998ad19f4b0/src/huggle_core/projectconfiguration.hpp#L172)) but on enWiki this is [currently set to 3 days](https://en.wikipedia.org/w/index.php?title=Wikipedia:Huggle/Config.yaml&diff=919417999&oldid=918243346). (I know I provided this to you @tobefree, but do check that I'm correct)
	* CBNG seems to [use 2 days](https://github.com/DamianZaremba/cluebotng/blob/4958e25d6874cba01c75f11debd2e511fd5a2ce5/bot/action_functions.php#L62).
* That default level is currently structured as a hidden ("advanced") preference, `autolevelStaleDays`, but should we make it open for user customization?  HG's is.
* <s>If they already have a level 4 warning, should saying **no** to the "do you really want to warn instead of report to AIV?" provide the user a link to the ARV module (current implementation) or just auto-open the ARV module for them?</s>
* <s>This uses the level 2 warnings for the previews; I wanted level 3 as that seemed an okay balance to ensure users know what the message could be, but there's one template without a level 3 warning (`{{uw-tempabuse3}]`).  That *does exist* as a redirect to `{{uw-disruptive3}}`, so if level 3 really is a better middle ground, we could add that redirect into the messages object.</s>
* <s>Is the display (no curlies, note that it's in reference to the series) a good idea?</s>

<s>I've left the hidden pref and the AIV link as separate commits in case that makes it easier to test/parse what I'm looking for feedback on.</s>  Maybe some of this should get discussed at WT:TW?  @musikanimal You do a lot of anti vandal work, so I wouldn't mind your input here.