### PR TITLE
XfD: Move RM technical request down

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1444,7 +1444,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var newtext = text.replace('---- and enter on a new line, directly below -->', '---- and enter on a new line, directly below -->\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
+			var newtext = text.replace('==== Contested technical requests ====', Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params) + '\n==== Contested technical requests ====');
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;


### PR DESCRIPTION
Per https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=929502397#RM_requests, these should be added at the bottom of the section (directly above the next section header) rather than the top.