### PR TITLE
protect: use API text output to check if page is redirect

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1439,7 +1439,7 @@ Twinkle.protect.callbacks = {
 		if (params.tag === 'none') {
 			summary = 'Removing protection template' + Twinkle.getPref('summaryAd');
 		} else {
-			if (Morebits.wiki.isPageRedirect()) {
+			if (/^\s*#redirect/i.test(text)) { // redirect page
 				// Only tag if no {{rcat shell}} is found
 				if (!text.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
 					text = text.replace(/#REDIRECT ?(\[\[.*?\]\])(.*)/i, '#REDIRECT $1$2\n\n{{' + tag + '}}');


### PR DESCRIPTION
Where available, content returned by the API should always be used rather than mw config data as it is more up-to-date.
Fixes the bug reported on [WT:TW](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Adding_protection_templates_on_redirects_breaks_the_redirect).