### PR TITLE
Morebits: Remove old outdated comment

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2855,7 +2855,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.movetalk = 'true';
 		}
 		if (ctx.moveSubpages) {
-			query.movesubpages = 'true';  // XXX don't know whether this works for non-admins
+			query.movesubpages = 'true';
 		}
 		if (ctx.moveSuppressRedirect) {
 			query.noredirect = 'true';


### PR DESCRIPTION
In fnProcessMove, remove the comment `XXX don't know whether this works for non-admins` after logic handling query.movesubpages - if the user cannot move subpages, this is enforced by the mediawiki api (https://gerrit.wikimedia.org/g/mediawiki/core/+/e398253aba0652afcf2a6eeb9fdb67e0a4ef8f0a/includes/api/ApiMove.php#210) and some non-admins (page movers) do indeed have the ability to move subpages.