### PR TITLE
warn: renamed uw-inline-el to uw-elinbody

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -870,6 +870,10 @@ Twinkle.warn.messages = {
 			label: 'Not using edit summary',
 			summary: 'Notice: Not using edit summary'
 		},
+		'uw-elinbody': {
+			label: 'Adding external links to the body of an article',
+			summary: 'Notice: Keep external links to External links sections at the bottom of an article'
+		},
 		'uw-english': {
 			label: 'Not communicating in English',
 			summary: 'Notice: Not communicating in English'
@@ -877,10 +881,6 @@ Twinkle.warn.messages = {
 		'uw-hasty': {
 			label: 'Hasty addition of speedy deletion tags',
 			summary: 'Notice: Allow creators time to improve their articles before tagging them for deletion'
-		},
-		'uw-inline-el': {
-			label: 'Adding external links to the body of an article',
-			summary: 'Notice: Keep external links to External links sections at the bottom of an article'
 		},
 		'uw-italicize': {
 			label: 'Italicize books, films, albums, magazines, TV series, etc within articles',


### PR DESCRIPTION
[Reported at WT:TW](http://en.wikipedia.org/wiki/Special:Permalink/931480269#uw-inline-el)

----

Opened as draft in case it's reverted/further changed.