### PR TITLE
speedy/image: Silently append File: prefix on speedy parameters

### DIFF
--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -160,7 +160,8 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 			work_area.append({
 				type: 'input',
 				name: 'replacement',
-				label: 'Replacement: '
+				label: 'Replacement: ',
+				tooltip: 'Optional file that replaces this one.  The "File:" prefix is optional.'
 			});
 			break;
 		case 'replaceable fair use':
@@ -197,8 +198,9 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 	if (event.target.reason) {
 		reason = event.target.reason.value;
 	}
-	if (event.target.replacement) {
-		replacement = event.target.replacement.value.replace(/^\s*(Image|File):/i, '');
+	if (event.target.replacement.value && event.target.replacement.value.trim()) {
+		replacement = event.target.replacement.value;
+		replacement = /^\s*(Image|File):/i.test(replacement) ? replacement : 'File:' + replacement;
 	}
 	if (event.target.derivative) {
 		derivative = event.target.derivative.checked;

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1558,15 +1558,14 @@ Twinkle.speedy.callbacks = {
 					(normalize === 'G6' && csdparam === 'fullvotepage') ||
 					(normalize === 'G6' && csdparam === 'sourcepage') ||
 					(normalize === 'A2' && csdparam === 'source') ||
-					(normalize === 'A10' && csdparam === 'article')) {
+					(normalize === 'A10' && csdparam === 'article') ||
+					(normalize === 'F1' && csdparam === 'filename') ||
+					(normalize === 'F5' && csdparam === 'replacement')) {
 					input = '[[:' + input + ']]';
 				} else if (normalize === 'G5' && csdparam === 'user') {
 					input = '[[:User:' + input + ']]';
 				} else if (normalize === 'G12' && csdparam.lastIndexOf('url', 0) === 0 && input.lastIndexOf('http', 0) === 0) {
 					input = '[' + input + ' ' + input + ']';
-				} else if ((normalize === 'F1' && csdparam === 'filename') ||
-					(normalize === 'F5' && csdparam === 'replacement')) {
-					input = '[[:File:' + input + ']]';
 				} else if (normalize === 'T3' && csdparam === 'template') {
 					input = '[[:Template:' + input + ']]';
 				} else if (normalize === 'F8' && csdparam === 'filename') {
@@ -1816,7 +1815,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 						parameters = null;
 						return false;
 					}
-					currentParams.filename = redimage.replace(/^\s*(Image|File):/i, '');
+					currentParams.filename = /^\s*(Image|File):/i.test(redimage) ? redimage : 'File:' + redimage;
 				}
 				break;
 
@@ -1829,8 +1828,8 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 			case 'commons':  // F8
 				if (form['csd.commons_filename']) {
 					var filename = form['csd.commons_filename'].value;
-					if (filename && filename !== Morebits.pageNameNorm) {
-						currentParams.filename = filename.indexOf('Image:') === 0 || filename.indexOf('File:') === 0 ? filename : 'File:' + filename;
+					if (filename && filename.trim() && filename !== Morebits.pageNameNorm) {
+						currentParams.filename = /^\s*(Image|File):/i.test(filename) ? filename : 'File:' + filename;
 					}
 				}
 				break;


### PR DESCRIPTION
The relevant templates (F1 and F8 in twinklespeedy; F5 in twinkleimage) each work either with or without the namespace prefix, but aligning them is a bit more neat, and as discussed in #695, this is somewhat more ideal.