### PR TITLE
fluff: Restructure fluff to use Twinkle.fluff() instead of Twinkle.fluff.init()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Some things to watch out for:
 - If your tests have any chance of making actual edits, consider making them in a sandbox; be aware that some things may not work properly outside the appropriate namespace.  An even better place to test is on the [test wiki](http://test.wikipedia.org)!  Some parts of Twinkle rely on specific template code or on certain wiki-preferences, so testing certain things outside of enWiki may be difficlut (e.g., pending changes).
 - The non-module scripts `morebits.js` and `twinkle.js` are usually more complicated to test.
 - The `twinkleconfig` pseudo-module holds the code to save and determine user preferences, while `twinkle.js` holds the defaults.
-- There is some variety in how the individual modules are written, in particular between the `friendly` family, as well as with `twinklefluff.js` and `twinkleconfig.js`.
+- There is some variety in how the individual modules are written, in particular among the `friendly` family as well as with `twinkleconfig.js`.
 
 As Twinkle is used many thousands of times a day, changes to how Twinkle works may be confusing or disruptive to editors.  Significant or major changes to workflow, design, or functionality should gain some modicum of consensus before being proposed or suggested, either through discussion at [Wikipedia talk:Twinkle][] or elsewhere.
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -36,7 +36,7 @@ Twinkle.fluff = function twinklefluff() {
 				Twinkle.fluff.auto();
 			}
 		} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Contributions') {
-			Twinkle.fluff.contributions();
+			Twinkle.fluff.addLinks.contributions();
 		} else if (mw.config.get('wgIsProbablyEditable')) {
 			// Only proceed if the user can actually edit the page
 			// in question (ignored for contributions, see #632).
@@ -46,10 +46,10 @@ Twinkle.fluff = function twinklefluff() {
 			// cascading or TitleBlacklist restrictions
 			if (mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId')) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
 				mw.hook('wikipage.diff').add(function () { // Reload alongside the revision slider
-					Twinkle.fluff.diff();
+					Twinkle.fluff.addLinks.diff();
 				});
 			} else if (mw.config.get('wgAction') === 'view' && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId')) {
-				Twinkle.fluff.oldid();
+				Twinkle.fluff.addLinks.oldid();
 			}
 		}
 	}
@@ -83,45 +83,120 @@ Twinkle.fluff.auto = function twinklefluffauto() {
 	Twinkle.fluff.revert(Morebits.queryString.get('twinklerevert'), vandal, true);
 };
 
-Twinkle.fluff.contributions = function twinklefluffcontributions() {
-	// $('sp-contributions-footer-anon-range') relies on the fmbox
-	// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
-	// is used to show rollback/vandalism links for IP ranges
-	if (mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0]) {
-		// Get the username these contributions are for
-		var username = mw.config.get('wgRelevantUserName');
-		if (Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
-			(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1) ||
-			(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
-			var list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
+Twinkle.fluff.addLinks = {
+	contributions: function() {
+		// $('sp-contributions-footer-anon-range') relies on the fmbox
+		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
+		// is used to show rollback/vandalism links for IP ranges
+		if (mw.config.exists('wgRelevantUserName') || !!$('#sp-contributions-footer-anon-range')[0]) {
+			// Get the username these contributions are for
+			var username = mw.config.get('wgRelevantUserName');
+			if (Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
+				(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1) ||
+				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
+				var list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
 
-			var revNode = document.createElement('strong');
-			var revLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
-			revNode.appendChild(revLink);
+				var revNode = document.createElement('strong');
+				var revLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
+				revNode.appendChild(revLink);
 
-			var revVandNode = document.createElement('strong');
-			var revVandLink = Twinkle.fluff.buildLink('Red', 'vandalism');
-			revVandNode.appendChild(revVandLink);
+				var revVandNode = document.createElement('strong');
+				var revVandLink = Twinkle.fluff.buildLink('Red', 'vandalism');
+				revVandNode.appendChild(revVandLink);
 
-			list.each(function(key, current) {
-				var href = $(current).find('.mw-changeslist-diff').attr('href');
-				current.appendChild(document.createTextNode(' '));
-				var tmpNode = revNode.cloneNode(true);
-				tmpNode.firstChild.setAttribute('href', href + '&' + Morebits.queryString.create({ 'twinklerevert': 'norm' }));
-				current.appendChild(tmpNode);
-				current.appendChild(document.createTextNode(' '));
-				tmpNode = revVandNode.cloneNode(true);
-				tmpNode.firstChild.setAttribute('href', href + '&' + Morebits.queryString.create({ 'twinklerevert': 'vand' }));
-				current.appendChild(tmpNode);
-			});
+				list.each(function(key, current) {
+					var href = $(current).find('.mw-changeslist-diff').attr('href');
+					current.appendChild(document.createTextNode(' '));
+					var tmpNode = revNode.cloneNode(true);
+					tmpNode.firstChild.setAttribute('href', href + '&' + Morebits.queryString.create({ 'twinklerevert': 'norm' }));
+					current.appendChild(tmpNode);
+					current.appendChild(document.createTextNode(' '));
+					tmpNode = revVandNode.cloneNode(true);
+					tmpNode.firstChild.setAttribute('href', href + '&' + Morebits.queryString.create({ 'twinklerevert': 'vand' }));
+					current.appendChild(tmpNode);
+				});
+			}
 		}
-	}
-};
+	},
 
-Twinkle.fluff.diff = function twinklefluffdiff() {
-	// Add a [restore this revision] link to the older revision
-	// Don't show if there's a single revision or weird diff (cur on latest)
-	if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
+	diff: function() {
+		// Add a [restore this revision] link to the older revision
+		// Don't show if there's a single revision or weird diff (cur on latest)
+		if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
+			var revertToRevision = document.createElement('div');
+			revertToRevision.setAttribute('id', 'tw-revert-to-orevision');
+			revertToRevision.style.fontWeight = 'bold';
+
+			var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
+			revertToRevisionLink.href = '#';
+			$(revertToRevisionLink).click(function() {
+				Twinkle.fluff.revertToRevision(mw.config.get('wgDiffOldId').toString());
+			});
+			revertToRevision.appendChild(revertToRevisionLink);
+
+			var otitle = document.getElementById('mw-diff-otitle1').parentNode;
+			otitle.insertBefore(revertToRevision, otitle.firstChild);
+		}
+
+		// Add either restore or rollback links to the newer revision
+		// Don't show if there's a single revision or weird diff (prev on first)
+		var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
+		if (document.getElementById('differences-nextlink')) {
+			// Not latest revision
+			var revertToRevisionN = document.createElement('div');
+			revertToRevisionN.setAttribute('id', 'tw-revert-to-nrevision');
+			revertToRevisionN.style.fontWeight = 'bold';
+
+			var revertToRevisionNLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
+			revertToRevisionNLink.href = '#';
+			$(revertToRevisionNLink).click(function() {
+				Twinkle.fluff.revertToRevision(mw.config.get('wgDiffNewId').toString());
+			});
+			revertToRevisionN.appendChild(revertToRevisionNLink);
+
+			ntitle.insertBefore(revertToRevisionN, ntitle.firstChild);
+		} else if (Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
+			var vandal = $('#mw-diff-ntitle2').find('a').first().text();
+
+			var revertNode = document.createElement('div');
+			revertNode.setAttribute('id', 'tw-revert');
+
+			var agfNode = document.createElement('strong');
+			var vandNode = document.createElement('strong');
+			var normNode = document.createElement('strong');
+
+			var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', 'rollback (AGF)');
+			var vandLink = Twinkle.fluff.buildLink('Red', 'rollback (VANDAL)');
+			var normLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
+
+			agfLink.href = '#';
+			vandLink.href = '#';
+			normLink.href = '#';
+			$(agfLink).click(function() {
+				Twinkle.fluff.revert('agf', vandal);
+			});
+			$(vandLink).click(function() {
+				Twinkle.fluff.revert('vand', vandal);
+			});
+			$(normLink).click(function() {
+				Twinkle.fluff.revert('norm', vandal);
+			});
+
+			agfNode.appendChild(agfLink);
+			vandNode.appendChild(vandLink);
+			normNode.appendChild(normLink);
+
+			revertNode.appendChild(agfNode);
+			revertNode.appendChild(document.createTextNode(' || '));
+			revertNode.appendChild(normNode);
+			revertNode.appendChild(document.createTextNode(' || '));
+			revertNode.appendChild(vandNode);
+
+			ntitle.insertBefore(revertNode, ntitle.firstChild);
+		}
+	},
+
+	oldid: function() { // Add a [restore this revision] link on old revisions
 		var revertToRevision = document.createElement('div');
 		revertToRevision.setAttribute('id', 'tw-revert-to-orevision');
 		revertToRevision.style.fontWeight = 'bold';
@@ -129,85 +204,12 @@ Twinkle.fluff.diff = function twinklefluffdiff() {
 		var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
 		revertToRevisionLink.href = '#';
 		$(revertToRevisionLink).click(function() {
-			Twinkle.fluff.revertToRevision(mw.config.get('wgDiffOldId').toString());
+			Twinkle.fluff.revertToRevision(mw.config.get('wgRevisionId').toString());
 		});
 		revertToRevision.appendChild(revertToRevisionLink);
-
-		var otitle = document.getElementById('mw-diff-otitle1').parentNode;
+		var otitle = document.getElementById('mw-revision-info').parentNode;
 		otitle.insertBefore(revertToRevision, otitle.firstChild);
 	}
-
-	// Add either restore or rollback links to the newer revision
-	// Don't show if there's a single revision or weird diff (prev on first)
-	var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
-	if (document.getElementById('differences-nextlink')) {
-		// Not latest revision
-		var revertToRevisionN = document.createElement('div');
-		revertToRevisionN.setAttribute('id', 'tw-revert-to-nrevision');
-		revertToRevisionN.style.fontWeight = 'bold';
-
-		var revertToRevisionNLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-		revertToRevisionNLink.href = '#';
-		$(revertToRevisionNLink).click(function() {
-			Twinkle.fluff.revertToRevision(mw.config.get('wgDiffNewId').toString());
-		});
-		revertToRevisionN.appendChild(revertToRevisionNLink);
-
-		ntitle.insertBefore(revertToRevisionN, ntitle.firstChild);
-	} else if (Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
-		var vandal = $('#mw-diff-ntitle2').find('a').first().text();
-
-		var revertNode = document.createElement('div');
-		revertNode.setAttribute('id', 'tw-revert');
-
-		var agfNode = document.createElement('strong');
-		var vandNode = document.createElement('strong');
-		var normNode = document.createElement('strong');
-
-		var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', 'rollback (AGF)');
-		var vandLink = Twinkle.fluff.buildLink('Red', 'rollback (VANDAL)');
-		var normLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
-
-		agfLink.href = '#';
-		vandLink.href = '#';
-		normLink.href = '#';
-		$(agfLink).click(function() {
-			Twinkle.fluff.revert('agf', vandal);
-		});
-		$(vandLink).click(function() {
-			Twinkle.fluff.revert('vand', vandal);
-		});
-		$(normLink).click(function() {
-			Twinkle.fluff.revert('norm', vandal);
-		});
-
-		agfNode.appendChild(agfLink);
-		vandNode.appendChild(vandLink);
-		normNode.appendChild(normLink);
-
-		revertNode.appendChild(agfNode);
-		revertNode.appendChild(document.createTextNode(' || '));
-		revertNode.appendChild(normNode);
-		revertNode.appendChild(document.createTextNode(' || '));
-		revertNode.appendChild(vandNode);
-
-		ntitle.insertBefore(revertNode, ntitle.firstChild);
-	}
-};
-
-Twinkle.fluff.oldid = function twinklefluffoldid() { // Add a [restore this revision] link on old revisions
-	var revertToRevision = document.createElement('div');
-	revertToRevision.setAttribute('id', 'tw-revert-to-orevision');
-	revertToRevision.style.fontWeight = 'bold';
-
-	var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-	revertToRevisionLink.href = '#';
-	$(revertToRevisionLink).click(function() {
-		Twinkle.fluff.revertToRevision(mw.config.get('wgRevisionId').toString());
-	});
-	revertToRevision.appendChild(revertToRevisionLink);
-	var otitle = document.getElementById('mw-revision-info').parentNode;
-	otitle.insertBefore(revertToRevision, otitle.firstChild);
 };
 
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -460,7 +460,7 @@ Twinkle.load = function () {
 	Twinkle.diff();
 	Twinkle.unlink();
 	Twinkle.config.init();
-	Twinkle.fluff.init();
+	Twinkle.fluff();
 	if (Morebits.userIsInGroup('sysop')) {
 		Twinkle.deprod();
 		Twinkle.batchdelete();


### PR DESCRIPTION
`twinklefluff.js` and `twinkleconfig.js` are the only modules that are loaded via `Twinkle.module.init` rather than `Twinkle.module`.  This was sort of @atlight's work in 2c544c1 but goes all the way back to @UncleDouggie's restructuring in a79b7d9.  These are the only two modules that aren't added to a menu/tab and are instead just run, so something different did make sense.  Still, I don't see a reason for `Twinkle.fluff()` to be different from the other tool-based modules: it may not "add menu button" but it does "enable the module."  I'm fine with config being different since it's clearly very different in scope.

Oh, and we can't use `Object.assign` because IE.

----

Putting this live on testwiki for testing, especially since the diff is annoying.