### PR TITLE
Add new option to disable individual Twinkle modules

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -197,6 +197,24 @@ Twinkle.config.sections = [
 				name: 'dialogLargeFont',
 				label: 'Use larger text in Twinkle dialogs',
 				type: 'boolean'
+			},
+
+			// Twinkle.config.disabledModules (array)
+			{
+				name: 'disabledModules',
+				label: 'Turn off the selected Twinkle modules',
+				helptip: 'Anything you select here will NOT be available for use, so act with care. Uncheck to reactivate.',
+				type: 'set',
+				setValues: { arv: 'ARV', warn: 'Warn', welcome: 'Welcome', shared: 'Shared IP', talkback: 'Talkback', speedy: 'CSD', prod: 'PROD', xfd: 'XfD', image: 'Image (DI)', protect: 'Protect (RPP)', tag: 'Tag', diff: 'Diff', unlink: 'Unlink', 'fluff': 'Revert and rollback' }
+			},
+
+			// Twinkle.config.disabledSysopModules (array)
+			{
+				name: 'disabledSysopModules',
+				label: 'Turn off the selected admin-only modules',
+				helptip: 'Anything you select here will NOT be available for use, so act with care. Uncheck to reactivate.',
+				type: 'set',
+				setValues: { block: 'Block', deprod: 'DePROD', batchdelete: 'D-batch', batchprotect: 'P-batch', batchundelete: 'Und-batch' }
 			}
 		]
 	},

--- a/twinkle.js
+++ b/twinkle.js
@@ -8,9 +8,6 @@
  * Imported from github [https://github.com/azatoth/twinkle].
  * All changes should be made in the repository, otherwise they will be lost.
  *
- * To update this script from github, you must have a local repository set up. Then
- * follow the instructions at [https://github.com/azatoth/twinkle/blob/master/README.md].
- *
  * ----------
  *
  * This is AzaToth's Twinkle, the popular script sidekick for newbies, admins, and
@@ -52,6 +49,8 @@ Twinkle.defaultConfig = {
 	protectionSummaryAd: ' ([[WP:TW|TW]])',
 	userTalkPageMode: 'tab',
 	dialogLargeFont: false,
+	disabledModules: [],
+	disabledSysopModules: [],
 
 	// ARV
 	spiWatchReport: 'yes',
@@ -440,35 +439,43 @@ Twinkle.load = function () {
 	// Set custom Api-User-Agent header, for server-side logging purposes
 	Morebits.wiki.api.setApiUserAgent('Twinkle/2.0 (' + mw.config.get('wgDBname') + ')');
 
+	// Don't load modules users have disabled
+	var disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
+	var loadEnabledModules = function(module) {
+		// Not disabled, load normally
+		if (disabledModules.indexOf(module) === -1) {
+			Twinkle[module]();
+		}
+	};
 	// Load the modules in the order that the tabs should appear
 	// User/user talk-related
-	Twinkle.arv();
-	Twinkle.warn();
+	loadEnabledModules('arv');
+	loadEnabledModules('warn');
 	if (Morebits.userIsSysop) {
-		Twinkle.block();
+		loadEnabledModules('block');
 	}
-	Twinkle.welcome();
-	Twinkle.shared();
-	Twinkle.talkback();
+	loadEnabledModules('welcome');
+	loadEnabledModules('shared');
+	loadEnabledModules('talkback');
 	// Deletion
-	Twinkle.speedy();
-	Twinkle.prod();
-	Twinkle.xfd();
-	Twinkle.image();
+	loadEnabledModules('speedy');
+	loadEnabledModules('prod');
+	loadEnabledModules('xfd');
+	loadEnabledModules('image');
 	// Maintenance
-	Twinkle.protect();
-	Twinkle.tag();
+	loadEnabledModules('protect');
+	loadEnabledModules('tag');
 	// Misc. ones last
-	Twinkle.diff();
-	Twinkle.unlink();
-	Twinkle.config.init();
-	Twinkle.fluff();
+	loadEnabledModules('diff');
+	loadEnabledModules('unlink');
+	loadEnabledModules('fluff');
 	if (Morebits.userIsSysop) {
-		Twinkle.deprod();
-		Twinkle.batchdelete();
-		Twinkle.batchprotect();
-		Twinkle.batchundelete();
+		loadEnabledModules('deprod');
+		loadEnabledModules('batchdelete');
+		loadEnabledModules('batchprotect');
+		loadEnabledModules('batchundelete');
 	}
+	Twinkle.config.init(); // Can't turn off
 	// Run the initialization callbacks for any custom modules
 	Twinkle.initCallbacks.forEach(function (func) {
 		func();

--- a/twinkle.js
+++ b/twinkle.js
@@ -439,43 +439,26 @@ Twinkle.load = function () {
 	// Set custom Api-User-Agent header, for server-side logging purposes
 	Morebits.wiki.api.setApiUserAgent('Twinkle/2.0 (' + mw.config.get('wgDBname') + ')');
 
+	// Load all the modules in the order that the tabs should appear
+	var twinkleModules = [
+		// User/user talk-related
+		'arv', 'warn', 'block', 'welcome', 'shared', 'talkback',
+		// Deletion
+		'speedy', 'prod', 'xfd', 'image',
+		// Maintenance
+		'protect', 'tag',
+		// Misc. ones last
+		'diff', 'unlink', 'fluff', 'deprod', 'batchdelete', 'batchprotect', 'batchundelete'
+	];
 	// Don't load modules users have disabled
 	var disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
-	var loadEnabledModules = function(module) {
-		// Not disabled, load normally
-		if (disabledModules.indexOf(module) === -1) {
-			Twinkle[module]();
-		}
-	};
-	// Load the modules in the order that the tabs should appear
-	// User/user talk-related
-	loadEnabledModules('arv');
-	loadEnabledModules('warn');
-	if (Morebits.userIsSysop) {
-		loadEnabledModules('block');
-	}
-	loadEnabledModules('welcome');
-	loadEnabledModules('shared');
-	loadEnabledModules('talkback');
-	// Deletion
-	loadEnabledModules('speedy');
-	loadEnabledModules('prod');
-	loadEnabledModules('xfd');
-	loadEnabledModules('image');
-	// Maintenance
-	loadEnabledModules('protect');
-	loadEnabledModules('tag');
-	// Misc. ones last
-	loadEnabledModules('diff');
-	loadEnabledModules('unlink');
-	loadEnabledModules('fluff');
-	if (Morebits.userIsSysop) {
-		loadEnabledModules('deprod');
-		loadEnabledModules('batchdelete');
-		loadEnabledModules('batchprotect');
-		loadEnabledModules('batchundelete');
-	}
+	twinkleModules.filter(function(mod) {
+		return disabledModules.indexOf(mod) === -1;
+	}).forEach(function(module) {
+		Twinkle[module]();
+	});
 	Twinkle.config.init(); // Can't turn off
+
 	// Run the initialization callbacks for any custom modules
 	Twinkle.initCallbacks.forEach(function (func) {
 		func();


### PR DESCRIPTION
Not everybody uses everything, and even in a menu, a lot of menus you never intend on using is annoying.  This adds two new config options, `Twinkle.config.disabledModules` and `Twinkle.config.disabledSysopModules`, and constructs an array of module names to be turned off.  The loading mechanism in `Twinkle.js` now only loads items not explicitly turned off.  The instances where we link from one to another (deli->spoeedy, speedy->unlink) work fine since they use the `callback`.  `config` cannot be turned off, and the default is, of course, to have everything on.

----

Currently live on testwiki for testing.  Depends on #792, but if that's not committed, it'd be trivial to replace `Twinkle[module]();` with:

```javascript
if (module !== 'fluff') {
   Twinkle[module]();
} else {
  Twinkle[module].init();
}
```