### PR TITLE
Merge pull request #794 from Amorymeltzer/morebits-fixunlinker

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3334,10 +3334,10 @@ Morebits.wikitext.page.prototype = {
 		var first_char = link_target.substr(0, 1);
 		var link_re_string = '[' + first_char.toUpperCase() + first_char.toLowerCase() + ']' + RegExp.escape(link_target.substr(1), true);
 
-		// Files and Categories become links with a leading colon.
-		// e.g. [[:File:Test.png]]
+		// Files and Categories become links with a leading colon, e.g. [[:File:Test.png]]
+		// Otherwise, allow for an optional leading colon, e.g. [[:User:Test]]
 		var special_ns_re = /^(?:[Ff]ile|[Ii]mage|[Cc]ategory):/;
-		var colon = special_ns_re.test(link_target) ? ':' : '';
+		var colon = special_ns_re.test(link_target) ? ':' : ':?';
 
 		var link_simple_re = new RegExp('\\[\\[' + colon + '(' + link_re_string + ')\\]\\]', 'g');
 		var link_named_re = new RegExp('\\[\\[' + colon + link_re_string + '\\|(.+?)\\]\\]', 'g');


### PR DESCRIPTION
If someone provides a non-file or non-category link with a leading colon (such as to avoid pinging a user), `removeLink` wasn't matching it, meaning `twinkleunlink` would fail.  A number of features, most notably Twinkle itself (#411), pre-emptively prepend a number of links (CSD logs, etc.) with the colon to avoid a potential ping; those links simply weren't being unlinked.