### PR TITLE
talkback: Don't parse html, always check user talk page for optout

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -115,7 +115,7 @@ Twinkle.talkback.callback.optoutStatus = function(apiobj) {
 
 	var $status = $('#twinkle-talkback-optout-message');
 	if ($status.length) {
-		$status.append(Twinkle.talkback.optout);
+		$status.text(Twinkle.talkback.optout);
 	}
 };
 
@@ -283,7 +283,7 @@ Twinkle.talkback.changeTarget = function(e) {
 	}
 
 	if (Twinkle.talkback.optout) {
-		$('#twinkle-talkback-optout-message').append(Twinkle.talkback.optout);
+		$('#twinkle-talkback-optout-message').text(Twinkle.talkback.optout);
 	}
 };
 

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -87,7 +87,7 @@ Twinkle.talkback.callback = function() {
 	var query = {
 		action: 'query',
 		prop: 'extlinks',
-		titles: mw.config.get('wgPageName'),
+		titles: 'User talk:' + mw.config.get('wgRelevantUserName'),
 		elquery: 'userjs.invalid/noTalkback',
 		ellimit: '1'
 	};
@@ -105,7 +105,7 @@ Twinkle.talkback.callback.optoutStatus = function(apiobj) {
 		Twinkle.talkback.optout = mw.config.get('wgRelevantUserName') + ' prefers not to receive talkbacks';
 		var url = $el.text();
 		if (url.indexOf('reason=') > -1) {
-			Twinkle.talkback.optout += ': ' + decodeURIComponent(url.substring(url.indexOf('reason=') + 7)) + '.';
+			Twinkle.talkback.optout += ': ' + decodeURIComponent(url.substring(url.indexOf('reason=') + 7));
 		} else {
 			Twinkle.talkback.optout += '.';
 		}


### PR DESCRIPTION
1st commit: Template:No_talkback creates a link to `http://userjs.invalid/noTalkback?reason=`; that gets used by the talkback module to provide a custom reason to the user, but by using `.append`, it allows someone to provide and run code via `<script>`.  Changing to `.text` does away with that.  See phab:T241950.

In the future, there are other options here, such as querying `templates` (removes the ability for editors to provide a custom `reason`), querying `revisions` (regex to match page the content), or simple removing the ability to provide custom text.


2nd commit: Always check the talkpage for optout.  Also don't append a . if user provides a custom reason, allow them to pick their punctuation