### PR TITLE
Partially revert "morebits: internationalize Date, and remove unused functions"

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1249,13 +1249,19 @@ Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
  * is fairly unlikely that anyone will iterate over a Date object.
  */
 
+Date.monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
+	'July', 'August', 'September', 'October', 'November', 'December' ];
+
+Date.monthNamesAbbrev = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
 Date.prototype.getUTCMonthName = function() {
-	return mw.config.get('wgMonthNames')[this.getUTCMonth() + 1];
+	return Date.monthNames[this.getUTCMonth()];
 };
 
 Date.prototype.getUTCMonthNameAbbrev = function() {
-	return mw.config.get('wgMonthNamesShort')[this.getUTCMonth() + 1];
+	return Date.monthNamesAbbrev[this.getUTCMonth()];
 };
+
 
 // Morebits.wikipedia.namespaces is deprecated - use mw.config.get('wgFormattedNamespaces') or mw.config.get('wgNamespaceIds') instead
 


### PR DESCRIPTION
This partially reverts commit 28d50ac from #635, restoring the hardcoded values for `Date.monthNames` and `Date.monthNamesAbbrev` while `Date.prototype.getMonthName` and `Date.prototype.getMonthNameAbbrev` remain removed (unused outside of ko.wiki).

Done in advance of [phab:T219340](phabricator.wikimedia.org/T219340); see discussion in #723, including #723 (comment) and #723 (comment).

As noted there, this is not the ideal situation, but it's simple, covers our current needs, and except for the last four months, was the norm for *years*.

cc @MusikAnimal @siddharthvp @Krinkle