### PR TITLE
config: Add optionsVersion 2 to preferences now that they're unified

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1536,13 +1536,13 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 	var form = pageobj.getCallbackParameters();
 
 	// this is the object which gets serialized into JSON
-	var newConfig = {};
+	var newConfig = {optionsVersion: 2};
 
 	// keeping track of all preferences that we encounter
 	// any others that are set in the user's current config are kept
 	// this way, preferences that this script doesn't know about are not lost
 	// (it does mean obsolete prefs will never go away, but... ah well...)
-	var foundPrefs = [];
+	var foundPrefs = ['optionsVersion'];
 
 	// a comparison function is needed later on
 	// it is just enough for our purposes (i.e. comparing strings, numbers, booleans,

--- a/twinkle.js
+++ b/twinkle.js
@@ -406,6 +406,8 @@ $.ajax({
 				} else {
 					Twinkle.prefs = options;
 				}
+				// v2 established after unification of Twinkle/Friendly objects
+				Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
 			}
 		} catch (e) {
 			mw.notify('Could not parse twinkleoptions.js');


### PR DESCRIPTION
Was discussed in #762 but not done there.  The format has been pretty stable before the unification (occasional new options aside) so this is reasonable as a marker.

----

The intent here (see https://github.com/azatoth/twinkle/pull/762#issuecomment-566443649 and https://github.com/azatoth/twinkle/pull/762#issuecomment-566486414) is to just mark current preferences going forward.  Is this all there really is to it?  cc @siddharthvp (also @atlight and @MusikAnimal in case you're curious)