### PR TITLE
twinkle: fix bug from #762

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -186,14 +186,14 @@ switch (mw.config.get('skin')) {
 
 
 Twinkle.getPref = function twinkleGetPref(name) {
-	if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name]) {
+	if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
 		return Twinkle.prefs[name];
 	}
 	// Old preferences format, used before twinkleoptions.js was a thing
-	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name]) {
+	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
 		return window.TwinkleConfig[name];
 	}
-	if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name]) {
+	if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
 		return window.FriendlyConfig[name];
 	}
 	return Twinkle.defaultConfig[name];


### PR DESCRIPTION
Don't ignore falsy preference values (eg. '', false, 0).

Closes #799.