### PR TITLE
morebits: fix two bugs in lookupCreation for redirects (from #710)

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2814,7 +2814,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				ctx.statusElement.error('Could not find name of page creator');
 				return;
 			}
-			
+
 		}
 		if (!ctx.timestamp) {
 			ctx.statusElement.error('Could not find timestamp of page creation');

--- a/morebits.js
+++ b/morebits.js
@@ -2809,16 +2809,15 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		if (!ctx.creator) {
 			// fallback to give first revision author if no non-redirect version in the first 50
 			ctx.creator = $(xml).find('rev')[0].getAttribute('user');
+			ctx.timestamp = $(xml).find('rev')[0].getAttribute('timestamp');
 			if (!ctx.creator) {
 				ctx.statusElement.error('Could not find name of page creator');
+				return;
 			}
-			return;
+			
 		}
 		if (!ctx.timestamp) {
-			ctx.timestamp = $(xml).find('rev')[0].getAttribute('timestamp');
-			if (!ctx.timestamp) {
-				ctx.statusElement.error('Could not find timestamp of page creation');
-			}
+			ctx.statusElement.error('Could not find timestamp of page creation');
 			return;
 		}
 


### PR DESCRIPTION
Misplaced return statement. The `return` should have been within the `if` per #804. Closes #804.

Also ensure that the username and timestamp given are both of the same edit.