### PR TITLE
block: Add support for partial blocks

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -220,6 +220,14 @@ Twinkle.config.sections = [
 		title: 'Block user',
 		adminOnly: true,
 		preferences: [
+			// TwinkleConfig.defaultToPartialBlocks (boolean)
+			// Whether to default partial blocks on or off
+			{
+				name: 'defaultToPartialBlocks',
+				label: 'Select partial blocks by default when opening the block menu',
+				type: 'boolean'
+			},
+
 			// TwinkleConfig.blankTalkpageOnIndefBlock (boolean)
 			// if true, blank the talk page when issuing an indef block notice (per [[WP:UWUL#Indefinitely blocked users]])
 			{

--- a/twinkle.js
+++ b/twinkle.js
@@ -55,6 +55,7 @@ Twinkle.defaultConfig = {
 	spiWatchReport: 'yes',
 
 	// Block
+	defaultToPartialBlocks: false,
 	blankTalkpageOnIndefBlock: false,
 
 	// Fluff (revert and rollback)


### PR DESCRIPTION
Would close #802, but this is still a WIP, mostly because I've been swamped in RL.  I think/hope most of the work remaining is CSS and language tweaks, so I wanted to get this up for folks (you originally wrote this, @MusikAnimal, so lookin' at you) to test and/or look over.

There are some (as yet) unorganized notes in the commit message, but this makes use of select2.  Like #692, however, that means this is held up by my gadget issues in #812 (see https://github.com/azatoth/twinkle/pull/812#issuecomment-576024668 and https://github.com/azatoth/twinkle/pull/812#issuecomment-576848165).  In the mean time, you can test it by first entering in the console:

>mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.12/js/select2.min.js');
>mw.loader.load('https://tools-static.wmflabs.org/cdnjs/ajax/libs/select2/4.0.12/css/select2.min.css', 'text/css');

Or, if on testwiki:

>importScript("MediaWiki:Gadget-select2.min.js");
>importStylesheet("MediaWiki:Gadget-select2.min.css");

A lot of the code isn't pretty ATM, and could be simplified, but the vagaries of the fieldset handling in `twinkleblock` alongside using select2 and some complicated logic make for interesting bedfellows.

----

ETA: full commit message below:

Partial blocks (https://phabricator.wikimedia.org/T190350) were turned on following an RfC (https://en.wikipedia.org/wiki/Wikipedia:Requests_for_comment/Partial_blocks), so it's time to support them.  Done so by adding a checkbox that toggles a "partial" status for both the blocking and templating behaviors.

In order to support entering specific pages, the modules needs to support multiple custom user inputs, which can't be done nicely with chosen (See harvesthq/chosen#166).  We can, however, use select2's tags system, recently added in #812 to make #692 (warn/xfd) happen.

This is all an active WIP, including the policy (WP:PB) and the/any templates (right now, only {{uw-pblock}}) so a lot of this is likely to be in flux for a while.

Some stray notes:

- Adds a `defaultToPartialBlocks` preference option
- Makes use of a hidden partial item to help build the query (like `reblock`)
- Includes checks to prevent empty entries (T208645])
- Adds jumping boxes for `email`/`accountcreate` when just issuing a partial template
- Will ignore the `email`/`accountcreate` template parameters if there's an `area`
- CSS and select2 tweaks a la #692
- I've skipped proper processing in `saveFieldset` of the select2 menu items, it's easier to just do `.join('|')` for the query
- This use a variable for formatted namespaces, namely "(Article)" rather than "".  The empty string really is no good here; Morebits.wikipedia.namespacesFriendly previously handled this sort of thing, was removed in #600.
- Compared to the rest of Twinkle, this is a weird module!  Very different but pretty enjoyable all in all; @MusikAnimal built something really quite elegant here in #260.

Closes #802.