### PR TITLE
Add Morebits.date

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,7 @@
 		"jquery": true
 	},
 	"globals": {
-		"mw": true,
-		"moment": true
+		"mw": true
 	},
 	"ignorePatterns": "select2*",
 	"rules": {

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,7 +17,7 @@ There are two ways to upload Twinkle scripts to Wikipedia or another destination
 
 After the files are synced, ensure that [MediaWiki:Gadgets-definition][] contains the following lines:
 
-    * Twinkle[ResourceLoader|dependencies=mediawiki.notify,moment,ext.gadget.morebits,ext.gadget.select2|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
+    * Twinkle[ResourceLoader|dependencies=mediawiki.notify,ext.gadget.morebits,ext.gadget.select2|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
     * morebits[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,jquery.ui,jquery.tipsy|hidden]|morebits.js|morebits.css
     * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
     * select2[ResourceLoader|hidden]|select2.min.js|select2.min.css

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -360,7 +360,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							});
 							$input.data('revinfo', rev);
 							$input.appendTo($entry);
-							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + moment(rev.timestamp).calendar() + '</a></span>').appendTo($diffs);
+							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + new Morebits.date(rev.timestamp).calendar() + '</a></span>').appendTo($diffs);
 						}
 					}).fail(function(data) {
 						console.log('API failed :(', data); // eslint-disable-line no-console
@@ -398,7 +398,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							});
 							$input.data('revinfo', rev);
 							$input.appendTo($entry);
-							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + moment(rev.timestamp).calendar() + '</a></span>').appendTo($warnings);
+							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + new Morebits.date(rev.timestamp).calendar() + '</a></span>').appendTo($warnings);
 						}
 					}).fail(function(data) {
 						console.log('API failed :(', data); // eslint-disable-line no-console
@@ -441,7 +441,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							});
 							$input.data('revinfo', rev);
 							$input.appendTo($entry);
-							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + moment(rev.timestamp).calendar() + '</a></span>').appendTo($resolves);
+							$entry.append('<span>"' + rev.parsedcomment + '" at <a href="' + mw.config.get('wgScript') + '?diff=' + rev.revid + '">' + new Morebits.date(rev.timestamp).calendar() + '</a></span>').appendTo($resolves);
 						}
 
 						// add free form input
@@ -894,25 +894,25 @@ Twinkle.arv.processAN3 = function(params) {
 			if (sub.length >= 2) {
 				var last = sub[0];
 				var first = sub.slice(-1)[0];
-				var label = 'Consecutive edits made from ' + moment(first.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + ' to ' + moment(last.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]');
+				var label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + '(UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
 				ret = '# {{diff|oldid=' + first.parentid + '|diff=' + last.revid + '|label=' + label + '}}\n';
 			}
 			ret += sub.reverse().map(function(v) {
-				return (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + moment(v.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + '}} "' + v.comment + '"';
+				return (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} "' + v.comment + '"';
 			}).join('\n');
 			return ret;
 		}).reverse().join('\n');
 		var warningtext = params.warnings.reverse().map(function(v) {
-			return '# ' + ' {{diff2|' + v.revid + '|' + moment(v.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + '}} "' + v.comment + '"';
+			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} "' + v.comment + '"';
 		}).join('\n');
 		var resolvetext = params.resolves.reverse().map(function(v) {
-			return '# ' + ' {{diff2|' + v.revid + '|' + moment(v.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + '}} "' + v.comment + '"';
+			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} "' + v.comment + '"';
 		}).join('\n');
 
 		if (params.free_resolves) {
 			var page = params.free_resolves;
 			var rev = page.revisions[0];
-			resolvetext += '\n# ' + ' {{diff2|' + rev.revid + '|' + moment(rev.timestamp).utc().format('HH:mm, D MMMM YYYY [(UTC)]') + ' on ' + page.title + '}} "' + rev.comment + '"';
+			resolvetext += '\n# ' + ' {{diff2|' + rev.revid + '|' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title + '}} "' + rev.comment + '"';
 		}
 
 		var comment = params.comment.replace(/~*$/g, '').trim();

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -327,8 +327,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 					var $diffs = $(root).find('[name=diffs]');
 					$diffs.find('.entry').remove();
 
-					var date = new Date();
-					date.setHours(date.getHours() - 48); // all since 48 hours
+					var date = new Morebits.date().subtract(48, 'hours'); // all since 48 hours
 
 					var api = new mw.Api();
 					api.get({

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1555,11 +1555,9 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 	var text = pageobj.getPageText(),
 		params = pageobj.getCallbackParameters(),
 		messageData = params.messageData,
-		date = new Date(pageobj.getLoadTime());
+		date = new Morebits.date(pageobj.getLoadTime());
 
-	var dateHeaderRegex = new RegExp('^==+\\s*(?:' + date.getUTCMonthName() + '|' + date.getUTCMonthNameAbbrev() +
-		')\\s+' + date.getUTCFullYear() + '\\s*==+', 'mg');
-	var dateHeaderRegexLast, dateHeaderRegexResult;
+	var dateHeaderRegex = date.monthHeaderRegex(), dateHeaderRegexLast, dateHeaderRegexResult;
 	while ((dateHeaderRegexLast = dateHeaderRegex.exec(text)) !== null) {
 		dateHeaderRegexResult = dateHeaderRegexLast;
 	}
@@ -1576,10 +1574,10 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 
 	if (Twinkle.getPref('blankTalkpageOnIndefBlock') && params.template !== 'uw-lblock' && params.indefinite) {
 		Morebits.status.info('Info', 'Blanking talk page per preferences and creating a new level 2 heading for the date');
-		text = '== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ==\n';
+		text = date.monthHeader() + '\n';
 	} else if (!dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex) {
 		Morebits.status.info('Info', 'Will create a new level 2 heading for the date, as none was found for this month');
-		text += '== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ==\n';
+		text += date.monthHeader() + '\n';
 	}
 
 	params.expiry = typeof params.template_expiry !== 'undefined' ? params.template_expiry : params.expiry;

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -244,9 +244,9 @@ Twinkle.prod.callbacks = {
 
 		// Alert if article is at least three days old, not in Category:Living people, and BLPPROD is selected
 		if (params.blp) {
-			var timeDiff = (new Date(pageobj.getLoadTime()).getTime() - new Date(params.creation).getTime()) / 1000 / 60 / 60 / 24; // days from milliseconds
+			var isMoreThan3DaysOld = new Morebits.date(params.creation).add(3, 'days').isAfter(new Date(pageobj.getLoadTime()));
 			var blpcheck_re = /\[\[Category:Living people\]\]/i;
-			if (!blpcheck_re.test(text) && timeDiff > 3) {
+			if (!blpcheck_re.test(text) && isMoreThan3DaysOld) {
 				if (!confirm('Please note that the article is not in Category:Living people and hence may be ineligible for BLPPROD. Are you sure you want to continue? \n\nYou may wish to add the category if you proceed, unless the article is about a recently deceased person.')) {
 					return;
 				}
@@ -373,10 +373,9 @@ Twinkle.prod.callbacks = {
 		}
 
 		// create monthly header if it doesn't exist already
-		var date = new Date(pageobj.getLoadTime());
-		var headerRe = new RegExp('^==+\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm');
-		if (!headerRe.exec(text)) {
-			text += '\n\n=== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ===';
+		var date = new Morebits.date(pageobj.getLoadTime());
+		if (!date.monthHeaderRegex().test(text)) {
+			text += '\n\n' + date.monthHeader(3);
 		}
 
 		text += '\n# [[:' + Morebits.pageNameNorm + ']]';

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1593,10 +1593,9 @@ Twinkle.speedy.callbacks = {
 			}
 
 			// create monthly header
-			var date = new Date(pageobj.getLoadTime());
-			var headerRe = new RegExp('^==+\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCFullYear() + '\\s*==+', 'm');
-			if (!headerRe.exec(text)) {
-				appendText += '\n\n=== ' + date.getUTCMonthName() + ' ' + date.getUTCFullYear() + ' ===';
+			var date = new Morebits.date(pageobj.getLoadTime());
+			if (!date.monthHeaderRegex().test(text)) {
+				appendText += '\n\n' + date.monthHeader(3);
 			}
 
 			var formatParamLog = function(normalize, csdparam, input) {

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -785,9 +785,9 @@ Twinkle.xfd.callbacks = {
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.discussionPage);
 
 			// Today's list
-			var date = new Date(pageobj.getLoadTime());
-			wikipedia_page = new Morebits.wiki.page('Wikipedia:Articles for deletion/Log/' + date.getUTCFullYear() + ' ' +
-				date.getUTCMonthName() + ' ' + date.getUTCDate(), "Adding discussion to today's list");
+			var date = new Morebits.date(pageobj.getLoadTime());
+			wikipedia_page = new Morebits.wiki.page('Wikipedia:Articles for deletion/Log/' +
+				date.format('YYYY MMMM D'), "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.todaysList);
@@ -1066,9 +1066,9 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var date = new Date(pageobj.getLoadTime());
-			var date_header = '===' + date.getUTCMonthName() + ' ' + date.getUTCDate() + ', ' + date.getUTCFullYear() + '===\n';
-			var date_header_regex = new RegExp('(===\\s*' + date.getUTCMonthName() + '\\s+' + date.getUTCDate() + ',\\s+' + date.getUTCFullYear() + '\\s*===)');
+			var date = new Morebits.date(pageobj.getLoadTime());
+			var date_header = date.format('===MMMM D, YYYY===\n');
+			var date_header_regex = new RegExp(date.format('(===\\s*MMMM\\s+D,\\s+YYYY\\s*===)'));
 			var new_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
 
 			if (date_header_regex.test(text)) { // we have a section already
@@ -1340,8 +1340,8 @@ Twinkle.xfd.callbacks = {
 			};
 		},
 		main: function(params) {
-			var date = new Date(params.curtimestamp);
-			params.logpage = 'Wikipedia:Redirects for discussion/Log/' + date.getUTCFullYear() + ' ' + date.getUTCMonthName() + ' ' + date.getUTCDate();
+			var date = new Morebits.date(params.curtimestamp);
+			params.logpage = 'Wikipedia:Redirects for discussion/Log/' + date.format('YYYY MMMM D');
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
 			// Tagging redirect
@@ -1519,7 +1519,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 	}
 
 	var query, wikipedia_page, wikipedia_api, logpage, params;
-	var date = new Date(); // XXX: avoid use of client clock, still used by TfD, FfD and CfD
+	var date = new Morebits.date(); // XXX: avoid use of client clock, still used by TfD, FfD and CfD
 	switch (type) {
 
 		case 'afd': // AFD
@@ -1545,7 +1545,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				xfdtarget = '';
 			}
 
-			logpage = 'Wikipedia:Templates for discussion/Log/' + date.getUTCFullYear() + ' ' + date.getUTCMonthName() + ' ' + date.getUTCDate();
+			logpage = 'Wikipedia:Templates for discussion/Log/' + date.format('YYYY MMMM D');
 
 			params = { tfdtype: tfdtype, logpage: logpage, noinclude: noinclude, xfdcat: xfdcat, target: xfdtarget, reason: reason };
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
@@ -1656,7 +1656,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			break;
 
 		case 'ffd': // FFD
-			var dateString = date.getUTCFullYear() + ' ' + date.getUTCMonthName() + ' ' + date.getUTCDate();
+			var dateString = date.format('YYYY MMMM D');
 			logpage = 'Wikipedia:Files for discussion/' + dateString;
 			params = { usertalk: usertalk, reason: reason, date: dateString, logpage: logpage };
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
@@ -1694,7 +1694,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				xfdtarget2 = xfdtarget2.replace(/^:?Category:/i, '');
 			}
 
-			logpage = 'Wikipedia:Categories for discussion/Log/' + date.getUTCFullYear() + ' ' + date.getUTCMonthName() + ' ' + date.getUTCDate();
+			logpage = 'Wikipedia:Categories for discussion/Log/' + date.format('YYYY MMMM D');
 
 			params = { reason: reason, xfdcat: xfdcat, target: xfdtarget, target2: xfdtarget2, logpage: logpage };
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;


### PR DESCRIPTION
New class in Morebits for handling of dates per brief discussion in/after https://github.com/azatoth/twinkle/issues/769#issuecomment-566163740. 

This replaces the moment dependency. Some of the functionality here exceeds that in moment - the `format` function can read the user's preferred time zone from the site preferences, which is ideal since dates shown by MediaWiki core and extensions are in that time zone. 

All the various UTC/non-UTC abbrev/full combinations for getting month/day names are provided. I didn't particularly like doing this, but I guess it's good to have them all for the sake of completeness. Some of these get used in `format`.

The `format` function has been reworked. The [gist version](https://gist.github.com/siddharthvp/dcdc51e05aa79a5856e63ecc116dcacf) presented a couple of problems with substitution. The rewrite should be more efficient and robust, and we get to implement `calendar` in terms of `format`. 
 
`Date.prototype.getUTCMonthName` and `Date.prototype.getUTCMonthNameAbbrev` have been removed (in favour of equivalent functions in Morebits.date). This is a good thing to do as modifications of native prototypes is discouraged in modern JavaScript. 

For i18n, only the `Morebits.date.localeData` object needs to be tweaked.

Closes #769, #770 and #723.