### PR TITLE
[ARV] Confirm reporting blocked users

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -62,7 +62,7 @@ Twinkle.arv.callback = function (username, isIP) {
 		if (confirm(confirmationMessage)) {
 			Twinkle.arv.callback.showform(username);
 		}
-	}, function(err) {
+	}, function() {
 		// If something went wrong, keep going
 		Twinkle.arv.callback.showform(username);
 	});

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -58,16 +58,15 @@ Twinkle.arv.callback = function (username, isIP) {
 			}
 		}
 		confirmationMessage += ' Are you sure you want to report it?';
-		
+
 		if (confirm(confirmationMessage)) {
 			Twinkle.arv.callback.showform(username);
 		}
 	}, function(err) {
-		console.log('Error fetching block info', err);
 		// If something went wrong, keep going
 		Twinkle.arv.callback.showform(username);
 	});
-}
+};
 
 Twinkle.arv.callback.showform = function (uid) {
 	var Window = new Morebits.simpleWindow(600, 500);


### PR DESCRIPTION
Before proceeding to open the form, check if the relevant user is blocked or range blocked. If blocked, request confirmation.
The former "Twinkle.arv.callback" is now at "Twinkle.arv.callback.showform" - other than the portletLink, I didn't see any callers
Closes #816