### PR TITLE
twinkle.js: Only load on sysop-only special pages for sysops

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -424,7 +424,10 @@ $.ajax({
 Twinkle.load = function () {
 	// Don't activate on special pages other than those on the whitelist so that
 	// they load faster, especially the watchlist.
-	var specialPageWhitelist = [ 'Block', 'Contributions', 'DeletedContributions', 'Prefixindex' ];
+	var specialPageWhitelist = [ 'Block', 'Contributions' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+	if (Morebits.userIsInGroup('sysop')) {
+		specialPageWhitelist = specialPageWhitelist.concat([ 'DeletedContributions', 'Prefixindex' ]);
+	}
 	var isSpecialPage = mw.config.get('wgNamespaceNumber') === -1 &&
 		specialPageWhitelist.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1;
 


### PR DESCRIPTION
wgRelevantUserName is defined on Special:Block, so it's theoretically useful for everyone (warn, tb, etc.)