### PR TITLE
Add Morebits.userIsSysop, use everywhere instead of Morebits.userIsInGroup

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -14,7 +14,7 @@
 
 Twinkle.batchdelete = function twinklebatchdelete() {
 	if (
-		Morebits.userIsInGroup('sysop') && (
+		Morebits.userIsSysop && (
 			(mw.config.get('wgCurRevisionId') && mw.config.get('wgNamespaceNumber') > 0) ||
 			mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex'
 		)

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -15,7 +15,7 @@
 
 
 Twinkle.batchprotect = function twinklebatchprotect() {
-	if (Morebits.userIsInGroup('sysop') && ((mw.config.get('wgArticleId') > 0 && (mw.config.get('wgNamespaceNumber') === 2 ||
+	if (Morebits.userIsSysop && ((mw.config.get('wgArticleId') > 0 && (mw.config.get('wgNamespaceNumber') === 2 ||
 		mw.config.get('wgNamespaceNumber') === 4)) || mw.config.get('wgNamespaceNumber') === 14 ||
 		mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex')) {
 		Twinkle.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -14,7 +14,7 @@
 
 
 Twinkle.batchundelete = function twinklebatchundelete() {
-	if (!Morebits.userIsInGroup('sysop') || !mw.config.get('wgArticleId') || (
+	if (!Morebits.userIsSysop || !mw.config.get('wgArticleId') || (
 		mw.config.get('wgNamespaceNumber') !== mw.config.get('wgNamespaceIds').user &&
 		mw.config.get('wgNamespaceNumber') !== mw.config.get('wgNamespaceIds').project)) {
 		return;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -17,7 +17,7 @@ menuFormattedNamespaces[0] = '(Article)';
 
 Twinkle.block = function twinkleblock() {
 	// should show on Contributions or Block pages, anywhere there's a relevant user
-	if (Morebits.userIsInGroup('sysop') && mw.config.get('wgRelevantUserName')) {
+	if (Morebits.userIsSysop && mw.config.get('wgRelevantUserName')) {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -974,7 +974,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 		contentform.appendChild(container);
 
 		$(Twinkle.config.sections).each(function(sectionkey, section) {
-			if (section.hidden || (section.adminOnly && !Morebits.userIsInGroup('sysop'))) {
+			if (section.hidden || (section.adminOnly && !Morebits.userIsSysop)) {
 				return true;  // i.e. "continue" in this context
 			}
 
@@ -1003,7 +1003,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 
 			// add each of the preferences to the form
 			$(section.preferences).each(function(prefkey, pref) {
-				if (pref.adminOnly && !Morebits.userIsInGroup('sysop')) {
+				if (pref.adminOnly && !Morebits.userIsSysop) {
 					return true;  // i.e. "continue" in this context
 				}
 
@@ -1456,7 +1456,7 @@ Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
 
 	// search tactics
 	$(Twinkle.config.sections).each(function(sectionkey, section) {
-		if (section.hidden || (section.adminOnly && !Morebits.userIsInGroup('sysop'))) {
+		if (section.hidden || (section.adminOnly && !Morebits.userIsSysop)) {
 			return true;  // continue: skip impossibilities
 		}
 
@@ -1512,11 +1512,11 @@ Twinkle.config.resetPref = function twinkleconfigResetPref(pref) {
 Twinkle.config.resetAllPrefs = function twinkleconfigResetAllPrefs() {
 	// no confirmation message - the user can just refresh/close the page to abort
 	$(Twinkle.config.sections).each(function(sectionkey, section) {
-		if (section.hidden || (section.adminOnly && !Morebits.userIsInGroup('sysop'))) {
+		if (section.hidden || (section.adminOnly && !Morebits.userIsSysop)) {
 			return true;  // continue: skip impossibilities
 		}
 		$(section.preferences).each(function(prefkey, pref) {
-			if (!pref.adminOnly || Morebits.userIsInGroup('sysop')) {
+			if (!pref.adminOnly || Morebits.userIsSysop) {
 				Twinkle.config.resetPref(pref);
 			}
 		});
@@ -1577,7 +1577,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 	};
 
 	$(Twinkle.config.sections).each(function(sectionkey, section) {
-		if (section.adminOnly && !Morebits.userIsInGroup('sysop')) {
+		if (section.adminOnly && !Morebits.userIsSysop) {
 			return;  // i.e. "continue" in this context
 		}
 
@@ -1586,7 +1586,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 			var userValue;  // = undefined
 
 			// only read form values for those prefs that have them
-			if (!section.hidden && (!pref.adminOnly || Morebits.userIsInGroup('sysop'))) {
+			if (!section.hidden && (!pref.adminOnly || Morebits.userIsSysop)) {
 				switch (pref.type) {
 
 					case 'boolean':  // read from the checkbox

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -14,7 +14,7 @@
 
 Twinkle.deprod = function() {
 	if (
-		!Morebits.userIsInGroup('sysop') ||
+		!Morebits.userIsSysop ||
 		mw.config.get('wgNamespaceNumber') !== 14 ||
 		!(/proposed_deletion/i).test(mw.config.get('wgPageName'))
 	) {

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -505,7 +505,7 @@ Twinkle.fluff.callbacks = {
 
 		// figure out whether we need to/can review the edit
 		var $flagged = $(xmlDoc).find('flagged');
-		if ((Morebits.userIsInGroup('reviewer') || Morebits.userIsInGroup('sysop')) &&
+		if ((Morebits.userIsInGroup('reviewer') || Morebits.userIsSysop) &&
 				$flagged.length &&
 				$flagged.attr('stable_revid') >= self.params.goodid &&
 				$flagged.attr('pending_since')) {

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -19,13 +19,13 @@ Twinkle.protect = function twinkleprotect() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.protect.callback, Morebits.userIsInGroup('sysop') ? 'PP' : 'RPP', 'tw-rpp',
-		Morebits.userIsInGroup('sysop') ? 'Protect page' : 'Request page protection');
+	Twinkle.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
+		Morebits.userIsSysop ? 'Protect page' : 'Request page protection');
 };
 
 Twinkle.protect.callback = function twinkleprotectCallback() {
 	var Window = new Morebits.simpleWindow(620, 530);
-	Window.setTitle(Morebits.userIsInGroup('sysop') ? 'Apply, request or tag page protection' : 'Request or tag page protection');
+	Window.setTitle(Morebits.userIsSysop ? 'Apply, request or tag page protection' : 'Request or tag page protection');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Protection templates', 'Template:Protection templates');
 	Window.addFooterLink('Protection policy', 'WP:PROT');
@@ -36,7 +36,7 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 		type: 'field',
 		label: 'Type of action'
 	});
-	if (Morebits.userIsInGroup('sysop')) {
+	if (Morebits.userIsSysop) {
 		actionfield.append({
 			type: 'radio',
 			name: 'actiontype',
@@ -59,8 +59,8 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 			{
 				label: 'Request page protection',
 				value: 'request',
-				tooltip: 'If you want to request protection via WP:RPP' + (Morebits.userIsInGroup('sysop') ? ' instead of doing the protection by yourself.' : '.'),
-				checked: !Morebits.userIsInGroup('sysop')
+				tooltip: 'If you want to request protection via WP:RPP' + (Morebits.userIsSysop ? ' instead of doing the protection by yourself.' : '.'),
+				checked: !Morebits.userIsSysop
 			},
 			{
 				label: 'Tag page with protection template',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -26,12 +26,12 @@ Twinkle.speedy = function twinklespeedy() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsInGroup('sysop') ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
+	Twinkle.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
 };
 
 // This function is run when the CSD tab/header link is clicked
 Twinkle.speedy.callback = function twinklespeedyCallback() {
-	Twinkle.speedy.initDialog(Morebits.userIsInGroup('sysop') ? Twinkle.speedy.callback.evaluateSysop : Twinkle.speedy.callback.evaluateUser, true);
+	Twinkle.speedy.initDialog(Morebits.userIsSysop ? Twinkle.speedy.callback.evaluateSysop : Twinkle.speedy.callback.evaluateUser, true);
 };
 
 // Used by unlink feature
@@ -79,7 +79,6 @@ Twinkle.speedy.mode = {
 // Prepares the speedy deletion dialog and displays it
 Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 	var dialog;
-	var isSysop = Morebits.userIsInGroup('sysop');
 	Twinkle.speedy.dialog = new Morebits.simpleWindow(Twinkle.getPref('speedyWindowWidth'), Twinkle.getPref('speedyWindowHeight'));
 	dialog = Twinkle.speedy.dialog;
 	dialog.setTitle('Choose criteria for speedy deletion');
@@ -88,7 +87,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 	dialog.addFooterLink('Twinkle help', 'WP:TW/DOC#speedy');
 
 	var form = new Morebits.quickForm(callbackfunc, Twinkle.getPref('speedySelectionStyle') === 'radioClick' ? 'change' : null);
-	if (isSysop) {
+	if (Morebits.userIsSysop) {
 		form.append({
 			type: 'checkbox',
 			list: [
@@ -204,7 +203,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 		name: 'tag_options'
 	});
 
-	if (isSysop) {
+	if (Morebits.userIsSysop) {
 		tagOptions.append({
 			type: 'header',
 			label: 'Tag-related options'
@@ -220,7 +219,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 				name: 'notify',
 				tooltip: 'A notification template will be placed on the talk page of the creator, IF you have a notification enabled in your Twinkle preferences ' +
 						'for the criterion you choose AND this box is checked. The creator may be welcomed as well.',
-				checked: !isSysop || !(Twinkle.speedy.hasCSD || Twinkle.getPref('deleteSysopDefaultToDelete')),
+				checked: !Morebits.userIsSysop || !(Twinkle.speedy.hasCSD || Twinkle.getPref('deleteSysopDefaultToDelete')),
 				event: function(event) {
 					event.stopPropagation();
 				}
@@ -523,7 +522,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 
 Twinkle.speedy.customRationale = [
 	{
-		label: 'Custom rationale' + (Morebits.userIsInGroup('sysop') ? ' (custom deletion reason)' : ' using {{db}} template'),
+		label: 'Custom rationale' + (Morebits.userIsSysop ? ' (custom deletion reason)' : ' using {{db}} template'),
 		value: 'reason',
 		tooltip: '{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can\'t find any criteria that fit.',
 		subgroup: {
@@ -1564,7 +1563,7 @@ Twinkle.speedy.callbacks = {
 					"This is a log of all [[WP:CSD|speedy deletion]] nominations made by this user using [[WP:TW|Twinkle]]'s CSD module.\n\n" +
 					'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
 					'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].';
-				if (Morebits.userIsInGroup('sysop')) {
+				if (Morebits.userIsSysop) {
 					appendText += '\n\nThis log does not track outright speedy deletions made using Twinkle.';
 				}
 			}

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -15,7 +15,7 @@
 Twinkle.unlink = function twinkleunlink() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || mw.config.get('wgPageName') === 'Wikipedia:Sandbox' ||
 		// Restrict to extended confirmed users (see #428)
-		(!Morebits.userIsInGroup('extendedconfirmed') && !Morebits.userIsInGroup('sysop'))) {
+		(!Morebits.userIsInGroup('extendedconfirmed') && !Morebits.userIsSysop)) {
 		return;
 	}
 	Twinkle.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');

--- a/morebits.js
+++ b/morebits.js
@@ -48,6 +48,8 @@ window.Morebits = Morebits;  // allow global access
 Morebits.userIsInGroup = function (group) {
 	return mw.config.get('wgUserGroups').indexOf(group) !== -1;
 };
+// Used a lot
+Morebits.userIsSysop = Morebits.userIsInGroup('sysop');
 
 
 
@@ -231,7 +233,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 	var childContainder = null;
 	var label;
 	var id = (in_id ? in_id + '_' : '') + 'node_' + this.id;
-	if (data.adminonly && !Morebits.userIsInGroup('sysop')) {
+	if (data.adminonly && !Morebits.userIsSysop) {
 		// hell hack alpha
 		data.type = 'hidden';
 	}
@@ -1877,7 +1879,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		if (typeof ctx.pageSection === 'number') {
 			ctx.loadQuery.rvsection = ctx.pageSection;
 		}
-		if (Morebits.userIsInGroup('sysop')) {
+		if (Morebits.userIsSysop) {
 			ctx.loadQuery.inprop = 'protection';
 		}
 
@@ -2414,7 +2416,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		if (ctx.followRedirect) {
 			query.redirects = '';  // follow all redirects
 		}
-		if (Morebits.userIsInGroup('sysop')) {
+		if (Morebits.userIsSysop) {
 			query.inprop = 'protection';
 		}
 
@@ -2434,7 +2436,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.onDeleteFailure = onFailure || emptyFunction;
 
 		// if a non-admin tries to do this, don't bother
-		if (!Morebits.userIsInGroup('sysop')) {
+		if (!Morebits.userIsSysop) {
 			ctx.statusElement.error('Cannot delete page: only admins can do that');
 			ctx.onDeleteFailure(this);
 			return;
@@ -2475,7 +2477,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.onUndeleteFailure = onFailure || emptyFunction;
 
 		// if a non-admin tries to do this, don't bother
-		if (!Morebits.userIsInGroup('sysop')) {
+		if (!Morebits.userIsSysop) {
 			ctx.statusElement.error('Cannot undelete page: only admins can do that');
 			ctx.onUndeleteFailure(this);
 			return;
@@ -2513,7 +2515,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.onProtectFailure = onFailure || emptyFunction;
 
 		// if a non-admin tries to do this, don't bother
-		if (!Morebits.userIsInGroup('sysop')) {
+		if (!Morebits.userIsSysop) {
 			ctx.statusElement.error('Cannot protect page: only admins can do that');
 			ctx.onProtectFailure(this);
 			return;
@@ -2560,7 +2562,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.onStabilizeFailure = onFailure || emptyFunction;
 
 		// if a non-admin tries to do this, don't bother
-		if (!Morebits.userIsInGroup('sysop')) {
+		if (!Morebits.userIsSysop) {
 			ctx.statusElement.error('Cannot apply FlaggedRevs settings: only admins can do that');
 			ctx.onStabilizeFailure(this);
 			return;
@@ -2615,7 +2617,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		// do we need to fetch the edit protection expiry?
-		if (Morebits.userIsInGroup('sysop') && !ctx.suppressProtectWarning) {
+		if (Morebits.userIsSysop && !ctx.suppressProtectWarning) {
 			// poor man's normalisation
 			if (Morebits.string.toUpperCaseFirstChar(mw.config.get('wgPageName')).replace(/ /g, '_').trim() !==
 				Morebits.string.toUpperCaseFirstChar(ctx.pageName).replace(/ /g, '_').trim()) {
@@ -2652,7 +2654,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		// extract protection info, to alert admins when they are about to edit a protected page
-		if (Morebits.userIsInGroup('sysop')) {
+		if (Morebits.userIsSysop) {
 			var editprot = $(xml).find('pr[type="edit"]');
 			if (editprot.length > 0 && editprot.attr('level') === 'sysop') {
 				ctx.fullyProtected = editprot.attr('expiry');
@@ -2938,7 +2940,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		// extract protection info
-		if (Morebits.userIsInGroup('sysop')) {
+		if (Morebits.userIsSysop) {
 			var editprot = $(xml).find('pr[type="edit"]');
 			if (editprot.length > 0 && editprot.attr('level') === 'sysop' && !ctx.suppressProtectWarning &&
 				!confirm('You are about to move the fully protected page "' + ctx.pageName +

--- a/twinkle.js
+++ b/twinkle.js
@@ -424,7 +424,7 @@ Twinkle.load = function () {
 	// Don't activate on special pages other than those on the whitelist so that
 	// they load faster, especially the watchlist.
 	var specialPageWhitelist = [ 'Block', 'Contributions' ]; // wgRelevantUserName defined for non-sysops on Special:Block
-	if (Morebits.userIsInGroup('sysop')) {
+	if (Morebits.userIsSysop) {
 		specialPageWhitelist = specialPageWhitelist.concat([ 'DeletedContributions', 'Prefixindex' ]);
 	}
 	if (mw.config.get('wgNamespaceNumber') === -1 &&
@@ -444,7 +444,7 @@ Twinkle.load = function () {
 	// User/user talk-related
 	Twinkle.arv();
 	Twinkle.warn();
-	if (Morebits.userIsInGroup('sysop')) {
+	if (Morebits.userIsSysop) {
 		Twinkle.block();
 	}
 	Twinkle.welcome();
@@ -463,7 +463,7 @@ Twinkle.load = function () {
 	Twinkle.unlink();
 	Twinkle.config.init();
 	Twinkle.fluff();
-	if (Morebits.userIsInGroup('sysop')) {
+	if (Morebits.userIsSysop) {
 		Twinkle.deprod();
 		Twinkle.batchdelete();
 		Twinkle.batchprotect();


### PR DESCRIPTION
We checking `Morebits.userIsInGroup('sysop')` over 40 times, it's by far the most common check.  Mentioned at https://github.com/azatoth/twinkle/pull/793#issuecomment-575462618