### PR TITLE
config: change commonEnums object to just contain the watchlist object

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -21,10 +21,7 @@
 
 Twinkle.config = {};
 
-Twinkle.config.commonEnums = {
-	watchlist: { yes: 'Add to watchlist', no: "Don't add to watchlist", 'default': 'Follow your site preferences' },
-	talkPageMode: { window: 'In a window, replacing other user talks', tab: 'In a new tab', blank: 'In a totally new window' }
-};
+Twinkle.config.watchlistEnums = { yes: 'Add to watchlist', no: "Don't add to watchlist", 'default': 'Follow your site preferences' };
 
 Twinkle.config.commonSets = {
 	csdCriteria: {
@@ -192,7 +189,7 @@ Twinkle.config.sections = [
 				name: 'userTalkPageMode',
 				label: 'When opening a user talk page, open it',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.talkPageMode
+				enumValues: { window: 'In a window, replacing other user talks', tab: 'In a new tab', blank: 'In a totally new window' }
 			},
 
 			// TwinkleConfig.dialogLargeFont (boolean)
@@ -211,7 +208,7 @@ Twinkle.config.sections = [
 				name: 'spiWatchReport',
 				label: 'Add sockpuppet report pages to watchlist',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			}
 		]
 	},
@@ -256,7 +253,7 @@ Twinkle.config.sections = [
 				name: 'deliWatchPage',
 				label: 'Add image page to watchlist when tagging',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.deliWatchUser (string)
@@ -265,7 +262,7 @@ Twinkle.config.sections = [
 				name: 'deliWatchUser',
 				label: 'Add user talk page of initial uploader to watchlist when notifying',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			}
 		]
 	},
@@ -765,7 +762,7 @@ Twinkle.config.sections = [
 				name: 'xfdWatchPage',
 				label: 'Add the nominated page to watchlist',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.xfdWatchDiscussion (string)
@@ -777,7 +774,7 @@ Twinkle.config.sections = [
 				label: 'Add the deletion discussion page to watchlist',
 				helptip: 'This refers to the discussion subpage (for AfD and MfD) or the daily log page (for TfD, CfD, RfD and FfD)',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.xfdWatchList (string)
@@ -789,7 +786,7 @@ Twinkle.config.sections = [
 				label: 'Add the daily log/list page to the watchlist (where applicable)',
 				helptip: 'This only applies for AfD and MfD, where the discussions are transcluded onto a daily log page (for AfD) or the main MfD page (for MfD).',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.xfdWatchUser (string)
@@ -799,7 +796,7 @@ Twinkle.config.sections = [
 				name: 'xfdWatchUser',
 				label: 'Add user talk page of initial contributor to watchlist (when notifying)',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.xfdWatchRelated (string)
@@ -810,7 +807,7 @@ Twinkle.config.sections = [
 				label: "Add the redirect's target page to watchlist (when notifying)",
 				helptip: 'This only applies for RfD, when leaving a notification on the talk page of the target of the redirect',
 				type: 'enum',
-				enumValues: Twinkle.config.commonEnums.watchlist
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			{


### PR DESCRIPTION
`Twinkle.config.commonEnums.watchlist` renamed to `Twinkle.config.watchlistEnums` while `commonEnums.talkPageMode` is just moved to its specific location.  Only `commonEnums.watchlist` was actually "common" in `config`; `commonEnums.talkPageMode` was only used once.  This likely stems from fead344 where it was used twice and consolidated just prior to the `twinkleconfig` system being created in 846b727, and never got used again.