### PR TITLE
block: Link pages in partial block template

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1398,7 +1398,9 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 				};
 				text += '|area=from certain ';
 				if (params.pagerestrictions.length) {
-					text += 'pages (' + makeSentence(params.pagerestrictions);
+					text += 'pages (' + makeSentence(params.pagerestrictions.map(function(p) {
+						return '[[:' + p + ']]';
+					}));
 					text += params.namespacerestrictions.length ? ') and certain ' : ')';
 				}
 				if (params.namespacerestrictions.length) {
@@ -1406,7 +1408,7 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 					var namespaceNames = params.namespacerestrictions.map(function(id) {
 						return menuFormattedNamespaces[id];
 					});
-					text += 'namespaces (' + makeSentence(namespaceNames) + ')';
+					text += '[[Wikipedia:Namespace|namespaces]] (' + makeSentence(namespaceNames) + ')';
 				}
 			} else if (params.area) {
 				text += '|area=' + params.area;


### PR DESCRIPTION
Probably should have been included to begin with in #813.

Also link to [[WP:Namespace]], although I'm not sure if that's particularly helpful.