### PR TITLE
Remove Twinkle.userAuthorized

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -17,40 +17,38 @@
  */
 
 Twinkle.fluff = function twinklefluff() {
-	if (Twinkle.userAuthorized) {
-		// A list of usernames, usually only bots, that vandalism revert is jumped over; that is,
-		// if vandalism revert was chosen on such username, then its target is on the revision before.
-		// This is for handling quick bots that makes edits seconds after the original edit is made.
-		// This only affects vandalism rollback; for good faith rollback, it will stop, indicating a bot
-		// has no faith, and for normal rollback, it will rollback that edit.
-		Twinkle.fluff.whiteList = [
-			'AnomieBOT',
-			'SineBot'
-		];
+	// A list of usernames, usually only bots, that vandalism revert is jumped over; that is,
+	// if vandalism revert was chosen on such username, then its target is on the revision before.
+	// This is for handling quick bots that makes edits seconds after the original edit is made.
+	// This only affects vandalism rollback; for good faith rollback, it will stop, indicating a bot
+	// has no faith, and for normal rollback, it will rollback that edit.
+	Twinkle.fluff.whiteList = [
+		'AnomieBOT',
+		'SineBot'
+	];
 
-		if (mw.util.getParamValue('twinklerevert')) {
-			// Return if the user can't edit the page in question
-			if (!mw.config.get('wgIsProbablyEditable')) {
-				alert("Unable to edit the page, it's probably protected.");
-			} else {
-				Twinkle.fluff.auto();
-			}
-		} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Contributions') {
-			Twinkle.fluff.addLinks.contributions();
-		} else if (mw.config.get('wgIsProbablyEditable')) {
-			// Only proceed if the user can actually edit the page
-			// in question (ignored for contributions, see #632).
-			// wgIsProbablyEditable should take care of
-			// namespace/contentModel restrictions as well as
-			// explicit protections; it won't take care of
-			// cascading or TitleBlacklist restrictions
-			if (mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId')) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
-				mw.hook('wikipage.diff').add(function () { // Reload alongside the revision slider
-					Twinkle.fluff.addLinks.diff();
-				});
-			} else if (mw.config.get('wgAction') === 'view' && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId')) {
-				Twinkle.fluff.addLinks.oldid();
-			}
+	if (mw.util.getParamValue('twinklerevert')) {
+		// Return if the user can't edit the page in question
+		if (!mw.config.get('wgIsProbablyEditable')) {
+			alert("Unable to edit the page, it's probably protected.");
+		} else {
+			Twinkle.fluff.auto();
+		}
+	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Contributions') {
+		Twinkle.fluff.addLinks.contributions();
+	} else if (mw.config.get('wgIsProbablyEditable')) {
+		// Only proceed if the user can actually edit the page
+		// in question (ignored for contributions, see #632).
+		// wgIsProbablyEditable should take care of
+		// namespace/contentModel restrictions as well as
+		// explicit protections; it won't take care of
+		// cascading or TitleBlacklist restrictions
+		if (mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId')) { // wgDiffOldId included for clarity in if else loop [[phab:T214985]]
+			mw.hook('wikipage.diff').add(function () { // Reload alongside the revision slider
+				Twinkle.fluff.addLinks.diff();
+			});
+		} else if (mw.config.get('wgAction') === 'view' && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId')) {
+			Twinkle.fluff.addLinks.oldid();
 		}
 	}
 };

--- a/twinkle.js
+++ b/twinkle.js
@@ -22,11 +22,13 @@
 
 (function (window, document, $) { // Wrap with anonymous function
 
+// Check if account is experienced enough to use Twinkle
+if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirmed')) {
+	return;
+}
+
 var Twinkle = {};
 window.Twinkle = Twinkle;  // allow global access
-
-// Check if account is experienced enough to use Twinkle
-Twinkle.userAuthorized = Morebits.userIsInGroup('autoconfirmed') || Morebits.userIsInGroup('confirmed');
 
 // for use by custom modules (normally empty)
 Twinkle.initCallbacks = [];
@@ -314,9 +316,6 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 
 		$(a).click(function(e) {
 			e.preventDefault();
-			if (!Twinkle.userAuthorized) {
-				alert('Sorry, your account is too new to use Twinkle.');
-			}
 		});
 
 		h5.appendChild(a);
@@ -428,11 +427,8 @@ Twinkle.load = function () {
 	if (Morebits.userIsInGroup('sysop')) {
 		specialPageWhitelist = specialPageWhitelist.concat([ 'DeletedContributions', 'Prefixindex' ]);
 	}
-	var isSpecialPage = mw.config.get('wgNamespaceNumber') === -1 &&
-		specialPageWhitelist.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1;
-
-	// Prevent users that are not autoconfirmed from loading Twinkle as well.
-	if (isSpecialPage || !Twinkle.userAuthorized) {
+	if (mw.config.get('wgNamespaceNumber') === -1 &&
+		specialPageWhitelist.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
 		return;
 	}
 


### PR DESCRIPTION
It's not really serving much of a purpose: used only in `twinkle.js` and `twinklefluff.js`.  Consolidated in 6dc2a75 (2013) as part of #151, where the requirement was added to the gadget definition.  It used to be checked in each module (ad5af2f, 2011) but is now left just in `fluff`; there's some sense to that, though, as `fluff` is the only one that doesn't add a menu button (see also #792).

The reality, though, is that `Twinkle.userAuthorized = false` is not much of a "security" check, all the moreso because it came in `Twinkle.load`.  Moving the check higher up, before the Twinkle object is declared, makes things somewhat more tricky.  We could be slightly trickier, forgoing `Morebits` and doing:

`!(mw.config.get('wgUserGroups').indexOf('autoconfirmed')!==-1 || mw.config.get('wgUserGroups').indexOf('confirmed')!==-1)`

but the reality is that anyone trying to get past it will have no difficult doing that as well; indeed, anyone seriously attempting this far would probably just copy/write their own.  Anything more complicated is probably not worth doing.

I've removed the check in `fluff` but not replaced it with anything; thus it's possible for someone to somewhat easily get the links, but, as above not particularly difficult or protective.

I've also removed the message in `Twinkle.addPortlet` as I couldn't trigger the message, so not sure about that.

----

Opened as a draft as this is mostly me thinking out loud and not, like, a major issue; mostly I just think it's currently less effective and (slightly) more complicated than need be.  Still, I welcome other thoughts.  Another idea is to have Twinkle set a requirement, which is checked by Morebits for each API query.  That seems overkill by far.