### PR TITLE
 tag: fix broken discussion links in merge tags

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1527,24 +1527,22 @@ Twinkle.tag.callbacks = {
 					case 'Merge to':
 					case 'Merge from':
 						params.mergeTag = tagName;
-						if (params.mergeTarget) {
-							// normalize the merge target for now and later
-							params.mergeTarget = Morebits.string.toUpperCaseFirstChar(params.mergeTarget.replace(/_/g, ' '));
+						// normalize the merge target for now and later
+						params.mergeTarget = Morebits.string.toUpperCaseFirstChar(params.mergeTarget.replace(/_/g, ' '));
 
-							currentTag += '|' + params.mergeTarget;
+						currentTag += '|' + params.mergeTarget;
 
-							// link to the correct section on the talk page, for article space only
-							if (mw.config.get('wgNamespaceNumber') === 0 && (params.mergeReason || params.discussArticle)) {
-								if (!params.discussArticle) {
-									// discussArticle is the article whose talk page will contain the discussion
-									params.discussArticle = tagName === 'Merge to' ? params.mergeTarget : mw.config.get('wgTitle');
-									// nonDiscussArticle is the article which won't have the discussion
-									params.nonDiscussArticle = tagName === 'Merge to' ? mw.config.get('wgTitle') : params.mergeTarget;
-									var direction = params.nonDiscussArticle + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + params.discussArticle;
-									params.talkDiscussionTitle = 'Proposed merge of ' + direction;
-								}
-								currentTag += '|discuss=Talk:' + params.discussArticle + '#' + params.talkDiscussionTitle;
+						// link to the correct section on the talk page, for article space only
+						if (mw.config.get('wgNamespaceNumber') === 0 && (params.mergeReason || params.discussArticle)) {
+							if (!params.discussArticle) {
+								// discussArticle is the article whose talk page will contain the discussion
+								params.discussArticle = tagName === 'Merge to' ? params.mergeTarget : mw.config.get('wgTitle');
+								// nonDiscussArticle is the article which won't have the discussion
+								params.nonDiscussArticle = tagName === 'Merge to' ? mw.config.get('wgTitle') : params.mergeTarget;
+								var direction = params.nonDiscussArticle + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + params.discussArticle;
+								params.talkDiscussionTitle = 'Proposed merge of ' + direction;
 							}
+							currentTag += '|discuss=Talk:' + params.discussArticle + '#' + params.talkDiscussionTitle;
 						}
 						break;
 					default:

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1246,15 +1246,12 @@ Twinkle.tag.callbacks = {
 			pageobj.save(function() {
 				// special functions for merge tags
 				if (params.mergeReason) {
-					// Use similar language for talkpage header and edit summary
-					var direction = '[[:' + params.nonDiscussArticle + ']] ' + (params.mergeTag === 'Merge' ? 'with' : 'into') + ' [[:' + params.discussArticle + ']]';
 					// post the rationale on the talk page (only operates in main namespace)
-					var talkpageText = '\n\n== Proposed merge of ' + direction + '  ==\n\n';
+					var talkpageText = '\n\n== ' + params.talkDiscussionTitle + ' ==\n\n';
 					talkpageText += params.mergeReason.trim() + ' ~~~~';
-
 					var talkpage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					talkpage.setAppendText(talkpageText);
-					talkpage.setEditSummary('Proposing to merge ' + direction + Twinkle.getPref('summaryAd'));
+					talkpage.setEditSummary('/* ' + params.talkDiscussionTitle + ' */ new section' + Twinkle.getPref('summaryAd'));
 					talkpage.setWatchlist(Twinkle.getPref('watchMergeDiscussions'));
 					talkpage.setCreateOption('recreate');
 					talkpage.append();
@@ -1543,7 +1540,8 @@ Twinkle.tag.callbacks = {
 									params.discussArticle = tagName === 'Merge to' ? params.mergeTarget : mw.config.get('wgTitle');
 									// nonDiscussArticle is the article which won't have the discussion
 									params.nonDiscussArticle = tagName === 'Merge to' ? mw.config.get('wgTitle') : params.mergeTarget;
-									params.talkDiscussionTitle = 'Proposed merge with ' + params.nonDiscussArticle;
+									var direction = params.nonDiscussArticle + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + params.discussArticle;
+									params.talkDiscussionTitle = 'Proposed merge of ' + direction;
 								}
 								currentTag += '|discuss=Talk:' + params.discussArticle + '#' + params.talkDiscussionTitle;
 							}


### PR DESCRIPTION
Solves bug reported on [TW talk](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Automated_%22merge_from%22) - the talk page section title used in the template's discuss link should match the one actually produced. 

Also, adjusted the edit summary to be a section link to the discussion (kinda fake section=new API action). This seems to be a better alternative that no thought of in #717 where we discussed it earlier, @Amorymeltzer.

The only bug left is that TW unnecessarily adds `\n\n` (visible extra whitespace) if the talk page was empty (also there in some other modules - talkback I think). But I think there's no easy fix short of adding `section=new` support into morebits, or not adding `\n\n` at all (leads to untidy wikicode on non-new pages).

The 2nd commit does away with `params.mergeTarget` check which isn't required as the field is compulsory (since #545). 

Tests:
- Tagging {{merge}}: [source](https://test.wikipedia.org/w/index.php?title=SD0001test&diff=next&oldid=413427), [destination](https://test.wikipedia.org/w/index.php?title=SD0001test2&diff=next&oldid=413428), [source talk](https://test.wikipedia.org/w/index.php?title=Talk:SD0001test&diff=next&oldid=413425)
- Tagging {{merge from}}: [source](https://test.wikipedia.org/w/index.php?title=SD0001test&diff=413441&oldid=413439), [destination](https://test.wikipedia.org/w/index.php?title=SD0001test2&diff=413443&oldid=413440), [source talk](https://test.wikipedia.org/w/index.php?title=Talk:SD0001test&diff=413442&oldid=413430)
- Tagging {{merge to}}: [source](https://test.wikipedia.org/w/index.php?title=SD0001test&diff=413435&oldid=413432), [destination](https://test.wikipedia.org/w/index.php?title=SD0001test2&diff=413437&oldid=413434), [destination talk](https://test.wikipedia.org/w/index.php?title=Talk:SD0001test2&diff=413436&oldid=404636)