### PR TITLE
speedy: Fix bug affecting checking of warnuser when toggling modes

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -115,7 +115,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 						cForm.notify.checked = cChecked;
 						// enable/disable deletion notification checkbox
 						cForm.warnusertalk.disabled = cChecked;
-						cForm.warnusertalk.checked = !cChecked;
+						cForm.warnusertalk.checked = !cChecked && $('#delete-reason').length < 1;
 						// enable/disable multiple
 						cForm.multiple.disabled = !cChecked;
 						cForm.multiple.checked = false;


### PR DESCRIPTION
A sysop toggling modes would lose the default unchecked-if-csd-present status