### PR TITLE
warn/fluff: Move code adding extraparams to user talk from warn to fluff

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -120,9 +120,29 @@ Twinkle.fluff.addLinks = {
 	},
 
 	diff: function() {
-		// Add a [restore this revision] link to the older revision
-		// Don't show if there's a single revision or weird diff (cur on latest)
+		// Autofill user talk links on diffs with vanarticle for easy warning, but don't autowarn
+		var warnFromTalk = function(xtitle) {
+			var talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
+			if (talkLink.length) {
+				var extraParams = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm) + '&' + 'noautowarn=true';
+				// diffIDs for vanarticlerevid
+				extraParams += '&vanarticlerevid=';
+				extraParams += xtitle === 'otitle' ? mw.config.get('wgDiffOldId') : mw.config.get('wgDiffNewId');
+
+				var href = talkLink.attr('href');
+				if (href.indexOf('?') === -1) {
+					talkLink.attr('href', href + '?' + extraParams);
+				} else {
+					talkLink.attr('href', href + '&' + extraParams);
+				}
+			}
+		};
+
+		// Don't load if there's a single revision or weird diff (cur on latest)
 		if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
+			warnFromTalk('otitle'); // Add quick-warn link to user talk link on older diff
+
+			// Add a [restore this revision] link to the older revision
 			var revertToRevision = document.createElement('div');
 			revertToRevision.setAttribute('id', 'tw-revert-to-orevision');
 			revertToRevision.style.fontWeight = 'bold';
@@ -138,6 +158,7 @@ Twinkle.fluff.addLinks = {
 			otitle.insertBefore(revertToRevision, otitle.firstChild);
 		}
 
+		warnFromTalk('ntitle'); // Add quick-warn link to user talk link on newer diff
 		// Add either restore or rollback links to the newer revision
 		// Don't show if there's a single revision or weird diff (prev on first)
 		var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -71,6 +71,24 @@ Twinkle.fluff.buildLink = function twinklefluffbuildLink(color, text) {
 	return link;
 };
 
+// Build [restore this revision] links
+Twinkle.fluff.restoreThisRevision = function (element, revType) {
+	var revertToRevision = document.createElement('div');
+	revertToRevision.setAttribute('id', 'tw-revert-to-' + (revType === 'wgDiffNewId' ? 'n' : 'o') + 'revision');
+	revertToRevision.style.fontWeight = 'bold';
+
+	var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
+	revertToRevisionLink.href = '#';
+	$(revertToRevisionLink).click(function() {
+		Twinkle.fluff.revertToRevision(mw.config.get(revType).toString());
+	});
+	revertToRevision.appendChild(revertToRevisionLink);
+
+	var title = document.getElementById(element).parentNode;
+	title.insertBefore(revertToRevision, title.firstChild);
+};
+
+
 Twinkle.fluff.auto = function twinklefluffauto() {
 	if (mw.config.get('wgRevisionId') !== mw.config.get('wgCurRevisionId')) {
 		// not latest revision
@@ -138,44 +156,21 @@ Twinkle.fluff.addLinks = {
 			}
 		};
 
+		// Older revision
+		warnFromTalk('otitle'); // Add quick-warn link to user talk link
 		// Don't load if there's a single revision or weird diff (cur on latest)
 		if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
-			warnFromTalk('otitle'); // Add quick-warn link to user talk link on older diff
-
 			// Add a [restore this revision] link to the older revision
-			var revertToRevision = document.createElement('div');
-			revertToRevision.setAttribute('id', 'tw-revert-to-orevision');
-			revertToRevision.style.fontWeight = 'bold';
-
-			var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-			revertToRevisionLink.href = '#';
-			$(revertToRevisionLink).click(function() {
-				Twinkle.fluff.revertToRevision(mw.config.get('wgDiffOldId').toString());
-			});
-			revertToRevision.appendChild(revertToRevisionLink);
-
-			var otitle = document.getElementById('mw-diff-otitle1').parentNode;
-			otitle.insertBefore(revertToRevision, otitle.firstChild);
+			Twinkle.fluff.restoreThisRevision('mw-diff-otitle1', 'wgDiffOldId');
 		}
 
-		warnFromTalk('ntitle'); // Add quick-warn link to user talk link on newer diff
+		// Newer revision
+		warnFromTalk('ntitle'); // Add quick-warn link to user talk link
 		// Add either restore or rollback links to the newer revision
 		// Don't show if there's a single revision or weird diff (prev on first)
-		var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
 		if (document.getElementById('differences-nextlink')) {
-			// Not latest revision
-			var revertToRevisionN = document.createElement('div');
-			revertToRevisionN.setAttribute('id', 'tw-revert-to-nrevision');
-			revertToRevisionN.style.fontWeight = 'bold';
-
-			var revertToRevisionNLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-			revertToRevisionNLink.href = '#';
-			$(revertToRevisionNLink).click(function() {
-				Twinkle.fluff.revertToRevision(mw.config.get('wgDiffNewId').toString());
-			});
-			revertToRevisionN.appendChild(revertToRevisionNLink);
-
-			ntitle.insertBefore(revertToRevisionN, ntitle.firstChild);
+			// Not latest revision, add [restore this revision] link to newer revision
+			Twinkle.fluff.restoreThisRevision('mw-diff-ntitle1', 'wgDiffNewId');
 		} else if (Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
 			var vandal = $('#mw-diff-ntitle2').find('a').first().text();
 
@@ -213,23 +208,13 @@ Twinkle.fluff.addLinks = {
 			revertNode.appendChild(document.createTextNode(' || '));
 			revertNode.appendChild(vandNode);
 
+			var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
 			ntitle.insertBefore(revertNode, ntitle.firstChild);
 		}
 	},
 
 	oldid: function() { // Add a [restore this revision] link on old revisions
-		var revertToRevision = document.createElement('div');
-		revertToRevision.setAttribute('id', 'tw-revert-to-orevision');
-		revertToRevision.style.fontWeight = 'bold';
-
-		var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
-		revertToRevisionLink.href = '#';
-		$(revertToRevisionLink).click(function() {
-			Twinkle.fluff.revertToRevision(mw.config.get('wgRevisionId').toString());
-		});
-		revertToRevision.appendChild(revertToRevisionLink);
-		var otitle = document.getElementById('mw-revision-info').parentNode;
-		otitle.insertBefore(revertToRevision, otitle.firstChild);
+		Twinkle.fluff.restoreThisRevision('mw-revision-info', 'wgRevisionId');
 	}
 };
 

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -10,7 +10,7 @@
  ****************************************
  * Mode of invocation:     Tab ("Warn")
  * Active on:              Any page with relevant user name (userspace, contribs,
- *                         etc.), as well as diffs and the rollback success page
+ *                         etc.), as well as the rollback success page
  */
 
 Twinkle.warn = function twinklewarn() {
@@ -43,28 +43,6 @@ Twinkle.warn = function twinklewarn() {
 				$vandalTalkLink.attr('href', href + '&' + extraParam);
 			}
 		}
-	} else if (mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId')) {
-		// Autofill user talk links on diffs with vanarticle for easy
-		// warning, but don't autowarn
-		var warnFromTalk = function(xtitle) {
-			var talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
-			if (talkLink.length) {
-				var extraParams = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm) + '&' + 'noautowarn=true';
-				// diffIDs for vanarticlerevid
-				extraParams += '&vanarticlerevid=';
-				extraParams += xtitle === 'otitle' ? mw.config.get('wgDiffOldId') : mw.config.get('wgDiffNewId');
-
-				var href = talkLink.attr('href');
-				if (href.indexOf('?') === -1) {
-					talkLink.attr('href', href + '?' + extraParams);
-				} else {
-					talkLink.attr('href', href + '&' + extraParams);
-				}
-			}
-		};
-
-		warnFromTalk('otitle'); // Older diff
-		warnFromTalk('ntitle'); // Newer diff
 	}
 };
 


### PR DESCRIPTION
`fluff` is already processing diffs, so this saves `warn` from checking anything on diffs.  Plus, this takes advantage of the already in-place handling of the revision slider hook (#407) so that these `extraParams` are also added to user talk links when the revision slider is updated.

Second commit just consolidates some duplicated code in `fluff`