### PR TITLE
Allow quickForm select elements to be disabled in morebits, apply to the partialblock preset menu

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -160,7 +160,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			name: 'preset',
 			label: 'Choose a preset:',
 			event: Twinkle.block.callback.change_preset,
-			list: Twinkle.block.callback.filtered_block_groups(blockGroup)
+			list: Twinkle.block.callback.filtered_block_groups(blockGroup),
+			disabled: partialBox // Only one option for partial blocks
 		});
 
 		field_block_options = new Morebits.quickForm.element({ type: 'field', label: 'Block options', name: 'field_block_options' });

--- a/morebits.js
+++ b/morebits.js
@@ -117,7 +117,7 @@ Morebits.sanitizeIPv6 = function (address) {
  * Index to Morebits.quickForm element types:
  *
  *   select    A combo box (aka drop-down).
- *              - Attributes: name, label, multiple, size, list, event
+ *              - Attributes: name, label, multiple, size, list, event, disabled
  *   option    An element for a combo box.
  *              - Attributes: value, label, selected, disabled
  *   optgroup  A group of "option"s.
@@ -268,6 +268,9 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			}
 			if (data.size) {
 				select.setAttribute('size', data.size);
+			}
+			if (data.disabled) {
+				select.setAttribute('disabled', 'disabled');
 			}
 			select.setAttribute('name', data.name);
 


### PR DESCRIPTION
quickForm `select` elements didn't get a `disabled` option way back in 2007, and clearly we haven't wanted it, but I don't see a good reason why not to allow it?

Second commit applies this to the preset menu for partial blocks, as it currently only has one option, so need not be available/tempting.  Can't do the same for the template menu since `serializeArrays` will skip over anything disabled, and I don't think it's important enough to justify reworking that whole bit (although increasingly, with the multi-select input for PBs, it's now got a few holes).

Minimally tested 'cause sick.