### PR TITLE
morebits: Allow addFooterLink to prepend rather than append

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -28,6 +28,10 @@ Twinkle.block.callback = function twinkleblockCallback() {
 		return;
 	}
 
+	Twinkle.block.currentBlockInfo = undefined;
+	Twinkle.block.field_block_options = {};
+	Twinkle.block.field_template_options = {};
+
 	var Window = new Morebits.simpleWindow(650, 530);
 	// need to be verbose about who we're blocking
 	Window.setTitle('Block or issue block template to ' + mw.config.get('wgRelevantUserName'));
@@ -35,10 +39,6 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Window.addFooterLink('Block templates', 'Template:Uw-block/doc/Block_templates');
 	Window.addFooterLink('Block policy', 'WP:BLOCK');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#block');
-
-	Twinkle.block.currentBlockInfo = undefined;
-	Twinkle.block.field_block_options = {};
-	Twinkle.block.field_template_options = {};
 
 	var form = new Morebits.quickForm(Twinkle.block.callback.evaluate);
 	var actionfield = form.append({
@@ -85,6 +85,9 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.fetchUserInfo(function() {
 		// clean up preset data (defaults, etc.), done exactly once, must be before Twinkle.block.callback.change_action is called
 		Twinkle.block.transformBlockPresets();
+		if (Twinkle.block.currentBlockInfo) {
+			Window.addFooterLink('Unblock this user', 'Special:Unblock/' + mw.config.get('wgRelevantUserName'), true);
+		}
 
 		// init the controls after user and block info have been fetched
 		var evt = document.createEvent('Event');

--- a/morebits.js
+++ b/morebits.js
@@ -4304,21 +4304,30 @@ Morebits.simpleWindow.prototype = {
 	 * as well as a link to Twinkle's documentation.
 	 * @param {string} text  Link's text content
 	 * @param {string} wikiPage  Link target
+	 * @param {boolean} [prep=false] Set true to prepend rather than append
 	 * @returns {Morebits.simpleWindow}
 	 */
-	addFooterLink: function(text, wikiPage) {
+	addFooterLink: function(text, wikiPage, prep) {
 		var $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
 		if (this.hasFooterLinks) {
 			var bullet = document.createElement('span');
 			bullet.textContent = ' \u2022 ';  // U+2022 BULLET
-			$footerlinks.append(bullet);
+			if (prep) {
+				$footerlinks.prepend(bullet);
+			} else {
+				$footerlinks.append(bullet);
+			}
 		}
 		var link = document.createElement('a');
 		link.setAttribute('href', mw.util.getUrl(wikiPage));
 		link.setAttribute('title', wikiPage);
 		link.setAttribute('target', '_blank');
 		link.textContent = text;
-		$footerlinks.append(link);
+		if (prep) {
+			$footerlinks.prepend(link);
+		} else {
+			$footerlinks.append(link);
+		}
 		this.hasFooterLinks = true;
 		return this;
 	},


### PR DESCRIPTION
1st commit: Lets us use `addFooterLink` to prepend if desired.

2nd commit: Does that in block to link to Special:Unblock/User if the user is blocked.