### PR TITLE
xfd: Make target required for tfm/cfd/cfds, and specify action in cfd-notify

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1179,32 +1179,29 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 
 			var added_data = '';
-			var editsummary = '';
+			var editsummary = 'Category being considered for ' + params.action;
 			switch (params.xfdcat) {
 				case 'cfd':
 					added_data = '{{subst:cfd}}';
-					editsummary = 'Category being considered for deletion; see [[:' + params.discussionpage + ']].';
 					break;
 				case 'cfm':
 					added_data = '{{subst:cfm|' + params.target + '}}';
-					editsummary = 'Category being considered for merging; see [[:' + params.discussionpage + ']].';
 					break;
 				case 'cfr':
 					added_data = '{{subst:cfr|' + params.target + '}}';
-					editsummary = 'Category being considered for renaming; see [[:' + params.discussionpage + ']].';
 					break;
 				case 'cfs':
 					added_data = '{{subst:cfs|' + params.target + '|' + params.target2 + '}}';
-					editsummary = 'Category being considered for splitting; see [[:' + params.discussionpage + ']].';
 					break;
 				case 'cfc':
 					added_data = '{{subst:cfc|' + params.target + '}}';
-					editsummary = 'Category being considered for conversion to an article; see [[:' + params.discussionpage + ']].';
+					editsummary += ' to an article';
 					break;
 				default:
 					alert('twinklexfd in taggingCategory(): unknown CFD action');
 					break;
 			}
+			editsummary += '; see [[:' + params.discussionpage + ']].';
 
 			pageobj.setPageText(added_data + '\n' + text);
 			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
@@ -1218,14 +1215,7 @@ Twinkle.xfd.callbacks = {
 			var statelem = pageobj.getStatusElement();
 
 			var added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
-			var summaryActions = {
-				cfd: 'delete',
-				cfm: 'merge',
-				cfr: 'rename',
-				cfs: 'split',
-				cfc: 'convert'
-			};
-			var editsummary = 'Adding ' + summaryActions[params.xfdcat] + ' nomination of [[:' + Morebits.pageNameNorm + ']].';
+			var editsummary = 'Adding ' + params.action + ' nomination of [[:' + Morebits.pageNameNorm + ']].';
 
 			var text = old_text.replace('below this line -->', 'below this line -->\n' + added_data);
 			if (text === old_text) {
@@ -1252,7 +1242,7 @@ Twinkle.xfd.callbacks = {
 			}
 
 			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
-			var notifytext = '\n{{subst:cfd-notify|1=' + Morebits.pageNameNorm + '}} ~~~~';
+			var notifytext = '\n{{subst:cfd-notify|1=' + Morebits.pageNameNorm + '|action=' + params.action + '}} ~~~~';
 			usertalkpage.setAppendText(notifytext);
 			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:CFD|categories for discussion]].' + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
@@ -1676,12 +1666,22 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			params = { reason: reason, xfdcat: xfdcat, target: xfdtarget, target2: xfdtarget2, logpage: logpage };
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
+			// Useful for customized actions in edit summaries and the notification template
+			var summaryActions = {
+				cfd: 'deletion',
+				cfm: 'merging',
+				cfr: 'renaming',
+				cfs: 'splitting',
+				cfc: 'conversion'
+			};
+			params.action = summaryActions[params.xfdcat];
+
 			// Updating data for the action completed event
 			Morebits.wiki.actionCompleted.redirect = logpage;
 			Morebits.wiki.actionCompleted.notice = "Nomination completed, now redirecting to today's log";
 
 			// Tagging category
-			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging category with deletion tag');
+			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging category with ' + params.action + ' tag');
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.cfd.taggingCategory);
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -311,7 +311,9 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 						var xfdtarget = new Morebits.quickForm.element({
 							name: 'xfdtarget',
 							type: 'input',
-							label: 'Other ' + templateOrModule + ' to be merged: '
+							label: 'Other ' + templateOrModule + ' to be merged: ',
+							tooltip: 'Required',
+							required: true
 						});
 						target.parentNode.appendChild(xfdtarget.render());
 					} else {
@@ -418,8 +420,10 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 					// update enabled status
 					if (value === 'cfd') {
 						target.disabled = true;
+						target.required = false;
 					} else {
 						target.disabled = false;
+						target.required = true;
 					}
 					// update label
 					if (value === 'cfs') {
@@ -434,6 +438,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 						var xfdtarget2 = document.createElement('input');
 						xfdtarget2.setAttribute('name', 'xfdtarget2');
 						xfdtarget2.setAttribute('type', 'text');
+						xfdtarget2.setAttribute('required', 'true');
 						target.parentNode.appendChild(xfdtarget2);
 					} else {
 						$(target.parentNode).find("input[name='xfdtarget2']").remove();
@@ -480,7 +485,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				type: 'input',
 				name: 'xfdtarget',
 				label: 'New name: ',
-				value: ''
+				value: '',
+				required: true
 			});
 			appendReasonBox();
 			work_area = work_area.render();
@@ -1486,7 +1492,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 	var delsort_cats = $(form.delsort).val(); // afd
 	var xfdcat = form.xfdcat && form.xfdcat.value; // afd, cfd, cfds, tfd
 	var xfdtarget = form.xfdtarget && form.xfdtarget.value; // cfd, cfds, tfd
-	var xfdtarget2 = form.xfdtarget2 && form.xfdtarget2.value; // cfd, cfds
+	var xfdtarget2 = form.xfdtarget2 && form.xfdtarget2.value; // cfd
 	var noinclude = form.noinclude && form.noinclude.checked; // afd, mfd, tfd
 	var tfdtype = form.templatetype && form.templatetype.value; // tfd
 	var notifyuserspace = form.notifyuserspace && form.notifyuserspace.checked; // mfd

--- a/morebits.js
+++ b/morebits.js
@@ -131,7 +131,7 @@ Morebits.sanitizeIPv6 = function (address) {
  *              - Attributes: name, list, event
  *              - Attributes (within list): name, label, value, checked, disabled, event, subgroup
  *   input     A text box.
- *              - Attributes: name, label, value, size, disabled, readonly, maxlength, event
+ *              - Attributes: name, label, value, size, disabled, required, readonly, maxlength, event
  *   dyninput  A set of text boxes with "Remove" buttons and an "Add" button.
  *              - Attributes: name, label, min, max, sublabel, value, size, maxlength, event
  *   hidden    An invisible form field.
@@ -145,7 +145,7 @@ Morebits.sanitizeIPv6 = function (address) {
  *   button    A generic button.
  *              - Attributes: name, label, disabled, event
  *   textarea  A big, multi-line text box.
- *              - Attributes: name, label, value, cols, rows, disabled, readonly
+ *              - Attributes: name, label, value, cols, rows, disabled, required, readonly
  *   fragment  A DocumentFragment object.
  *              - No attributes, and no global attributes except adminonly
  *
@@ -456,6 +456,9 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			if (data.disabled) {
 				subnode.setAttribute('disabled', 'disabled');
 			}
+			if (data.required) {
+				subnode.setAttribute('required', 'required');
+			}
 			if (data.readonly) {
 				subnode.setAttribute('readonly', 'readonly');
 			}
@@ -645,6 +648,9 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			}
 			if (data.disabled) {
 				subnode.setAttribute('disabled', 'disabled');
+			}
+			if (data.required) {
+				subnode.setAttribute('required', 'required');
 			}
 			if (data.readonly) {
 				subnode.setAttribute('readonly', 'readonly');


### PR DESCRIPTION
1. Adds the `required` attribute to `input` and `textarea` `quickForm` elements in `Morebits`
1. Uses that to require users to enter an input for TfM, CfM/CfR/CfS/CfC (i.e. WP:CFD but not deletion), and all CfDS.
1. Adds the `action` parameter to the {{cfd-notify}} template, and uses that language a bit more throughout

I opened this as a draft pending a response to my [question at WT:CFD](https://en.wikipedia.org/wiki/Wikipedia_talk:Categories_for_discussion#Should_Twinkle_require_nominators_to_input_new/other_category_names?) about point 2 above: I think it's a good idea, but I could theoretically imagine that some folks at CfD like being able to make nominations without the target specified.