### PR TITLE
xfd: Add XfD log, parallel to CSD and PROD

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -785,6 +785,25 @@ Twinkle.config.sections = [
 	{
 		title: 'XFD (deletion discussions)',
 		preferences: [
+			{
+				name: 'logXfdNominations',
+				label: 'Keep a log in userspace of all pages you nominate for a deletion discussion (XfD)',
+				helptip: 'The userspace log offers a good way to keep track of all pages you nominate for XfD using Twinkle.',
+				type: 'boolean'
+			},
+			{
+				name: 'xfdLogPageName',
+				label: 'Keep the deletion discussion userspace log at this user subpage',
+				helptip: 'Enter a subpage name in this box. You will find your XfD log at User:<i>username</i>/<i>subpage name</i>. Only works if you turn on the XfD userspace log.',
+				type: 'string'
+			},
+			{
+				name: 'noLogOnXfdNomination',
+				label: 'Do not create a userspace log entry when nominating at this venue',
+				type: 'set',
+				setValues: { afd: 'AfD', tfd: 'TfD', ffd: 'FfD', cfd: 'CfD', cfds: 'CfD/S', mfd: 'MfD', rfd: 'RfD', rm: 'RM' }
+			},
+
 			// TwinkleConfig.xfdWatchPage (string)
 			// The watchlist setting of the page being nominated for XfD. Either "yes" (add to watchlist), "no" (don't
 			// add to watchlist), or "default" (use setting from preferences). Default is "default" (duh).

--- a/twinkle.js
+++ b/twinkle.js
@@ -112,6 +112,9 @@ Twinkle.defaultConfig = {
 	customWarningList: [],
 
 	// XfD
+	logXfdNominations: false,
+	xfdLogPageName: 'XfD log',
+	noLogOnXfdNomination: [],
 	xfdWatchDiscussion: 'default',
 	xfdWatchList: 'no',
 	xfdWatchPage: 'default',


### PR DESCRIPTION
There's not the same reason to log XfD nominations as there is for CSDs and PRODs, but this is useful/interesting regardless; a few folks have asked for it or though it would be useful.  It is also a lot more complicated.

The basics:
- Adds config options (logXfdNominations and xfdLogPageName)
- Lots of venue-specific log formatting (`toTLACase`, etc.)
- Like PROD/CSD, checks whether user was notified (although see below).  CfDS and RM have no user notification.
- Includes a link to the page log for files
- Stores common parameters and makes use of `.extend`

Nitty-gritty:
There are real complications around several venues, in particular confirmations on whether something actually happened and what information is available.  Most are dealt with, some aren't.  At a very basic level, we're just simply not going to check the success of each and every deletion sorting listing before adding to the XfD log, which gives some leeway for being lax on other parameters.  To wit:

- RfD logs the notification of just the initial contributer, not the target page (although it does log the redirect's target)
- MfDs of userspace pages created by a different user will log both names, but only checks if the notification to the creator was successful
- TfD merges (TfM) only log the creator of the first page, and can't currently note whether the second template's creator was notified or not (it *does* log the name of that second page, though)

----

Open to suggestions about better to ways to do some of these; this was put together fairly quickly and though I tested each option fairly well, there are bound to be mistakes.

For TfMs, to deal with the above, we could just assume the second creator (if there is one) was notified and add a generic note like '(notified creator)'.  <s>Additionally, after #836, CfD should change `'Target:'` to `params.action + ' to:'`.</s> Done