### PR TITLE
xfd: Update technical RM hidden comment

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1460,7 +1460,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var hiddenComment = '---- and enter on a new line, directly below; do not add spare lines between entries, for accessibility reasons -->';
+			var hiddenComment = '---- and enter on a new line, directly below; do not add spare lines between entries; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->';
 			var newtext = text.replace(hiddenComment, hiddenComment + '\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');


### PR DESCRIPTION
Onwiki comment updated in [1], per discussion at [2]; the current value results in the request being placed in the `Requests to revert undiscussed moves` section instead of the intended `Uncontroversial technical requests` section[3]
[1] Diff: https://w.wiki/GtM
[2] Discussion: https://w.wiki/GtN (permalink to current: https://w.wiki/GtP)
[3] Diff: https://w.wiki/GtQ