### PR TITLE
warn: Fix bug with kitchensink edit summaries

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1462,6 +1462,17 @@ Twinkle.warn.callbacks = {
 			}
 			summary += ': ' + Morebits.string.toUpperCaseFirstChar(messageData.label);
 		} else {
+			// Normalize kitchensink to the 1-4im style
+			if (params.main_group === 'kitchensink' && !/^D+$/.test(params.sub_group)) {
+				var sub = params.sub_group.substr(-1);
+				if (sub === 'm') {
+					sub = params.sub_group.substr(-3);
+				}
+				// Don't overwrite uw-3rr, technically unnecessary
+				if (/\d/.test(sub)) {
+					params.main_group = 'level' + sub;
+				}
+			}
 			summary = /^\D+$/.test(params.main_group) ? messageData.summary : messageData[params.main_group].summary;
 			if (messageData.suppressArticleInSummary !== true && params.article) {
 				if (params.sub_group === 'uw-agf-sock' ||


### PR DESCRIPTION
[Reported at WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=939908648#Apparent_(rather_minor)_Twinkle_bug).  Basically, when #773 added the kitchensink menu, I didn't account for the fact that the edit summary test was relying on the `main_group` to have a number in it, which fails with kitchensink.  For kitchensink, then, we rely on the `sub_group` via `substr`, as with custom; similarly, it's over-complicated because of 4im levels.  Also worth noting that `uw-3rr` is a non-level1-4im with a digit in it.