### PR TITLE
speedy: Adjust default tag mode for sysops

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -480,11 +480,12 @@ Twinkle.config.sections = [
 				type: 'boolean'
 			},
 
-			// TwinkleConfig.deleteSysopDefaultToTag (boolean)
-			// Make the CSD screen default to "tag" instead of "delete" (admin only)
+			// TwinkleConfig.deleteSysopDefaultToDelete (boolean)
+			// Make the CSD screen default to "delete" instead of "tag" (admin only)
 			{
-				name: 'deleteSysopDefaultToTag',
-				label: 'Default to speedy tagging instead of outright deletion',
+				name: 'deleteSysopDefaultToDelete',
+				label: 'Default to outright deletion instead of speedy tagging',
+				helptip: 'If there is a CSD tag already present, Twinkle will always default to "delete" mode',
 				adminOnly: true,
 				type: 'boolean'
 			},

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -36,6 +36,8 @@ Twinkle.speedy.callback = function twinklespeedyCallback() {
 
 // Used by unlink feature
 Twinkle.speedy.dialog = null;
+// Used throughout
+Twinkle.speedy.hasCSD = !!$('#delete-reason').length;
 
 // The speedy criteria list can be in one of several modes
 Twinkle.speedy.mode = {
@@ -95,7 +97,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 					value: 'tag_only',
 					name: 'tag_only',
 					tooltip: 'If you just want to tag the page, instead of deleting it now',
-					checked: Twinkle.getPref('deleteSysopDefaultToTag'),
+					checked: !(Twinkle.speedy.hasCSD || Twinkle.getPref('deleteSysopDefaultToDelete')),
 					event: function(event) {
 						var cForm = event.target.form;
 						var cChecked = event.target.checked;
@@ -110,7 +112,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 						// enable notify checkbox
 						cForm.notify.checked = cChecked;
 						// enable deletion notification checkbox
-						cForm.warnusertalk.checked = !cChecked && $('#delete-reason').length < 1;
+						cForm.warnusertalk.checked = !cChecked && !Twinkle.speedy.hasCSD;
 						// enable multiple
 						cForm.multiple.checked = false;
 						// enable requesting creation protection
@@ -188,7 +190,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 					name: 'warnusertalk',
 					tooltip: 'A notification template will be placed on the talk page of the creator, IF you have a notification enabled in your Twinkle preferences ' +
 						'for the criterion you choose AND this box is checked. The creator may be welcomed as well.',
-					checked: $('#delete-reason').length < 1,
+					checked: !Twinkle.speedy.hasCSD,
 					event: function(event) {
 						event.stopPropagation();
 					}
@@ -218,7 +220,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 				name: 'notify',
 				tooltip: 'A notification template will be placed on the talk page of the creator, IF you have a notification enabled in your Twinkle preferences ' +
 						'for the criterion you choose AND this box is checked. The creator may be welcomed as well.',
-				checked: !isSysop || Twinkle.getPref('deleteSysopDefaultToTag'),
+				checked: !isSysop || !(Twinkle.speedy.hasCSD || Twinkle.getPref('deleteSysopDefaultToDelete')),
 				event: function(event) {
 					event.stopPropagation();
 				}
@@ -411,7 +413,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 	form.replaceChild(work_area.render(), old_area);
 
 	// if sysop, check if CSD is already on the page and fill in custom rationale
-	if (isSysopMode && $('#delete-reason').length) {
+	if (isSysopMode && Twinkle.speedy.hasCSD) {
 		var customOption = $('input[name=csd][value=reason]')[0];
 		if (customOption) {
 			if (Twinkle.getPref('speedySelectionStyle') !== 'radioClick') {
@@ -1243,7 +1245,7 @@ Twinkle.speedy.callbacks = {
 			initialContrib = null;
 
 		// Check for already existing tags
-		} else if ($('#delete-reason').length && params.warnUser && !confirm('The page is has a deletion-related tag, and thus the creator has likely been notified.  Do you want to notify them for this deletion as well?')) {
+		} else if (Twinkle.speedy.hasCSD && params.warnUser && !confirm('The page is has a deletion-related tag, and thus the creator has likely been notified.  Do you want to notify them for this deletion as well?')) {
 			Morebits.status.info('Notifying initial contributor', 'canceled by user; skipping notification.');
 			initialContrib = null;
 		} else {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -264,7 +264,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 	});
 
 	if (Twinkle.getPref('speedySelectionStyle') !== 'radioClick') {
-		form.append({ type: 'submit' });
+		form.append({ type: 'submit' }); // Renamed in modeChanged
 	}
 
 	var result = form.render();
@@ -306,9 +306,11 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 	if (isSysopMode) {
 		$('[name=delete_options]').show();
 		$('[name=tag_options]').hide();
+		$('.morebits-dialog-buttons button').text('Delete page'); // Submit button
 	} else {
 		$('[name=delete_options]').hide();
 		$('[name=tag_options]').show();
+		$('.morebits-dialog-buttons button').text('Tag page'); // Submit button
 	}
 
 	var work_area = new Morebits.quickForm.element({
@@ -326,7 +328,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		work_area.append({
 			type: 'button',
 			name: 'submit-multiple',
-			label: 'Submit Query',
+			label: isSysopMode ? 'Delete page' : 'Tag page',
 			event: function(event) {
 				Twinkle.speedy.callback[evaluateType](event);
 				event.stopPropagation();
@@ -497,7 +499,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 				criterion.subgroup = criterion.subgroup.concat({
 					type: 'button',
 					name: 'submit',
-					label: 'Submit Query',
+					label: isSysopMode ? 'Delete page' : 'Tag page',
 					event: submitSubgroupHandler
 				});
 			} else {
@@ -506,7 +508,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 					{
 						type: 'button',
 						name: 'submit',  // ends up being called "csd.submit" so this is OK
-						label: 'Submit Query',
+						label: isSysopMode ? 'Delete page' : 'Tag page',
 						event: submitSubgroupHandler
 					}
 				];

--- a/twinkle.js
+++ b/twinkle.js
@@ -90,7 +90,7 @@ Twinkle.defaultConfig = {
 	promptForSpeedyDeletionSummary: [],
 	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,
-	deleteSysopDefaultToTag: false,
+	deleteSysopDefaultToDelete: false,
 	speedyWindowHeight: 500,
 	speedyWindowWidth: 800,
 	logSpeedyNominations: false,


### PR DESCRIPTION
Requested by the community following discussion after an [arb case](https://en.wikipedia.org/wiki/Wikipedia:Arbitration/Requests/Case/RHaworth).  `deleteSysopDefaultToTag` is used by around 50 individuals, and there was some local consensus to have Twinkle default to tagging for sysops if there's no CSD tag already present.  Accordingly:

- `deleteSysopDefaultToTag` (default `false`) is replaced by `deleteSysopDefaultToDelete` (default false), reverting the default behavior for all sysops; sysops will now default to "tag" mode (if there's no CSD present, see below).  Users must manually opt for the previous default behavior, to default to "delete" mode.
- If there is a deletion tag present, Twinkle will now always default to "delete" mode.  This isn't technically required, but makes sense with the above, and is probably just a good idea in general.  We were using it for some behaviors already, so this makes use of `Twinkle.speedy.hasCSD` throughout since we're using `$('#delete-reason')` quite a bit now.

----

Is this the kind of thing that should update `optionsVersion`?  Doing 2.1 seems overly precious, I don't really feel like instituting semver there... :lol:

I had a broken url in my notes so I've lost the location of the discussion thread since I wrote this a week or two ago.