### PR TITLE
speedy: disable G8 and T2 rationale when deleting

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -838,7 +838,8 @@ Twinkle.speedy.templateList = [
 			type: 'input',
 			label: 'Optional explanation: ',
 			size: 60
-		}
+		},
+		hideSubgroupWhenSysop: true
 	},
 	{
 		label: 'T3: Duplicate templates or hardcoded instances',
@@ -997,7 +998,8 @@ Twinkle.speedy.generalList = [
 			type: 'input',
 			label: 'Optional explanation: ',
 			size: 60
-		}
+		},
+		hideSubgroupWhenSysop: true
 	},
 	{
 		label: 'G8: Subpages with no parent page',


### PR DESCRIPTION
Like G7 (disabled in 7191d4c as part of #300), the rationales here aren't used.  G8 is different from G7, though, in that it uses `rationale` for the tag, but `summary` for the deletion log.  We could instead set `currentParams.summary` to `currentParams.rationale` for G8 (and hide on multiple?), but the reality is that G7 and G8 are two of the CSD areas that a custom summary is least useful for.  Moreover, we only have this for the generic G8 option, and doing so would mean removing the standard G8 text (barring some moderate edits to the template).  T2, on the other hand, is just like G7, in that the summary takes no parameter.

We could, of course, change either template, forcing them to take a `{{{rationale}}}` (and/or `{{{summary}}}`), but not sure that's super helpful here; I can start a discussion on the meta talkpage about syncing/unifying some of these.