### PR TITLE
Add uw-upeblock to block options

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -957,7 +957,7 @@ Twinkle.block.blockPresetsInfo = {
 		nocreate: true,
 		pageParam: true,
 		reason: '[[WP:PAID|Undisclosed paid editing]] in violation of the WMF [[WP:TOU|Terms of Use]]',
-		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] in violation of [[WP:PAID|Wikipedia policy on paid advocacy'
+		summary: 'You have been indefinitely blocked from editing because your account is being used in violation of [[WP:PAID|Wikipedia policy on undisclosed paid advocacy]]'
 	},
 	'uw-vaublock': {
 		autoblock: true,

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -950,6 +950,14 @@ Twinkle.block.blockPresetsInfo = {
 		reason: '{{uw-ublock-double}} <!-- Username closely resembles another user, hard block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] appears to impersonate another established Wikipedia user'
 	},
+	'uw-upeblock': {
+		autoblock: true,
+		expiry: 'infinity',
+	    	forRegisteredOnly: true,
+	    	nocreate: true,
+		reason: '[[WP:PAID|Undisclosed paid editing]] in violation of the WMF [[WP:TOU|Terms of Use]]',
+		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] in violation of [[WP:PAID|Wikipedia policy on paid advocacy'
+	},
 	'uw-vaublock': {
 		autoblock: true,
 		expiry: 'infinity',
@@ -1114,6 +1122,7 @@ Twinkle.block.blockGroups = [
 			{ label: 'Spam', value: 'uw-sblock' },
 			{ label: 'Spam/advertising-only account', value: 'uw-soablock' },
 			{ label: 'Unapproved bot', value: 'uw-botblock' },
+			{ label: 'Undisclosed paid editing', value: 'uw-upeblock' },
 			{ label: 'Violating the three-revert rule', value: 'uw-3block' }
 		]
 	},

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -955,6 +955,7 @@ Twinkle.block.blockPresetsInfo = {
 		expiry: 'infinity',
 		forRegisteredOnly: true,
 		nocreate: true,
+		pageParam: true,
 		reason: '[[WP:PAID|Undisclosed paid editing]] in violation of the WMF [[WP:TOU|Terms of Use]]',
 		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] in violation of [[WP:PAID|Wikipedia policy on paid advocacy'
 	},

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -953,8 +953,8 @@ Twinkle.block.blockPresetsInfo = {
 	'uw-upeblock': {
 		autoblock: true,
 		expiry: 'infinity',
-	    	forRegisteredOnly: true,
-	    	nocreate: true,
+		forRegisteredOnly: true,
+		nocreate: true,
 		reason: '[[WP:PAID|Undisclosed paid editing]] in violation of the WMF [[WP:TOU|Terms of Use]]',
 		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] in violation of [[WP:PAID|Wikipedia policy on paid advocacy'
 	},


### PR DESCRIPTION
Per #850, add a new Template:Uw-upeblock, for blocks related to undisclosed paid editing, to the list of available block presets.