### PR TITLE
morebits: Proxy submit buttons take the className

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4261,6 +4261,7 @@ Morebits.simpleWindow.prototype = {
 			value.style.display = 'none';
 			var button = document.createElement('button');
 			button.textContent = value.hasAttribute('value') ? value.getAttribute('value') : value.textContent ? value.textContent : 'Submit Query';
+			button.className = value.className || 'submitButtonProxy';
 			// here is an instance of cheap coding, probably a memory-usage hit in using a closure here
 			button.addEventListener('click', function() {
 				value.click();


### PR DESCRIPTION
Not entirely sure if this is helpful or not, but if there's a `className` given in a quickForm `type: 'submit'`, we were just dropping it when creating a proxy button, which seems counter-intuitive.  Without a `className`, the proxy button is accessible via `$('.morebits-dialog-buttons button')`, which isn't submit-specific, so absent a provided `className`, adds <s>`submitProxy`</s> `submitButtonProxy` to the button class.

Currently unused in Twinkle, but it would make things like https://github.com/azatoth/twinkle/blob/9a7ecce336dc70a637c02ff4829fb19f861df7fb/modules/friendlytag.js#L270 (from #648) and https://github.com/azatoth/twinkle/pull/844/files#diff-4e20504588e50710cb9f42b74f59993dR309-R313 prettier.  I had initially considered an `id`, but a class seemed appropriate given we allow the user to provide one.