### PR TITLE
xfd: Use shorter comment and regex to avoid constantly updating RM/TR comment

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1460,8 +1460,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var hiddenComment = '---- and enter on a new line, directly below; do not add spare lines between entries; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->';
-			var newtext = text.replace(hiddenComment, hiddenComment + '\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
+			var hiddenCommentRE = /---- and enter on a new line.* -->/;
+			var newtext = text.replace(hiddenCommentRE, '$&\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;
@@ -1739,6 +1739,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			wikipedia_page.setCallbackParameters(params);
 
 			if (rmtr) {
+				wikipedia_page.setPageSection(2);
 				wikipedia_page.load(Twinkle.xfd.callbacks.rm.listAtRMTR);
 			} else {
 				// listAtTalk uses .append(), so no need to load the page


### PR DESCRIPTION
The hidden message has been changing frequently, leaving us behind (e.g. #791, #842), so by using a short regex rather than an exact string match, we should be able to handle subsequent changes.  This change also only loads section number 2; that's possibly overkill, but could theoretically avoid some off-target effects with the page's other hidden comment.  Would cause issues in the unlikely event of the page being restructured.