### PR TITLE
Slightly improve handling of Scribunto/non-wikitext content models

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1513,7 +1513,18 @@ Twinkle.speedy.callbacks = {
 			pageobj.setPageText(code + (params.normalizeds.indexOf('g10') !== -1 ? '' : '\n' + text)); // cause attack pages to be blanked
 			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 			pageobj.setWatchlist(params.watch);
-			pageobj.setCreateOption('recreate'); // Module /doc might not exist
+			if (params.scribunto) {
+				pageobj.setCreateOption('recreate'); // Module /doc might not exist
+				if (params.watch) {
+					// Watch module in addition to /doc subpage
+					var watch_query = {
+						action: 'watch',
+						titles: mw.config.get('wgPageName'),
+						token: mw.user.tokens.get('watchToken')
+					};
+					new Morebits.wiki.api('Adding Module to watchlist', watch_query).post();
+				}
+			}
 			pageobj.save(Twinkle.speedy.callbacks.user.tagComplete);
 		},
 
@@ -2159,8 +2170,8 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete';
 
 	// Modules can't be tagged, follow standard at TfD and place on /doc subpage
-	var isScribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
-	var wikipedia_page = isScribunto ? new Morebits.wiki.page(mw.config.get('wgPageName') + '/doc', 'Tagging module documentation page') : new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+	params.scribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
+	var wikipedia_page = params.scribunto ? new Morebits.wiki.page(mw.config.get('wgPageName') + '/doc', 'Tagging module documentation page') : new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.speedy.callbacks.user.main);
 };

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -314,7 +314,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 							name: 'xfdtarget',
 							type: 'input',
 							label: 'Other ' + templateOrModule + ' to be merged: ',
-							tooltip: 'Required',
+							tooltip: 'Required. Should not include the ' + Morebits.string.toUpperCaseFirstChar(templateOrModule) + ': namespace prefix.',
 							required: true
 						});
 						target.parentNode.appendChild(xfdtarget.render());
@@ -629,6 +629,9 @@ Twinkle.xfd.callbacks = {
 			if (venue === 'rfd') {
 				text += '|target=' + params.target + (params.section ? '#' + params.section : '');
 			} else if (venue !== 'cfd') {
+				if (params.xfdcat && params.xfdcat === 'tfm') {
+					params.target = Morebits.string.toUpperCaseFirstChar(params.target.replace(/^:?(?:Template|Module):/i, ''));
+				}
 				text += '|2=' + params.target;
 			}
 		}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -892,7 +892,9 @@ Twinkle.xfd.callbacks = {
 				(params.tfdtype !== 'standard' ? '|type=' + params.tfdtype : '') + (params.noinclude ? '}}</noinclude>' : '}}') + tableNewline + text);
 			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
-			pageobj.setCreateOption('recreate'); // Module /doc might not exist
+			if (params.scribunto) {
+				pageobj.setCreateOption('recreate'); // Module /doc might not exist
+			}
 			pageobj.save();
 		},
 		taggingTemplateForMerge: function(pageobj) {
@@ -905,7 +907,9 @@ Twinkle.xfd.callbacks = {
 				(params.noinclude ? '}}</noinclude>' : '}}') + tableNewline + text);
 			pageobj.setEditSummary('Listed for merging with [[:' + params.otherTemplateName + ']]; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
-			pageobj.setCreateOption('recreate'); // Module /doc might not exist
+			if (params.scribunto) {
+				pageobj.setCreateOption('recreate'); // Module /doc might not exist
+			}
 			pageobj.save();
 		},
 		todaysList: function(pageobj) {
@@ -1539,36 +1543,52 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			params = { tfdtype: tfdtype, logpage: logpage, noinclude: noinclude, xfdcat: xfdcat, target: xfdtarget, reason: reason };
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
-			// Modules can't be tagged, TfD instructions are to place on /doc subpage
-			var isScribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
+			// Modules can't be tagged, TfD instructions are to place
+			// on /doc subpage, so need to tag and watch specially
+			params.scribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
+			var watch_query = {
+				action: 'watch',
+				titles: mw.config.get('wgPageName'),
+				token: mw.user.tokens.get('watchToken')
+			};
 			// Tagging template(s)/module(s)
 			if (xfdcat === 'tfm') { // Merge
-			// Tag this template/module
-				if (isScribunto) {
+				var wikipedia_otherpage;
+
+				// Tag this template/module
+				if (params.scribunto) {
 					wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName') + '/doc', 'Tagging this module documentation with merge tag');
 					params.otherTemplateName = 'Module:' + xfdtarget;
+					wikipedia_otherpage = new Morebits.wiki.page(params.otherTemplateName + '/doc', 'Tagging other module documentation with merge tag');
+
+					// Watch tagged module pages as well
+					if (Twinkle.getPref('xfdWatchPage') !== 'no') {
+						watch_query.titles += '|' + params.otherTemplateName;
+						new Morebits.wiki.api('Adding Modules to watchlist', watch_query).post();
+					}
 				} else {
 					wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging this template with merge tag');
 					params.otherTemplateName = 'Template:' + xfdtarget;
+					wikipedia_otherpage = new Morebits.wiki.page(params.otherTemplateName, 'Tagging other template with merge tag');
 				}
 				wikipedia_page.setFollowRedirect(true);
 				wikipedia_page.setCallbackParameters(params);
 				wikipedia_page.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
 
 				// Tag other template/module
-				if (isScribunto) {
-					wikipedia_page = new Morebits.wiki.page('Module:' + xfdtarget + '/doc', 'Tagging other module documentation with merge tag');
-				} else {
-					wikipedia_page = new Morebits.wiki.page('Template:' + xfdtarget, 'Tagging other template with merge tag');
-				}
-				wikipedia_page.setFollowRedirect(true);
+				wikipedia_otherpage.setFollowRedirect(true);
 				var otherParams = $.extend({}, params);
 				otherParams.otherTemplateName = Morebits.pageNameNorm;
-				wikipedia_page.setCallbackParameters(otherParams);
-				wikipedia_page.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
+				wikipedia_otherpage.setCallbackParameters(otherParams);
+				wikipedia_otherpage.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
 			} else { // delete
-				if (isScribunto) {
+				if (params.scribunto) {
 					wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName') + '/doc', 'Tagging module documentation with deletion tag');
+
+					// Watch tagged module page as well
+					if (Twinkle.getPref('xfdWatchPage') !== 'no') {
+						new Morebits.wiki.api('Adding Module to watchlist', watch_query).post();
+					}
 				} else {
 					wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging template with deletion tag');
 				}
@@ -1593,7 +1613,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				var seenusers = [];
 				involvedpages.push(new Morebits.wiki.page(mw.config.get('wgPageName')));
 				if (xfdcat === 'tfm') {
-					if (isScribunto) {
+					if (params.scribunto) {
 						involvedpages.push(new Morebits.wiki.page('Module:' + xfdtarget));
 					} else {
 						involvedpages.push(new Morebits.wiki.page('Template:' + xfdtarget));

--- a/morebits.js
+++ b/morebits.js
@@ -2172,6 +2172,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	 *    less 50 revisions and all are redirects, the original creation is retrived.
 	 * 2. Revisions that the user is not privileged to access (revdeled/suppressed) will be treated
 	 *    as non-redirects.
+	 * 3. Must not be used when the page has a non-wikitext contentmodel
+	 *    such as Modulespace Lua or user JavaScript/CSS
 	 */
 	this.setLookupNonRedirectCreator = function(flag) {
 		ctx.lookupNonRedirectCreator = flag;
@@ -2316,10 +2318,19 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			'prop': 'revisions',
 			'titles': ctx.pageName,
 			'rvlimit': 1,
-			'rvprop': 'user|timestamp|content',
-			'rvsection': 0,
+			'rvprop': 'user|timestamp',
 			'rvdir': 'newer'
 		};
+
+		// Only the wikitext content model can reliably handle
+		// rvsection, others return an error when paired with the
+		// content rvprop. Relatedly, non-wikitext models don't
+		// understand the #REDIRECT concept, so we shouldn't attempt
+		// the redirect resolution in fnLookupCreationSuccess
+		if (ctx.lookupNonRedirectCreator) {
+			query.rvsection = 0;
+			query.rvprop += '|content';
+		}
 
 		if (ctx.followRedirect) {
 			query.redirects = '';  // follow all redirects


### PR DESCRIPTION
**1st commit: morebits: lookupCreation won't query content and section unless lookupNonRedirectCreator is provided**

PR #710 added the ability for `fnLookupCreationSuccess` to find the creator of the first non-redirect revision via `fnLookupNonRedirectCreator` (see also #805) by adding `content` to the `rvprop`s list as well as `rvsection=0`.  That doesn't work for non-wikitext content models, who will returned a `rvnosuchsection` error in such cases.  Removing `content` would solve the error, as would `rvsection=0`, but the actual redirect check (`/^\s*#redirect/i`) doesn't make sense in those scenarios (e.g. Scribunto, JS, CSS), so there's no really point in even checking.

Instead, only attempt to use `content` and `rvsection` if `lookupNonRedirectCreator` is set.  Currently, only AfD and PROD do so, which aligns with how it should be limited.

We could probably just use `wgPageContentModel`, but in theory the ability to query pages other than the current one, even if the two have different content models, seems useful.  In practice, only `twinklexfd` attempts sch a thing, only for TfD merge nominations (`involvedpages`), and assumes that the target is in the same namespace as the current page, so Scribunto will match with Scribunto.

**2nd commit: xfd/speedy: Watch tagged modules**

Uses params.scribunto to check if we're dealing with a /doc subpage or not (easier and more portable than regex testing, etc.), and simply call the `watch` api.  Also removes some collateral with undesired `pageobj.setCreateOption('recreate')` for non-module taggings.  Closes #572; Sorry if you were actively looking at this @DannyS712 and I scooped you, I got thinking after the above.

**3rd commit: xfd: Fix tfm preview when namespace is included**