### PR TITLE
block: Use word boundary regex to match bot usernames

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1273,7 +1273,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 	data.hardblock = data.hardblock !== undefined ? data.hardblock : false;
 
 	// disable autoblock if blocking a bot
-	if (Twinkle.block.isRegistered && relevantUserName.search(/bot$/i) > 0) {
+	if (Twinkle.block.isRegistered && relevantUserName.search(/bot\b/i) > 0) {
 		data.autoblock = false;
 	}
 


### PR DESCRIPTION
Requiring the username to end in 'bot' means we miss out on some major ones (e.g. AnomieBot III, ClueBot NG), but checking for a word boundary should improve things without much collateral (e.g. NinjaRobotPirate).