### PR TITLE
speedy: Allow G4 and G5 when multiple

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -907,8 +907,7 @@ Twinkle.speedy.generalList = [
 			label: 'Page where the deletion discussion took place: ',
 			tooltip: 'Must start with "Wikipedia:"',
 			size: 60
-		},
-		hideSubgroupWhenMultiple: true
+		}
 	},
 	{
 		label: 'G5: Created by a banned or blocked user',
@@ -919,8 +918,7 @@ Twinkle.speedy.generalList = [
 			type: 'input',
 			label: 'Username of banned user (if available): ',
 			tooltip: 'Should not start with "User:"'
-		},
-		hideSubgroupWhenMultiple: true
+		}
 	},
 	{
 		label: 'G6: Move',
@@ -1950,7 +1948,7 @@ Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParamete
 			break;
 		case 'g4':
 			utparams.key1 = 'xfd';
-			utparams.value1 = parameters.xfd;
+			utparams.value1 = utparams.xfd = parameters.xfd;
 			break;
 		case 'g6':
 			utparams.key1 = 'to';


### PR DESCRIPTION
This is much delayed.

`HideSubgroupWhenMultiple` was added to G5 in Oct 2013 (https://github.com/azatoth/twinkle/commit/a04f034f33f5165ed784356f541337346308cb4e) and to G4 two years later (Dec 2015) as part of #300 (https://github.com/azatoth/twinkle/commit/7191d4cb24887b58909033ff7b58df3de5e8e616).  At the time, neither was supported by {{db-multiple}}, but both now are: G5 has been supported since [Feb 2017](https://en.wikipedia.org/w/index.php?title=Template%3ADb-multiple&diff=prev&oldid=765075803), with G4 coming later in [May](https://en.wikipedia.org/w/index.php?title=Template:Db-multiple&diff=prev&oldid=781332988).

Additionally, I've added support for an `xfd` parameter in the {{db-[notice|deleted]-multiple}} templates and covered that here as well; {{db-csd-[notice|deleted]-custom}} already support G4's parameter (as did Twinkle) and G5 is by definition unsupported as a notice.

Relatedly, we don't particularly need `HideSubgroupWhenSysop`, since both {{db-g4}} and {{db-g5}} make use of their respective parameters via `summary`.