### PR TITLE
xfd: Avoid client clock for soft redirects

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1320,7 +1320,11 @@ Twinkle.xfd.callbacks = {
 				if (!apiobj.params.target) { // Not a softredirect
 					var target = $xmlDoc.find('redirects r').first().attr('to');
 					if (!target) {
-						apiobj.statelem.error('This page is currently not a redirect, aborting');
+						var message = 'This page does not appear to be a redirect, aborting';
+						if (mw.config.get('wgAction') === 'history') {
+							message += '. If this is a soft redirect, try again from the content page, not the page history.';
+						}
+						apiobj.statelem.error(message);
 						return;
 					}
 					apiobj.params.target = target;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1292,43 +1292,46 @@ Twinkle.xfd.callbacks = {
 	rfd: {
 		// This gets called both on submit and preview to determine the redirect target
 		findTarget: function(params, callback) {
+			// Used by regular redirects to find the target, but for all redirects,
+			// avoid relying on the client clock to build the log page
+			var query = {
+				'action': 'query',
+				'curtimestamp': true
+			};
 			if (document.getElementById('softredirect')) {
-				// For soft redirects, skip straight to the callback
+				// For soft redirects, define the target early
+				// to skip target checks in findTargetCallback
 				params.target = document.getElementById('softredirect').textContent.replace(/^:+/, '');
-				callback(params);
 			} else {
 				// Find current target of redirect
-				var query = {
-					'action': 'query',
-					'titles': mw.config.get('wgPageName'),
-					'redirects': true,
-					'curtimestamp': true
-				};
-				var wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
-				wikipedia_api.params = params;
-				wikipedia_api.post();
+				query.titles = mw.config.get('wgPageName');
+				query.redirects = true;
 			}
+			var wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
+			wikipedia_api.params = params;
+			wikipedia_api.post();
 		},
 		// This is a closure for the callback from the above API request, which gets the target of the redirect
 		findTargetCallback: function(callback) {
 			return function(apiobj) {
 				var $xmlDoc = $(apiobj.responseXML);
 				var curtimestamp = $xmlDoc.find('api').attr('curtimestamp');
-				var target = $xmlDoc.find('redirects r').first().attr('to');
-				if (!target) {
-					apiobj.statelem.error('This page is currently not a redirect, aborting');
-					return;
-				}
-				var section = $xmlDoc.find('redirects r').first().attr('tofragment');
 				apiobj.params.curtimestamp = curtimestamp;
-				apiobj.params.target = target;
-				apiobj.params.section = section;
+				if (!apiobj.params.target) { // Not a softredirect
+					var target = $xmlDoc.find('redirects r').first().attr('to');
+					if (!target) {
+						apiobj.statelem.error('This page is currently not a redirect, aborting');
+						return;
+					}
+					apiobj.params.target = target;
+					var section = $xmlDoc.find('redirects r').first().attr('tofragment');
+					apiobj.params.section = section;
+				}
 				callback(apiobj.params);
 			};
 		},
 		main: function(params) {
-			// Fallback to client clock for softredirects
-			var date = params.curtimestamp ? new Date(params.curtimestamp) : new Date();
+			var date = new Date(params.curtimestamp);
 			params.logpage = 'Wikipedia:Redirects for discussion/Log/' + date.getUTCFullYear() + ' ' + date.getUTCMonthName() + ' ' + date.getUTCDate();
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 


### PR DESCRIPTION
In doing #862, I undid the intent of #714 to avoid the client clock as much as possible for the specific case of soft redirects being nominated at RfD.  It never worked - thus #861 - but the idea is sound.  This has softredirects go through the same `curtimestamp` query and "typical" redirects, but simply skips processing of target or section.  It's not a free check anymore, but it should be incredibly infrequent and fairly quick.

Also added a note for softredirect failures from the history tab.  If run from history, the `Morebits.wiki.isPageRedirect` check for soft redirects won't work.  The module fails fine, but a note suggesting users retry from the content tab is helpful.