### PR TITLE
xfd: Align setFollowRedirect(true) use aka add to everything missing it

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1448,7 +1448,6 @@ Twinkle.xfd.callbacks = {
 			pageobj.setAppendText('\n\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			pageobj.setEditSummary('Proposing move' + (params.newname ? ' to ' + params.newname : '') + Twinkle.getPref('summaryAd'));
 			pageobj.setCreateOption('recreate'); // since the talk page need not exist
-			pageobj.setFollowRedirect(true);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.append(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1686,6 +1685,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 			// Tagging category
 			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging category with ' + params.action + ' tag');
+			wikipedia_page.setFollowRedirect(true); // should never be needed, but if the page is moved, we would want to follow the redirect
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.cfd.taggingCategory);
 
@@ -1720,11 +1720,13 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 			// Tagging category
 			wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging category with rename tag');
+			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.cfds.taggingCategory);
 
 			// Adding discussion to list
 			wikipedia_page = new Morebits.wiki.page(logpage, 'Adding discussion to the list');
+			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.cfds.addToList);
 
@@ -1746,6 +1748,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			Morebits.wiki.actionCompleted.notice = 'Nomination completed, now redirecting to the discussion page';
 
 			wikipedia_page = new Morebits.wiki.page(nomPageName, rmtr ? 'Adding entry at WP:RM/TR' : 'Adding entry on talk page');
+			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 
 			if (rmtr) {


### PR DESCRIPTION
Mostly for completion's sake, but this is alrady explicitly set for nearly everything.  The only exceptions were:

- CfD tagging.  Was the only tagging without it, left off when added to all taggings in c97229c, presumably an oversight.
- CfD/S listing and tagging. Not included when added in 9d6818a, presumably unintentional given the other options. CfD/S doesn't have user notifications.
- RMTR listing.  RM was added in #698 and involves no notifications or tagging.  `setFollowRedirect` added to `listAtTalk` per comments there (https://github.com/azatoth/twinkle/pull/698#discussion_r339865891) but hadn't been present for the rmtr options.

----

As above, this is mostly for completion's sake.  We may want to consider revisiting some of these (vis-a-vis #379 and #753 (in particular taggings (in particular AfD))) but it's probably ideal to start from a uniform slate regardless.