### PR TITLE
speedy: Log nomination even if user notification prevented

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1248,7 +1248,9 @@ Twinkle.speedy.callbacks = {
 		} else if ($('#delete-reason').length && params.warnUser && !confirm('The page is has a deletion-related tag, and thus the creator has likely been notified.  Do you want to notify them for this deletion as well?')) {
 			Morebits.status.info('Notifying initial contributor', 'canceled by user; skipping notification.');
 			initialContrib = null;
-		} else {
+		}
+
+		if (initialContrib) {
 			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')'),
 				notifytext, i, editsummary;
 
@@ -1294,6 +1296,9 @@ Twinkle.speedy.callbacks = {
 					Twinkle.speedy.callbacks.user.addToLog(params, null);
 				}
 			});
+		} else if (params.lognomination) {
+			// log nomination even if the user notification wasn't sent
+			Twinkle.speedy.callbacks.user.addToLog(params, null);
 		}
 	},
 


### PR DESCRIPTION
Since #578, we've been trying to correctly note in the CSD log whether the user notification went successfully.  That was carried over into #563, but the changes in #578 meant that if the user attempted to notify the creator (e.g. `params.usertalk`) but then discovered (in `noteToCreator`) that there was a good reason not to, no CSD log entry was made; it accounted for whether you wanted to notify-then-log or just log, but didn't account for notify-but-notify-not-done-then-log, essentially ignoring the checks from #436.  Specific cases, like R2 ([reported at WT:TW](http://en.wikipedia.org/wiki/Special:Permalink/942392393#CSD_R2_instances_not_being_logged)), were especially prone to being missed in the log.

This uses those `initialContrib = null` checks to recheck whether a notification should go out, and if not, log if appropriate.