### PR TITLE
protect: Fix bug affecting untagging on PC-ineligible namespaces

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1059,14 +1059,16 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 				Twinkle.protect.formevents.movemodify({ target: form.movemodify });
 			}
 
-			if (item.stabilize) {
-				form.pcmodify.checked = true;
-				Twinkle.protect.formevents.pcmodify({ target: form.pcmodify });
-				form.pclevel.value = item.stabilize;
-				Twinkle.protect.formevents.pclevel({ target: form.pclevel });
-			} else if (form.pcmodify) {
-				form.pcmodify.checked = false;
-				Twinkle.protect.formevents.pcmodify({ target: form.pcmodify });
+			if (form.pcmodify) {
+				if (item.stabilize) {
+					form.pcmodify.checked = true;
+					Twinkle.protect.formevents.pcmodify({ target: form.pcmodify });
+					form.pclevel.value = item.stabilize;
+					Twinkle.protect.formevents.pclevel({ target: form.pclevel });
+				} else {
+					form.pcmodify.checked = false;
+					Twinkle.protect.formevents.pcmodify({ target: form.pcmodify });
+				}
 			}
 		} else {
 			if (item.create) {


### PR DESCRIPTION
If PC isn't enabled or available on the given namespace (see, among others, #560 and #738), the check for `item.stabilize` would throw an error, leading most notable to the "unprotection" preset not setting the template option to "none."