### PR TITLE
warn: Fix long-standing bug in cpmove warning

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1305,9 +1305,14 @@ Twinkle.warn.callbacks = {
 	getWarningWikitext: function(templateName, article, reason, isCustom) {
 		var text = '{{subst:' + templateName;
 
+		// add linked article for user warnings
 		if (article) {
-			// add linked article for user warnings
-			text += '|1=' + article;
+			// c&pmove has the source as the first parameter
+			if (templateName === 'uw-c&pmove') {
+				text += '|to=' + article;
+			} else {
+				text += '|1=' + article;
+			}
 		}
 		if (reason && !isCustom) {
 			// add extra message


### PR DESCRIPTION
As noted in #872 for the CSD module, {{uw-c&pmove}} actually takes the source of the material as the first unnamed parameter, and the target article as the `to` parameter.  As users are likely to be warning an editor for the incorrect behavior, this will be populated with the target of the c&p move, so should take the `to` parameter.

In the future, it would be nice to have an additional box just for {{uw-c&pmove}} to also list the source page, if it's known, but that'd involve a larger restructuring.