### PR TITLE
block: better detect bots and turn off autoblock

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -105,6 +105,7 @@ Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
 		lelimit: 1,
 		bkusers: mw.config.get('wgRelevantUserName'),
 		ususers: mw.config.get('wgRelevantUserName'),
+		usprop: 'groupmemberships',
 		letitle: 'User:' + mw.config.get('wgRelevantUserName')
 	})
 		.then(function(data) {
@@ -124,6 +125,10 @@ Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
 			Twinkle.block.hasBlockLog = !!data.query.logevents.length;
 			// Used later to check if block status changed while filling out the form
 			Twinkle.block.blockLogId = Twinkle.block.hasBlockLog ? data.query.logevents[0].logid : false;
+
+			Twinkle.block.userIsBot = userinfo.groupmemberships.map(function(e) {
+				return e.group;
+			}).indexOf('bot') !== -1;
 
 			if (typeof fn === 'function') {
 				return fn();
@@ -1294,7 +1299,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 	data.hardblock = data.hardblock !== undefined ? data.hardblock : false;
 
 	// disable autoblock if blocking a bot
-	if (Twinkle.block.isRegistered && relevantUserName.search(/bot\b/i) > 0) {
+	if (Twinkle.block.userIsBot || relevantUserName.search(/bot\b/i) > 0) {
 		data.autoblock = false;
 	}
 


### PR DESCRIPTION
Let's do #858 a bit systematically. While the hack used there is probably good enough for enwiki, not so for other language wikis. 