### PR TITLE
config: Don't save deprecated options, properly save hidden options

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -849,19 +849,14 @@ Twinkle.config.sections = [
 				name: 'revertMaxRevisions',
 				type: 'integer'
 			},
-			// twinklebatchdelete.js: How many pages should be processed at a time
-			{
-				name: 'batchdeleteChunks',
-				type: 'integer'
-			},
-			// twinklebatchdelete.js: How many pages left in the process of being completed should allow a new batch to be initialized
-			{
-				name: 'batchDeleteMinCutOff',
-				type: 'integer'
-			},
 			// twinklebatchdelete.js: How many pages should be processed maximum
 			{
 				name: 'batchMax',
+				type: 'integer'
+			},
+			// twinklebatchdelete.js: How many pages should be processed at a time
+			{
+				name: 'batchdeleteChunks',
 				type: 'integer'
 			},
 			// twinklebatchprotect.js: How many pages should be processed at a time
@@ -869,19 +864,9 @@ Twinkle.config.sections = [
 				name: 'batchProtectChunks',
 				type: 'integer'
 			},
-			// twinklebatchprotect.js: How many pages left in the process of being completed should allow a new batch to be initialized
-			{
-				name: 'batchProtectMinCutOff',
-				type: 'integer'
-			},
 			// twinklebatchundelete.js: How many pages should be processed at a time
 			{
 				name: 'batchundeleteChunks',
-				type: 'integer'
-			},
-			// twinklebatchundelete.js: How many pages left in the process of being completed should allow a new batch to be initialized
-			{
-				name: 'batchUndeleteMinCutOff',
 				type: 'integer'
 			},
 			// twinkledeprod.js: How many pages should be processed at a time

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1528,8 +1528,6 @@ Twinkle.config.resetAllPrefs = function twinkleconfigResetAllPrefs() {
 Twinkle.config.save = function twinkleconfigSave(e) {
 	Morebits.status.init(document.getElementById('twinkle-config-content'));
 
-	Morebits.wiki.actionCompleted.notice = 'Save';
-
 	var userjs = mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user] + ':' + mw.config.get('wgUserName') + '/twinkleoptions.js';
 	var wikipedia_page = new Morebits.wiki.page(userjs, 'Saving preferences to ' + userjs);
 	wikipedia_page.setCallbackParameters(e.target);

--- a/twinkle.js
+++ b/twinkle.js
@@ -121,8 +121,8 @@ Twinkle.defaultConfig = {
 
 	// Hidden preferences
 	revertMaxRevisions: 50,
-	batchdeleteChunks: 50,
 	batchMax: 5000,
+	batchdeleteChunks: 50,
 	batchProtectChunks: 50,
 	batchundeleteChunks: 50,
 	proddeleteChunks: 50,


### PR DESCRIPTION
They're barely used, but the various "hidden" preferences have been ignored by `twinkleconfig` for ages.  The unification of twinkleconfig and friendlyconfig from #762 (f0ebd3f) didn't actually solve that problem, and the check to catch them has only meant that deprecated options (present in [[twinkleoptions.js]], but different from the default by dint of no longer existing in the default) are retained instead (moved to the bottom).  The problem is that these were getting added to `foundPrefs` (`foundTwinklePrefs` and `foundFriendlyPrefs` prior to #762) without a value (skipped because they are hidden in the form), but since they were "found" the iteration over `Twinkle.prefs` to find missing items would by its very nature skip them.  Instead, since they can't be changed in the form, hidden prefs get passed straight through to the `newConfig` object.

This PR also: adjusts the processing loop to properly check for `adminOnly` options, and properly marks the `adminOnly` hidden options as such; removes the unhelpful completion notice upon saving; and removes the ages-ago deprecated `MinCutOff` options.