### PR TITLE
morebits: don't handle notoken error

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2822,7 +2822,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			}
 
 		// check for loss of edit token
-		} else if ((errorCode === 'badtoken' || errorCode === 'notoken') && ctx.retries++ < ctx.maxRetries) {
+		} else if (errorCode === 'badtoken' && ctx.retries++ < ctx.maxRetries) {
 
 			ctx.statusElement.info('Edit token is invalid, retrying');
 			--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
@@ -3047,7 +3047,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			ctx.statusElement.info('Database query error, retrying');
 			--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 			ctx.deleteProcessApi.post(); // give it another go!
-		} else if ((errorCode === 'badtoken' || errorCode === 'notoken') && ctx.retries++ < ctx.maxRetries) {
+		} else if (errorCode === 'badtoken' && ctx.retries++ < ctx.maxRetries) {
 			ctx.statusElement.info('Invalid token, retrying');
 			--Morebits.wiki.numberOfActionsLeft;
 			ctx.deleteProcessApi.query.token = fnGetToken.call(this);
@@ -3129,7 +3129,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			ctx.statusElement.info('Database query error, retrying');
 			--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 			ctx.undeleteProcessApi.post(); // give it another go!
-		} else if ((errorCode === 'badtoken' || errorCode === 'notoken') && ctx.retries++ < ctx.maxRetries) {
+		} else if (errorCode === 'badtoken' && ctx.retries++ < ctx.maxRetries) {
 			ctx.statusElement.info('Invalid token, retrying');
 			--Morebits.wiki.numberOfActionsLeft;
 			ctx.undeleteProcessApi.query.token = fnGetToken.call(this);


### PR DESCRIPTION
`notoken` error code has been removed from MediaWiki. Write queries without token now return the standard `missingparams` error.

It is anyway not necessary to handle this error since we do specify the token, so this just wouldn't ever occur.

In case of expired tokens, the `badtoken` error continues to be returned, which we do handle.