### PR TITLE
morebits: Change status class to morebits_status from tw_status

### DIFF
--- a/morebits.css
+++ b/morebits.css
@@ -10,19 +10,19 @@
 
 /* Morebits.status */
 
-.tw_status_status {
+.morebits_status_status {
 	color: #4682B4;
 }
 
-.tw_status_info {
+.morebits_status_info {
 	color: #228B22;
 }
 
-.tw_status_warn {
+.morebits_status_warn {
 	color: #FF4500;
 }
 
-.tw_status_error {
+.morebits_status_error {
 	color: #FF4500;
 	font-weight: bold;
 }

--- a/morebits.js
+++ b/morebits.js
@@ -3688,7 +3688,7 @@ Morebits.status.prototype = {
 
 	/** Complete the html, for the second part of the status message */
 	render: function() {
-		this.node.className = 'tw_status_' + this.type;
+		this.node.className = 'morebits_status_' + this.type;
 		while (this.target.hasChildNodes()) {
 			this.target.removeChild(this.target.firstChild);
 		}
@@ -3729,7 +3729,7 @@ Morebits.status.error = function(text, status) {
 Morebits.status.actionCompleted = function(text) {
 	var node = document.createElement('div');
 	node.appendChild(document.createElement('span')).appendChild(document.createTextNode(text));
-	node.className = 'tw_status_info';
+	node.className = 'morebits_status_info';
 	if (Morebits.status.root) {
 		Morebits.status.root.appendChild(node);
 	}


### PR DESCRIPTION
Makes the library slightly more Twinkle-agnostic.  <s>Only proper use is User:SD0001/RFUD-helper.js and even that seems unnecessary given the comment; regardless, @siddharthvp is more than capable of managing any issues ;)</s> No real uses.