### PR TITLE
morebits: Use csrftoken obtained via meta=tokens

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -3,7 +3,7 @@
 
 (function($) {
 
-var api = new mw.Api(), relevantUserName;
+var relevantUserName;
 var menuFormattedNamespaces = $.extend({}, mw.config.get('wgFormattedNamespaces'));
 menuFormattedNamespaces[0] = '(Article)';
 
@@ -97,7 +97,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 };
 
 Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
-
+	var api = new mw.Api();
 	api.get({
 		format: 'json',
 		action: 'query',
@@ -1434,19 +1434,14 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		blockoptions.allowusertalk = blockoptions.disabletalk ? undefined : true;
 
 		// execute block
-		api.getToken('block').then(function(token) {
-			statusElement.status('Processing...');
-			blockoptions.token = token;
-			var mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
-				statusElement.info('Completed');
-				if (toWarn) {
-					Twinkle.block.callback.issue_template(templateoptions);
-				}
-			});
-			mbApi.post();
-		}, function() {
-			statusElement.error('Unable to fetch block token');
+		blockoptions.token = mw.user.tokens.get('csrfToken');
+		var mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
+			statusElement.info('Completed');
+			if (toWarn) {
+				Twinkle.block.callback.issue_template(templateoptions);
+			}
 		});
+		mbApi.post();
 	} else if (toWarn) {
 		Morebits.simpleWindow.setButtonsEnabled(false);
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -241,7 +241,9 @@ Twinkle.fluff.revert = function revertPage(type, vandal, autoRevert, rev, page) 
 		'titles': pagename,
 		'rvlimit': 50, // intentionally limited
 		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
-		'intoken': 'edit'
+		'curtimestamp': '',
+		'meta': 'tokens',
+		'type': 'csrf'
 	};
 	var wikipedia_api = new Morebits.wiki.api('Grabbing data of earlier revisions', query, Twinkle.fluff.callbacks.main);
 	wikipedia_api.params = params;
@@ -259,8 +261,10 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 		'rvlimit': 1,
 		'rvstartid': oldrev,
 		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
-		'intoken': 'edit',
-		'format': 'xml'
+		'format': 'xml',
+		'curtimestamp': '',
+		'meta': 'tokens',
+		'type': 'csrf'
 	};
 	var wikipedia_api = new Morebits.wiki.api('Grabbing data of the earlier revision', query, Twinkle.fluff.callbacks.toRevision.main);
 	wikipedia_api.params = { rev: oldrev };
@@ -278,8 +282,8 @@ Twinkle.fluff.callbacks = {
 
 			var lastrevid = parseInt($(xmlDoc).find('page').attr('lastrevid'), 10);
 			var touched = $(xmlDoc).find('page').attr('touched');
-			var starttimestamp = $(xmlDoc).find('page').attr('starttimestamp');
-			var edittoken = $(xmlDoc).find('page').attr('edittoken');
+			var loadtimestamp = $(xmlDoc).find('api').attr('curtimestamp');
+			var csrftoken = $(xmlDoc).find('tokens').attr('csrftoken');
 			var revertToRevID = $(xmlDoc).find('rev').attr('revid');
 			var revertToUser = $(xmlDoc).find('rev').attr('user');
 
@@ -299,11 +303,11 @@ Twinkle.fluff.callbacks = {
 				'action': 'edit',
 				'title': mw.config.get('wgPageName'),
 				'summary': summary,
-				'token': edittoken,
+				'token': csrftoken,
 				'undo': lastrevid,
 				'undoafter': revertToRevID,
 				'basetimestamp': touched,
-				'starttimestamp': starttimestamp,
+				'starttimestamp': loadtimestamp,
 				'watchlist': Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1 ? 'watch' : undefined,
 				'minor': Twinkle.getPref('markRevertedPagesAsMinor').indexOf('torev') !== -1 ? true : undefined
 			};
@@ -322,8 +326,8 @@ Twinkle.fluff.callbacks = {
 
 		var lastrevid = parseInt($(xmlDoc).find('page').attr('lastrevid'), 10);
 		var touched = $(xmlDoc).find('page').attr('touched');
-		var starttimestamp = $(xmlDoc).find('page').attr('starttimestamp');
-		var edittoken = $(xmlDoc).find('page').attr('edittoken');
+		var loadtimestamp = $(xmlDoc).find('api').attr('curtimestamp');
+		var csrftoken = $(xmlDoc).find('tokens').attr('csrftoken');
 		var lastuser = $(xmlDoc).find('rev').attr('user');
 
 		var revs = $(xmlDoc).find('rev');
@@ -510,18 +514,18 @@ Twinkle.fluff.callbacks = {
 				$flagged.attr('stable_revid') >= self.params.goodid &&
 				$flagged.attr('pending_since')) {
 			self.params.reviewRevert = true;
-			self.params.edittoken = edittoken;
+			self.params.csrftoken = csrftoken;
 		}
 
 		query = {
 			'action': 'edit',
 			'title': self.params.pagename,
 			'summary': summary,
-			'token': edittoken,
+			'token': csrftoken,
 			'undo': lastrevid,
 			'undoafter': self.params.goodid,
 			'basetimestamp': touched,
-			'starttimestamp': starttimestamp,
+			'starttimestamp': loadtimestamp,
 			'watchlist': Twinkle.getPref('watchRevertedPages').indexOf(self.params.type) !== -1 ? 'watch' : undefined,
 			'minor': Twinkle.getPref('markRevertedPagesAsMinor').indexOf(self.params.type) !== -1 ? true : undefined
 		};
@@ -551,7 +555,7 @@ Twinkle.fluff.callbacks = {
 				var query = {
 					'action': 'review',
 					'revid': $edit.attr('newrevid'),
-					'token': apiobj.params.edittoken,
+					'token': apiobj.params.csrftoken,
 					'comment': Twinkle.getPref('summaryAd').trim()
 				};
 				var wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);

--- a/morebits.js
+++ b/morebits.js
@@ -2546,8 +2546,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			inprop: 'protection',
 			meta: 'tokens',
 			type: 'csrf',
-			titles: ctx.pageName,
-			watchlist: ctx.watchlistOption
+			titles: ctx.pageName
 		};
 		if (ctx.followRedirect) {
 			query.redirects = '';  // follow all redirects
@@ -2972,7 +2971,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			'from': pageTitle,
 			'to': ctx.moveDestination,
 			'token': token,
-			'reason': ctx.editSummary
+			'reason': ctx.editSummary,
+			'watchlist': ctx.watchlistOption
 		};
 		if (ctx.moveTalkPage) {
 			query.movetalk = 'true';
@@ -2982,9 +2982,6 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 		if (ctx.moveSuppressRedirect) {
 			query.noredirect = 'true';
-		}
-		if (ctx.watchlistOption === 'watch') {
-			query.watch = 'true';
 		}
 
 		ctx.moveProcessApi = new Morebits.wiki.api('moving page...', query, ctx.onMoveSuccess, ctx.statusElement, ctx.onMoveFailure);
@@ -3032,11 +3029,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			'action': 'delete',
 			'title': pageTitle,
 			'token': token,
-			'reason': ctx.editSummary
+			'reason': ctx.editSummary,
+			'watchlist': ctx.watchlistOption
 		};
-		if (ctx.watchlistOption === 'watch') {
-			query.watch = 'true';
-		}
 
 		ctx.deleteProcessApi = new Morebits.wiki.api('deleting page...', query, ctx.onDeleteSuccess, ctx.statusElement, fnProcessDeleteError);
 		ctx.deleteProcessApi.setParent(this);
@@ -3112,11 +3107,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			'action': 'undelete',
 			'title': pageTitle,
 			'token': token,
-			'reason': ctx.editSummary
+			'reason': ctx.editSummary,
+			'watchlist': ctx.watchlistOption
 		};
-		if (ctx.watchlistOption === 'watch') {
-			query.watch = 'true';
-		}
 
 		ctx.undeleteProcessApi = new Morebits.wiki.api('undeleting page...', query, ctx.onUndeleteSuccess, ctx.statusElement, fnProcessUndeleteError);
 		ctx.undeleteProcessApi.setParent(this);
@@ -3218,13 +3211,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			token: token,
 			protections: protections.join('|'),
 			expiry: expirys.join('|'),
-			reason: ctx.editSummary
+			reason: ctx.editSummary,
+			watchlist: ctx.watchlistOption
 		};
 		if (ctx.protectCascade) {
 			query.cascade = 'true';
-		}
-		if (ctx.watchlistOption === 'watch') {
-			query.watch = 'true';
 		}
 
 		ctx.protectProcessApi = new Morebits.wiki.api('protecting page...', query, ctx.onProtectSuccess, ctx.statusElement, ctx.onProtectFailure);
@@ -3259,8 +3250,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			expiry: ctx.flaggedRevs.expiry,
 			reason: ctx.editSummary
 		};
+		// [[phab:T247915]]
 		if (ctx.watchlistOption === 'watch') {
-			query.watch = 'true';
+			query.watchlist = 'true';
 		}
 
 		ctx.stabilizeProcessApi = new Morebits.wiki.api('configuring stabilization settings...', query, ctx.onStabilizeSuccess, ctx.statusElement, ctx.onStabilizeFailure);


### PR DESCRIPTION
There are a few connected commits here, but the meat of it is in the second commit.  Closes #615.

Using `intoken` was deprecated ages ago.  `curtimestamp` is used in `.load` now that we no longer use `intoken`.  As noted in #741, `starttimestamp` was only available because we were still using the outdated `intoken` method; with that gone, we need to explicitly provide `query.curtimestamp`, thus replicating the loading timestamp that we can feed it into `starttimestamp` and avoid edit conflicts.  Some references to token names in error messages were kept for ease of debugging.

Some token handling is changed in `block` (1st commit) and `fluff` (2nd commit).  The 3rd commit tweaks the querys to update the deprecated `watch`/`watchlist` parameter (excepting for PC).

4th commit: Use `fnCanUseMwUserToken` for move and stabilize.  First added in d37e981, reasonable to use for `move` and `stabilize` since we're not using any additional information.  Unlike with protection, flaggedrevs doesn't need any previous statuses; like protection, we don't issue alerts for acting on already-stabilized pages.  Thus, there isn't an additional need to check `wgStableRevisionId` or something.

The 5th commit is the one I'm really not sure of and wouldn't mind opinions on.  It uses a common query for non-load actions (delete, etc.) to consolidate/deduplicate the query.  `fnNeedTokenInfoQuery` takes the relevant `action`.  Of note, removes the `prop=info` check for non-sysop moves as well as all `prop=info|flagged` for `stabilize`; they were unused.

The query gets stuffed out of the way and although it should be easier to maintain, outside of token stuff like this these queries are unlikely to need a lot of future maintenance.  This is basically what Dan Abramov has written about: https://overreacted.io/goodbye-clean-code/

In theory, this means more `if`s for each action, in particular delete, and has the query even more removed from the proper context.  Another way to do this would be to set the median query but then have individual items tweak as necessary "locally" (`redirects` removed for undelete, stabilize and non-sysop move remove `prop` and `inprop`).  That keeps things somewhat closer to their relevant areas, but then again, `delete` is slow and it'd be is "harder" to "maintain."

It's live on testwiki (with an excessive amount of logging).  cc @MusikAnimal 