### PR TITLE
config: Move CSS for box on userjs to twinkle.css

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1246,12 +1246,8 @@ Twinkle.config.init = function twinkleconfigInit() {
 			mw.config.get('wgPageName').slice(-3) === '.js') {
 
 		var box = document.createElement('div');
+		// Styled in twinkle.css
 		box.setAttribute('id', 'twinkle-config-headerbox');
-		box.style.border = '1px #f60 solid';
-		box.style.background = '#fed';
-		box.style.padding = '0.6em';
-		box.style.margin = '0.5em auto';
-		box.style.textAlign = 'center';
 
 		var link,
 			scriptPageName = mw.config.get('wgPageName').slice(mw.config.get('wgPageName').lastIndexOf('/') + 1,
@@ -1259,9 +1255,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 
 		if (scriptPageName === 'twinkleoptions') {
 			// place "why not try the preference panel" notice
-			box.style.fontWeight = 'bold';
-			box.style.width = '80%';
-			box.style.borderWidth = '2px';
+			box.setAttribute('class', 'config-twopt-box');
 
 			if (mw.config.get('wgArticleId') > 0) {  // page exists
 				box.appendChild(document.createTextNode('This page contains your Twinkle preferences. You can change them using the '));
@@ -1277,7 +1271,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 
 		} else if (['monobook', 'vector', 'cologneblue', 'modern', 'timeless', 'minerva', 'common'].indexOf(scriptPageName) !== -1) {
 			// place "Looking for Twinkle options?" notice
-			box.style.width = '60%';
+			box.setAttribute('class', 'config-userskin-box');
 
 			box.appendChild(document.createTextNode('If you want to set Twinkle preferences, you can use the '));
 			link = document.createElement('a');

--- a/twinkle.css
+++ b/twinkle.css
@@ -5,3 +5,24 @@
 .skin-vector #p-twinkle {
 	width: 3.24em;
 }
+
+/* The additional box on user skin.js and twinklepreferences.js pages */
+#twinkle-config-headerbox {
+	border: 1px #f60 solid;
+	background: #fed;
+	padding: 0.6em;
+	margin: 0.5em auto;
+	text-align: center;
+}
+
+/* twinkleoptions.js */
+#twinkle-config-headerbox.config-twopt-box {
+	font-weight: bold;
+	width: 80%;
+	border-width: 2px;
+}
+
+/* skin-specific js */
+#twinkle-config-headerbox.config-userskin-box {
+	width: 60%;
+}


### PR DESCRIPTION
Was requested by @Enterprisey a while ago: https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_42#%22If_you_want_to_set_Twinkle_preferences...%22_box_CSS, see also #778