### PR TITLE
tag: Remove extra newline after section in merge discussions

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1301,7 +1301,7 @@ Twinkle.tag.callbacks = {
 				// special functions for merge tags
 				if (params.mergeReason) {
 					// post the rationale on the talk page (only operates in main namespace)
-					var talkpageText = '\n\n== ' + params.talkDiscussionTitleLinked + ' ==\n\n';
+					var talkpageText = '\n\n== ' + params.talkDiscussionTitleLinked + ' ==\n';
 					talkpageText += params.mergeReason.trim() + ' ~~~~';
 					var talkpage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					talkpage.setAppendText(talkpageText);


### PR DESCRIPTION
This is a dumb PR, but I'm opening it rather than just doing it because I feel like I have to be missing something.  There's no visual change, but is there actually a reason the merge discussion has had two newlines for ages?  I would have thought someone would have noticed otherwise...