### PR TITLE
lint: Enforce quote-props consistent-as-needed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
 		"no-trailing-spaces": "error",
 		"no-unneeded-ternary": "error",
 		"no-whitespace-before-property": "error",
+		"quote-props": ["error", "consistent-as-needed"],
 		"quotes": ["error", "single", { "avoidEscape": true }],
 		"semi": ["error", "always"],
 		"space-before-blocks": "error",

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -894,7 +894,7 @@ Twinkle.tag.redirectList = {
 		]
 	},
 	'Alternative names': {
-		'General': [
+		General: [
 			{
 				tag: 'R from alternative language',
 				description: 'redirect from or to a title in another language',
@@ -931,7 +931,7 @@ Twinkle.tag.redirectList = {
 			{ tag: 'R from sort name', description: 'redirect from the target\'s sort name, such as beginning with their surname rather than given name' },
 			{ tag: 'R from synonym', description: 'redirect from a semantic synonym of the target page title' }
 		],
-		'People': [
+		People: [
 			{ tag: 'R from birth name', description: 'redirect from a person\'s birth name to a more common name' },
 			{ tag: 'R from given name', description: 'redirect from a person\'s given name' },
 			{ tag: 'R from name with title', description: 'redirect from a person\'s name preceded or followed by a title to the name with no title or with the title in parentheses' },
@@ -940,14 +940,14 @@ Twinkle.tag.redirectList = {
 			{ tag: 'R from pseudonym', description: 'redirect from a pseudonym' },
 			{ tag: 'R from surname', description: 'redirect from a title that is a surname' }
 		],
-		'Technical': [
+		Technical: [
 			{ tag: 'R from drug trade name', description: 'redirect from (or to) the trade name of a drug to (or from) the international nonproprietary name (INN)' },
 			{ tag: 'R from filename', description: 'redirect from a title that is a filename of the target' },
 			{ tag: 'R from molecular formula', description: 'redirect from a molecular/chemical formula to its technical or trivial name' },
 
 			{ tag: 'R from gene symbol', description: 'redirect from a Human Genome Organisation (HUGO) symbol for a gene to an article about the gene' }
 		],
-		'Organisms': [
+		Organisms: [
 			{ tag: 'R to scientific name', description: 'redirect from the common name to the scientific name' },
 			{ tag: 'R from scientific name', description: 'redirect from the scientific name to the common name' },
 			{ tag: 'R from alternative scientific name', description: 'redirect from an alternative scientific name to the accepted scientific name' },
@@ -956,7 +956,7 @@ Twinkle.tag.redirectList = {
 			{ tag: 'R from monotypic taxon', description: 'redirect from a monotypic taxon to its only lower-ranking member' },
 			{ tag: 'R taxon with possibilities', description: 'redirect from a title related to a living organism that potentially could be expanded into an article' }
 		],
-		'Geography': [
+		Geography: [
 			{ tag: 'R from name and country', description: 'redirect from the specific name to the briefer name' },
 			{ tag: 'R from more specific geographic name', description: 'redirect from a geographic location that includes extraneous identifiers such as the county or region of a city' }
 		]
@@ -1008,13 +1008,13 @@ Twinkle.tag.redirectList = {
 		]
 	},
 	'Media': {
-		'General': [
+		General: [
 			{ tag: 'R from book', description: 'redirect from a book title to a more general, relevant article' },
 			{ tag: 'R from album', description: 'redirect from an album to a related topic such as the recording artist or a list of albums' },
 			{ tag: 'R from song', description: 'redirect from a song title to a more general, relevant article' },
 			{ tag: 'R from television episode', description: 'redirect from a television episode title to a related work or lists of episodes' }
 		],
-		'Fiction': [
+		Fiction: [
 			{ tag: 'R from fictional character', description: 'redirect from a fictional character to a related fictional work or list of characters' },
 			{ tag: 'R from fictional element', description: 'redirect from a fictional element (such as an object or concept) to a related fictional work or list of similar elements' },
 			{ tag: 'R from fictional location', description: 'redirect from a fictional location or setting to a related fictional work or list of places' }
@@ -1412,14 +1412,14 @@ Twinkle.tag.callbacks = {
 
 			// Remove tags which appear in page text as redirects
 			var api = new Morebits.wiki.api('Getting template redirects', {
-				'action': 'query',
-				'prop': 'linkshere',
-				'titles': getRedirectsFor.join('|'),
-				'redirects': 1,  // follow redirect if the class name turns out to be a redirect page
-				'lhnamespace': '10',  // template namespace only
-				'lhshow': 'redirect',
-				'lhlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				prop: 'linkshere',
+				titles: getRedirectsFor.join('|'),
+				redirects: 1,  // follow redirect if the class name turns out to be a redirect page
+				lhnamespace: '10',  // template namespace only
+				lhshow: 'redirect',
+				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			}, function removeRedirectTag(apiobj) {
 				var pages = apiobj.getResponse().query.pages.filter(function(p) {
 					return !p.missing && !!p.linkshere;
@@ -1632,14 +1632,14 @@ Twinkle.tag.callbacks = {
 			}
 
 			var api = new Morebits.wiki.api('Getting template redirects', {
-				'action': 'query',
-				'prop': 'linkshere',
-				'titles': getRedirectsFor.join('|'),
-				'redirects': 1,
-				'lhnamespace': '10', // template namespace only
-				'lhshow': 'redirect',
-				'lhlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				prop: 'linkshere',
+				titles: getRedirectsFor.join('|'),
+				redirects: 1,
+				lhnamespace: '10', // template namespace only
+				lhshow: 'redirect',
+				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			}, function replaceRedirectTag(apiobj) {
 				var pages = apiobj.getResponse().query.pages.filter(function(p) {
 					return !p.missing && !!p.linkshere;

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -292,17 +292,17 @@ Twinkle.talkback.changeTarget = function(e) {
 };
 
 Twinkle.talkback.noticeboards = {
-	'an': {
+	an: {
 		label: "WP:AN (Administrators' noticeboard)",
 		text: '{{subst:AN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Administrators\' noticeboard]]'
 	},
-	'an3': {
+	an3: {
 		label: "WP:AN3 (Administrators' noticeboard/Edit warring)",
 		text: '{{subst:An3-notice|$SECTION}} ~~~~',
 		editSummary: "Notice of discussion at [[Wikipedia:Administrators' noticeboard/Edit warring]]"
 	},
-	'ani': {
+	ani: {
 		label: "WP:ANI (Administrators' noticeboard/Incidents)",
 		text: "== Notice of Administrators' noticeboard/Incidents discussion ==\n" +
 		'{{subst:ANI-notice|thread=$SECTION}} ~~~~',
@@ -310,67 +310,67 @@ Twinkle.talkback.noticeboards = {
 		defaultSelected: true
 	},
 	// let's keep AN and its cousins at the top
-	'afchd': {
+	afchd: {
 		label: 'WP:AFCHD (Articles for creation/Help desk)',
 		text: '{{subst:AFCHD/u|$SECTION}} ~~~~',
 		editSummary: 'You have replies at the [[Wikipedia:AFCHD|Articles for Creation Help Desk]]'
 	},
-	'blpn': {
+	blpn: {
 		label: 'WP:BLPN (Biographies of living persons noticeboard)',
 		text: '{{subst:BLPN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Biographies of living persons/Noticeboard]]'
 	},
-	'coin': {
+	coin: {
 		label: 'WP:COIN (Conflict of interest noticeboard)',
 		text: '{{subst:Coin-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Conflict of interest/Noticeboard]]'
 	},
-	'drn': {
+	drn: {
 		label: 'WP:DRN (Dispute resolution noticeboard)',
 		text: '{{subst:DRN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Dispute resolution noticeboard]]'
 	},
-	'effp': {
+	effp: {
 		label: 'WP:EFFP/R (Edit filter false positive report)',
 		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies to your [[Wikipedia:Edit filter/False positives/Reports|edit filter false positive report]]'
 	},
-	'eln': {
+	eln: {
 		label: 'WP:ELN (External links noticeboard)',
 		text: '{{subst:ELN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:External links/Noticeboard]]'
 	},
-	'ftn': {
+	ftn: {
 		label: 'WP:FTN (Fringe theories noticeboard)',
 		text: '{{subst:Ftn-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Fringe theories/Noticeboard]]'
 	},
-	'hd': {
+	hd: {
 		label: 'WP:HD (Help desk)',
 		text: '== Your question at the Help desk ==\n' + '{{helpdeskreply|1=$SECTION|ts=~~~~~}}',
 		editSummary: 'You have replies at the [[Wikipedia:Help desk|Wikipedia help desk]]'
 	},
-	'norn': {
+	norn: {
 		label: 'WP:NORN (Reliable sources noticeboard)',
 		text: '{{subst:Norn-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Reliable sources/Noticeboard]]'
 	},
-	'npovn': {
+	npovn: {
 		label: 'WP:NPOVN (Neutral point of view noticeboard)',
 		text: '{{subst:NPOVN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Neutral point of view/Noticeboard]]'
 	},
-	'rsn': {
+	rsn: {
 		label: 'WP:RSN (Reliable sources noticeboard)',
 		text: '{{subst:RSN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Reliable sources/Noticeboard]]'
 	},
-	'th': {
+	th: {
 		label: 'WP:THQ (Teahouse question forum)',
 		text: "== Teahouse talkback: you've got messages! ==\n{{WP:Teahouse/Teahouse talkback|WP:Teahouse/Questions|$SECTION|ts=~~~~}}",
 		editSummary: 'You have replies at the [[Wikipedia:Teahouse/Questions|Teahouse question board]]'
 	},
-	'otrs': {
+	otrs: {
 		label: 'WP:OTRS/N (OTRS noticeboard)',
 		text: '{{OTRSreply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies at the [[Wikipedia:OTRS noticeboard|OTRS noticeboard]]'

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -64,8 +64,8 @@ Twinkle.welcome.normal = function() {
 
 				var oWelcomeNode = welcomeNode.cloneNode(true);
 				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + $.param({
-					'friendlywelcome': Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
-					'vanarticle': Morebits.pageNameNorm
+					friendlywelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
+					vanarticle: Morebits.pageNameNorm
 				}));
 				$oList[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
 				$oList[0].parentNode.parentNode.appendChild(oWelcomeNode);
@@ -76,8 +76,8 @@ Twinkle.welcome.normal = function() {
 
 				var nWelcomeNode = welcomeNode.cloneNode(true);
 				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + $.param({
-					'friendlywelcome': Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
-					'vanarticle': Morebits.pageNameNorm
+					friendlywelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
+					vanarticle: Morebits.pageNameNorm
 				}));
 				$nList[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
 				$nList[0].parentNode.parentNode.appendChild(nWelcomeNode);
@@ -226,7 +226,7 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 //   - $HEADER$    - adds a level 2 header (most templates already include this)
 
 Twinkle.welcome.templates = {
-	'standard': {
+	standard: {
 		'General welcome templates': {
 			'welcome': {
 				description: 'standard welcome',
@@ -334,7 +334,7 @@ Twinkle.welcome.templates = {
 		}
 	},
 
-	'anonymous': {
+	anonymous: {
 		'Anonymous user welcome templates': {
 			'welcome-anon': {
 				description: 'for anonymous users; encourages creating an account',
@@ -364,7 +364,7 @@ Twinkle.welcome.templates = {
 		}
 	},
 
-	'wikiProject': {
+	wikiProject: {
 		'WikiProject-specific welcome templates': {
 			'welcome-anatomy': {
 				description: 'welcome for users with an apparent interest in anatomy topics',
@@ -480,7 +480,7 @@ Twinkle.welcome.templates = {
 		}
 	},
 
-	'nonEnglish': {
+	nonEnglish: {
 		'Non-English welcome templates': {
 			'welcomeen': {
 				description: 'welcome for users whose first language is not listed here',

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -384,12 +384,12 @@ Twinkle.arv.callback.changeCategory = function (e) {
 								for (var i = 0; i < page.revisions.length; ++i) {
 									var rev = page.revisions[i];
 									var $entry = $('<div/>', {
-										'class': 'entry'
+										class: 'entry'
 									});
 									var $input = $('<input/>', {
-										'type': 'checkbox',
-										'name': 's_' + field,
-										'value': rev.revid
+										type: 'checkbox',
+										name: 's_' + field,
+										value: rev.revid
 									});
 									$input.data('revinfo', rev);
 									$input.appendTo($entry);
@@ -408,16 +408,16 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							// add free form input for resolves
 							if (field === 'resolves') {
 								var $free_entry = $('<div/>', {
-									'class': 'entry'
+									class: 'entry'
 								});
 								var $free_input = $('<input/>', {
-									'type': 'text',
-									'name': 's_resolves_free'
+									type: 'text',
+									name: 's_resolves_free'
 								});
 
 								var $free_label = $('<label/>', {
-									'for': 's_resolves_free',
-									'html': 'URL link of diff with additional discussions: '
+									for: 's_resolves_free',
+									html: 'URL link of diff with additional discussions: '
 								});
 								$free_entry.append($free_label).append($free_input).appendTo($field);
 							}
@@ -701,13 +701,13 @@ Twinkle.arv.callback.evaluate = function(e) {
 				}
 
 				var an3Parameters = {
-					'uid': uid,
-					'page': form.page.value.trim(),
-					'comment': form.comment.value.trim(),
-					'diffs': diffs,
-					'warnings': warnings,
-					'resolves': resolves,
-					'free_resolves': free_resolves
+					uid: uid,
+					page: form.page.value.trim(),
+					comment: form.comment.value.trim(),
+					diffs: diffs,
+					warnings: warnings,
+					resolves: resolves,
+					free_resolves: free_resolves
 				};
 
 				Morebits.simpleWindow.setButtonsEnabled(false);

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -111,11 +111,11 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	});
 
 	var query = {
-		'action': 'query',
-		'prop': 'revisions|info|imageinfo',
-		'inprop': 'protection',
-		'rvprop': 'size|user',
-		'format': 'json'
+		action: 'query',
+		prop: 'revisions|info|imageinfo',
+		inprop: 'protection',
+		rvprop: 'size|user',
+		format: 'json'
 	};
 
 	// On categories
@@ -518,13 +518,13 @@ Twinkle.batchdelete.callbacks = {
 		if (params.unlink_page) {
 			Twinkle.batchdelete.unlinkCache = {};
 			query = {
-				'action': 'query',
-				'list': 'backlinks',
-				'blfilterredir': 'nonredirects',
-				'blnamespace': [0, 100], // main space and portal space only
-				'bltitle': params.page,
-				'bllimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				list: 'backlinks',
+				blfilterredir: 'nonredirects',
+				blnamespace: [0, 100], // main space and portal space only
+				bltitle: params.page,
+				bllimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			};
 			wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.batchdelete.callbacks.unlinkBacklinksMain);
 			wikipedia_api.params = params;
@@ -533,11 +533,11 @@ Twinkle.batchdelete.callbacks = {
 
 		if (params.unlink_file) {
 			query = {
-				'action': 'query',
-				'list': 'imageusage',
-				'iutitle': params.page,
-				'iulimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				list: 'imageusage',
+				iutitle: params.page,
+				iulimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			};
 			wikipedia_api = new Morebits.wiki.api('Grabbing file links', query, Twinkle.batchdelete.callbacks.unlinkImageInstancesMain);
 			wikipedia_api.params = params;
@@ -547,11 +547,11 @@ Twinkle.batchdelete.callbacks = {
 		if (params.delete_page) {
 			if (params.delete_redirects) {
 				query = {
-					'action': 'query',
-					'titles': params.page,
-					'prop': 'redirects',
-					'rdlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-					'format': 'json'
+					action: 'query',
+					titles: params.page,
+					prop: 'redirects',
+					rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+					format: 'json'
 				};
 				wikipedia_api = new Morebits.wiki.api('Grabbing redirects', query, Twinkle.batchdelete.callbacks.deleteRedirectsMain);
 				wikipedia_api.params = params;
@@ -562,9 +562,9 @@ Twinkle.batchdelete.callbacks = {
 				if (pageTitle && pageTitle.namespace % 2 === 0 && pageTitle.namespace !== 2) {
 					pageTitle.namespace++;  // now pageTitle is the talk page title!
 					query = {
-						'action': 'query',
-						'titles': pageTitle.toText(),
-						'format': 'json'
+						action: 'query',
+						titles: pageTitle.toText(),
+						format: 'json'
 					};
 					wikipedia_api = new Morebits.wiki.api('Checking whether talk page exists', query, Twinkle.batchdelete.callbacks.deleteTalk);
 					wikipedia_api.params = params;

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -147,11 +147,11 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 	});
 
 	var query = {
-		'action': 'query',
-		'prop': 'revisions|info',
-		'rvprop': 'size',
-		'inprop': 'protection',
-		'format': 'json'
+		action: 'query',
+		prop: 'revisions|info',
+		rvprop: 'size',
+		inprop: 'protection',
+		format: 'json'
 	};
 
 	if (mw.config.get('wgNamespaceNumber') === 14) {  // categories
@@ -280,9 +280,9 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 	batchOperation.setPageList(input.pages);
 	batchOperation.run(function(pageName) {
 		var query = {
-			'action': 'query',
-			'titles': pageName,
-			'format': 'json'
+			action: 'query',
+			titles: pageName,
+			format: 'json'
 		};
 		var wikipedia_api = new Morebits.wiki.api('Checking if page ' + pageName + ' exists', query,
 			Twinkle.batchprotect.callbacks.main, null, batchOperation.workerFailure);

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -54,13 +54,13 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 	Window.display();
 
 	var query = {
-		'action': 'query',
-		'generator': 'links',
-		'prop': 'info',
-		'inprop': 'protection',
-		'titles': mw.config.get('wgPageName'),
-		'gpllimit': Twinkle.getPref('batchMax'),
-		'format': 'json'
+		action: 'query',
+		generator: 'links',
+		prop: 'info',
+		inprop: 'protection',
+		titles: mw.config.get('wgPageName'),
+		gpllimit: Twinkle.getPref('batchMax'),
+		format: 'json'
 	};
 	var statelem = new Morebits.status('Grabbing list of pages');
 	var wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
@@ -177,12 +177,12 @@ Twinkle.batchundelete.callbacks = {
 			var talkpagename = new mw.Title(params.page).getTalkPage().getPrefixedText();
 			if (talkpagename !== params.page) {
 				query = {
-					'action': 'query',
-					'prop': 'deletedrevisions',
-					'drvprop': 'ids',
-					'drvlimit': 1,
-					'titles': talkpagename,
-					'format': 'json'
+					action: 'query',
+					prop: 'deletedrevisions',
+					drvprop: 'ids',
+					drvlimit: 1,
+					titles: talkpagename,
+					format: 'json'
 				};
 				wikipedia_api = new Morebits.wiki.api('Checking talk page for deleted revisions', query, Twinkle.batchundelete.callbacks.undeleteTalk);
 				wikipedia_api.params = params;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -518,12 +518,12 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 						return;
 					}
 					return {
-						'action': 'query',
-						'format': 'json',
-						'list': 'allpages',
-						'apfrom': title.title,
-						'apnamespace': title.namespace,
-						'aplimit': '10'
+						action: 'query',
+						format: 'json',
+						list: 'allpages',
+						apfrom: title.title,
+						apnamespace: title.namespace,
+						aplimit: '10'
 					};
 				},
 				processResults: function(data) {

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -22,8 +22,8 @@
 Twinkle.config = {};
 
 Twinkle.config.watchlistEnums = {
-	yes: 'Add to watchlist (indefinitely)',
-	no: "Don't add to watchlist",
+	'yes': 'Add to watchlist (indefinitely)',
+	'no': "Don't add to watchlist",
 	'default': 'Follow your site preferences',
 	'1 week': 'Watch for 1 week',
 	'1 month': 'Watch for 1 month',
@@ -100,32 +100,32 @@ Twinkle.config.commonSets = {
 		'p1', 'p2'
 	],
 	namespacesNoSpecial: {
-		'0': 'Article',
-		'1': 'Talk (article)',
-		'2': 'User',
-		'3': 'User talk',
-		'4': 'Wikipedia',
-		'5': 'Wikipedia talk',
-		'6': 'File',
-		'7': 'File talk',
-		'8': 'MediaWiki',
-		'9': 'MediaWiki talk',
-		'10': 'Template',
-		'11': 'Template talk',
-		'12': 'Help',
-		'13': 'Help talk',
-		'14': 'Category',
-		'15': 'Category talk',
-		'100': 'Portal',
-		'101': 'Portal talk',
-		'108': 'Book',
-		'109': 'Book talk',
-		'118': 'Draft',
-		'119': 'Draft talk',
-		'710': 'TimedText',
-		'711': 'TimedText talk',
-		'828': 'Module',
-		'829': 'Module talk'
+		0: 'Article',
+		1: 'Talk (article)',
+		2: 'User',
+		3: 'User talk',
+		4: 'Wikipedia',
+		5: 'Wikipedia talk',
+		6: 'File',
+		7: 'File talk',
+		8: 'MediaWiki',
+		9: 'MediaWiki talk',
+		10: 'Template',
+		11: 'Template talk',
+		12: 'Help',
+		13: 'Help talk',
+		14: 'Category',
+		15: 'Category talk',
+		100: 'Portal',
+		101: 'Portal talk',
+		108: 'Book',
+		109: 'Book talk',
+		118: 'Draft',
+		119: 'Draft talk',
+		710: 'TimedText',
+		711: 'TimedText talk',
+		828: 'Module',
+		829: 'Module talk'
 	}
 };
 
@@ -186,7 +186,7 @@ Twinkle.config.sections = [
 				label: 'Turn off the selected Twinkle modules',
 				helptip: 'Anything you select here will NOT be available for use, so act with care. Uncheck to reactivate.',
 				type: 'set',
-				setValues: { arv: 'ARV', warn: 'Warn', welcome: 'Welcome', shared: 'Shared IP', talkback: 'Talkback', speedy: 'CSD', prod: 'PROD', xfd: 'XfD', image: 'Image (DI)', protect: 'Protect (RPP)', tag: 'Tag', diff: 'Diff', unlink: 'Unlink', 'fluff': 'Revert and rollback' }
+				setValues: { arv: 'ARV', warn: 'Warn', welcome: 'Welcome', shared: 'Shared IP', talkback: 'Talkback', speedy: 'CSD', prod: 'PROD', xfd: 'XfD', image: 'Image (DI)', protect: 'Protect (RPP)', tag: 'Tag', diff: 'Diff', unlink: 'Unlink', fluff: 'Revert and rollback' }
 			},
 
 			// Twinkle.config.disabledSysopModules (array)
@@ -465,7 +465,7 @@ Twinkle.config.sections = [
 				name: 'speedySelectionStyle',
 				label: 'When to go ahead and tag/delete the page',
 				type: 'enum',
-				enumValues: { 'buttonClick': 'When I click "Submit"', 'radioClick': 'As soon as I click an option' }
+				enumValues: { buttonClick: 'When I click "Submit"', radioClick: 'As soon as I click an option' }
 			},
 
 			// TwinkleConfig.watchSpeedyPages (array)
@@ -646,7 +646,7 @@ Twinkle.config.sections = [
 				name: 'tagArticleSortOrder',
 				label: 'Default view order for article tags',
 				type: 'enum',
-				enumValues: { 'cat': 'By categories', 'alpha': 'In alphabetical order' }
+				enumValues: { cat: 'By categories', alpha: 'In alphabetical order' }
 			},
 			{
 				name: 'customTagList',
@@ -729,17 +729,17 @@ Twinkle.config.sections = [
 				label: 'Default warning level',
 				type: 'enum',
 				enumValues: {
-					'1': 'Level 1',
-					'2': 'Level 2',
-					'3': 'Level 3',
-					'4': 'Level 4',
-					'5': 'Level 4im',
-					'6': 'Single-issue notices',
-					'7': 'Single-issue warnings',
+					1: 'Level 1',
+					2: 'Level 2',
+					3: 'Level 3',
+					4: 'Level 4',
+					5: 'Level 4im',
+					6: 'Single-issue notices',
+					7: 'Single-issue warnings',
 					// 8 was used for block templates before #260
-					'9': 'Custom warnings',
-					'10': 'All warning templates',
-					'11': 'Auto-select level (1-4)'
+					9: 'Custom warnings',
+					10: 'All warning templates',
+					11: 'Auto-select level (1-4)'
 				}
 			},
 

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -41,15 +41,15 @@ Twinkle.deprod.callback = function() {
 	Window.display();
 
 	var query = {
-		'action': 'query',
-		'generator': 'categorymembers',
-		'gcmtitle': mw.config.get('wgPageName'),
-		'gcmlimit': Twinkle.getPref('batchMax'),
-		'gcmnamespace': '0|6|108|2', // mostly to ignore categories
-		'prop': [ 'info', 'revisions' ],
-		'rvprop': [ 'content' ],
-		'inprop': [ 'protection' ],
-		'format': 'json'
+		action: 'query',
+		generator: 'categorymembers',
+		gcmtitle: mw.config.get('wgPageName'),
+		gcmlimit: Twinkle.getPref('batchMax'),
+		gcmnamespace: '0|6|108|2', // mostly to ignore categories
+		prop: [ 'info', 'revisions' ],
+		rvprop: [ 'content' ],
+		inprop: [ 'protection' ],
+		format: 'json'
 	};
 
 	var statelem = new Morebits.status('Grabbing list of pages');
@@ -104,12 +104,12 @@ Twinkle.deprod.callback = function() {
 			}
 		});
 		apiobj.params.form.append({
-			'type': 'checkbox',
-			'name': 'pages',
-			'list': list
+			type: 'checkbox',
+			name: 'pages',
+			list: list
 		});
 		apiobj.params.form.append({
-			'type': 'submit'
+			type: 'submit'
 		});
 
 		var rendered = apiobj.params.form.render();
@@ -140,11 +140,11 @@ var callback_commit = function(event) {
 			var params = { page: pageName, reason: concerns[page] };
 
 			var query = {
-				'action': 'query',
-				'titles': pageName,
-				'prop': 'redirects',
-				'rdlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				titles: pageName,
+				prop: 'redirects',
+				rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			};
 			var wikipedia_api = new Morebits.wiki.api('Grabbing redirects', query, callback_deleteRedirects);
 			wikipedia_api.params = params;
@@ -155,9 +155,9 @@ var callback_commit = function(event) {
 			if (pageTitle && pageTitle.namespace % 2 === 0 && pageTitle.namespace !== 2) {
 				pageTitle.namespace++;  // now pageTitle is the talk page title!
 				query = {
-					'action': 'query',
-					'titles': pageTitle.toText(),
-					'format': 'json'
+					action: 'query',
+					titles: pageTitle.toText(),
+					format: 'json'
 				};
 				wikipedia_api = new Morebits.wiki.api('Checking whether ' + pageName + ' has a talk page', query,
 					callback_deleteTalk);

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -46,14 +46,14 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 		user = $(node).find('a').first().text();
 	}
 	var query = {
-		'prop': 'revisions',
-		'action': 'query',
-		'titles': mw.config.get('wgPageName'),
-		'rvlimit': 1,
-		'rvprop': [ 'ids', 'user' ],
-		'rvstartid': mw.config.get('wgCurRevisionId') - 1, // i.e. not the current one
-		'rvuser': user,
-		'format': 'json'
+		prop: 'revisions',
+		action: 'query',
+		titles: mw.config.get('wgPageName'),
+		rvlimit: 1,
+		rvprop: [ 'ids', 'user' ],
+		rvstartid: mw.config.get('wgCurRevisionId') - 1, // i.e. not the current one
+		rvuser: user,
+		format: 'json'
 	};
 	Morebits.status.init(document.getElementById('mw-content-text'));
 	var wikipedia_api = new Morebits.wiki.api('Grabbing data of initial contributor', query, Twinkle.diff.callbacks.main);

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -361,17 +361,17 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 	};
 
 	var query = {
-		'action': 'query',
-		'prop': ['info', 'revisions', 'flagged'],
-		'titles': pagename,
-		'inprop': 'watched',
-		'intestactions': 'edit',
-		'rvlimit': Twinkle.getPref('revertMaxRevisions'),
-		'rvprop': [ 'ids', 'timestamp', 'user' ],
-		'curtimestamp': '',
-		'meta': 'tokens',
-		'type': 'csrf',
-		'format': 'json'
+		action: 'query',
+		prop: ['info', 'revisions', 'flagged'],
+		titles: pagename,
+		inprop: 'watched',
+		intestactions: 'edit',
+		rvlimit: Twinkle.getPref('revertMaxRevisions'),
+		rvprop: [ 'ids', 'timestamp', 'user' ],
+		curtimestamp: '',
+		meta: 'tokens',
+		type: 'csrf',
+		format: 'json'
 	};
 	var wikipedia_api = new Morebits.wiki.api('Grabbing data of earlier revisions', query, Twinkle.fluff.callbacks.main);
 	wikipedia_api.params = params;
@@ -383,17 +383,17 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 	Morebits.status.init(document.getElementById('mw-content-text'));
 
 	var query = {
-		'action': 'query',
-		'prop': ['info', 'revisions'],
-		'titles': mw.config.get('wgPageName'),
-		'inprop': 'watched',
-		'rvlimit': 1,
-		'rvstartid': oldrev,
-		'rvprop': [ 'ids', 'user' ],
-		'curtimestamp': '',
-		'meta': 'tokens',
-		'type': 'csrf',
-		'format': 'json'
+		action: 'query',
+		prop: ['info', 'revisions'],
+		titles: mw.config.get('wgPageName'),
+		inprop: 'watched',
+		rvlimit: 1,
+		rvstartid: oldrev,
+		rvprop: [ 'ids', 'user' ],
+		curtimestamp: '',
+		meta: 'tokens',
+		type: 'csrf',
+		format: 'json'
 	};
 	var wikipedia_api = new Morebits.wiki.api('Grabbing data of the earlier revision', query, Twinkle.fluff.callbacks.toRevision);
 	wikipedia_api.params = { rev: oldrev };
@@ -435,17 +435,17 @@ Twinkle.fluff.callbacks = {
 			revertToUserHidden ? null : revertToUser, optional_summary);
 
 		var query = {
-			'action': 'edit',
-			'title': mw.config.get('wgPageName'),
-			'summary': summary,
-			'tags': Twinkle.changeTags,
-			'token': csrftoken,
-			'undo': lastrevid,
-			'undoafter': revertToRevID,
-			'basetimestamp': touched,
-			'starttimestamp': loadtimestamp,
-			'minor': Twinkle.getPref('markRevertedPagesAsMinor').indexOf('torev') !== -1 ? true : undefined,
-			'format': 'json'
+			action: 'edit',
+			title: mw.config.get('wgPageName'),
+			summary: summary,
+			tags: Twinkle.changeTags,
+			token: csrftoken,
+			undo: lastrevid,
+			undoafter: revertToRevID,
+			basetimestamp: touched,
+			starttimestamp: loadtimestamp,
+			minor: Twinkle.getPref('markRevertedPagesAsMinor').indexOf('torev') !== -1 ? true : undefined,
+			format: 'json'
 		};
 		// Handle watching, possible expiry
 		if (Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1) {
@@ -668,17 +668,17 @@ Twinkle.fluff.callbacks = {
 		}
 
 		var query = {
-			'action': 'edit',
-			'title': params.pagename,
-			'summary': summary,
-			'tags': Twinkle.changeTags,
-			'token': csrftoken,
-			'undo': lastrevid,
-			'undoafter': params.goodid,
-			'basetimestamp': touched,
-			'starttimestamp': loadtimestamp,
-			'minor': Twinkle.getPref('markRevertedPagesAsMinor').indexOf(params.type) !== -1 ? true : undefined,
-			'format': 'json'
+			action: 'edit',
+			title: params.pagename,
+			summary: summary,
+			tags: Twinkle.changeTags,
+			token: csrftoken,
+			undo: lastrevid,
+			undoafter: params.goodid,
+			basetimestamp: touched,
+			starttimestamp: loadtimestamp,
+			minor: Twinkle.getPref('markRevertedPagesAsMinor').indexOf(params.type) !== -1 ? true : undefined,
+			format: 'json'
 		};
 		// Handle watching, possible expiry
 		if (Twinkle.getPref('watchRevertedPages').indexOf(params.type) !== -1) {
@@ -724,15 +724,15 @@ Twinkle.fluff.callbacks = {
 				Morebits.status.info('Info', [ 'Opening user talk page edit form for user ', Morebits.htmlNode('strong', params.user) ]);
 
 				var windowQuery = {
-					'title': 'User talk:' + params.user,
-					'action': 'edit',
-					'preview': 'yes',
-					'vanarticle': params.pagename.replace(/_/g, ' '),
-					'vanarticlerevid': params.revid,
-					'vantimestamp': params.vantimestamp,
-					'vanarticlegoodrevid': params.goodid,
-					'type': params.type,
-					'count': params.count
+					title: 'User talk:' + params.user,
+					action: 'edit',
+					preview: 'yes',
+					vanarticle: params.pagename.replace(/_/g, ' '),
+					vanarticlerevid: params.revid,
+					vantimestamp: params.vantimestamp,
+					vanarticlegoodrevid: params.goodid,
+					type: params.type,
+					count: params.count
 				};
 
 				switch (Twinkle.getPref('userTalkPageMode')) {
@@ -757,10 +757,10 @@ Twinkle.fluff.callbacks = {
 			// review the revert, if needed
 			if (apiobj.params.reviewRevert) {
 				var query = {
-					'action': 'review',
-					'revid': edit.newrevid,
-					'token': apiobj.params.csrftoken,
-					'comment': 'Automatically reviewing reversion' + Twinkle.summaryAd // until the below
+					action: 'review',
+					revid: edit.newrevid,
+					token: apiobj.params.csrftoken,
+					comment: 'Automatically reviewing reversion' + Twinkle.summaryAd // until the below
 					// 'tags': Twinkle.changeTags // flaggedrevs tag support: [[phab:T247721]]
 				};
 				var wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -194,11 +194,11 @@ Twinkle.prod.callbacks = {
 			'Template:Olddelrev|' + // Prior DRV template
 			'Template:Old prod';
 		var query = {
-			'action': 'query',
-			'titles': talk_title,
-			'prop': 'templates',
-			'tltemplates': blocking_templates,
-			'format': 'json'
+			action: 'query',
+			titles: talk_title,
+			prop: 'templates',
+			tltemplates: blocking_templates,
+			format: 'json'
 		};
 
 		var wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1066,71 +1066,71 @@ Twinkle.speedy.redirectList = [
 ];
 
 Twinkle.speedy.normalizeHash = {
-	'reason': 'db',
-	'nonsense': 'g1',
-	'test': 'g2',
-	'vandalism': 'g3',
-	'hoax': 'g3',
-	'repost': 'g4',
-	'banned': 'g5',
-	'move': 'g6',
-	'xfd': 'g6',
-	'movedab': 'g6',
-	'copypaste': 'g6',
-	'g6': 'g6',
-	'author': 'g7',
-	'g8': 'g8',
-	'talk': 'g8',
-	'subpage': 'g8',
-	'redirnone': 'g8',
-	'templatecat': 'g8',
-	'imagepage': 'g8',
-	'attack': 'g10',
-	'negublp': 'g10',
-	'spam': 'g11',
-	'spamuser': 'g11',
-	'copyvio': 'g12',
-	'afc': 'g13',
-	'disambig': 'g14',
-	'nocontext': 'a1',
-	'foreign': 'a2',
-	'nocontent': 'a3',
-	'transwiki': 'a5',
-	'a7': 'a7',
-	'person': 'a7',
-	'corp': 'a7',
-	'web': 'a7',
-	'band': 'a7',
-	'club': 'a7',
-	'animal': 'a7',
-	'event': 'a7',
-	'a9': 'a9',
-	'a10': 'a10',
-	'madeup': 'a11',
-	'rediruser': 'r2',
-	'redirtypo': 'r3',
-	'redircom': 'r4',
-	'redundantimage': 'f1',
-	'noimage': 'f2',
-	'fpcfail': 'f2',
-	'noncom': 'f3',
-	'unksource': 'f4',
-	'unfree': 'f5',
-	'f5': 'f5',
-	'norat': 'f6',
-	'badfairuse': 'f7',
-	'commons': 'f8',
-	'imgcopyvio': 'f9',
-	'badfiletype': 'f10',
-	'nopermission': 'f11',
-	'catempty': 'c1',
-	'userreq': 'u1',
-	'nouser': 'u2',
-	'gallery': 'u3',
-	'notwebhost': 'u5',
-	'duplicatetemplate': 't3',
-	'p1': 'p1',
-	'emptyportal': 'p2'
+	reason: 'db',
+	nonsense: 'g1',
+	test: 'g2',
+	vandalism: 'g3',
+	hoax: 'g3',
+	repost: 'g4',
+	banned: 'g5',
+	move: 'g6',
+	xfd: 'g6',
+	movedab: 'g6',
+	copypaste: 'g6',
+	g6: 'g6',
+	author: 'g7',
+	g8: 'g8',
+	talk: 'g8',
+	subpage: 'g8',
+	redirnone: 'g8',
+	templatecat: 'g8',
+	imagepage: 'g8',
+	attack: 'g10',
+	negublp: 'g10',
+	spam: 'g11',
+	spamuser: 'g11',
+	copyvio: 'g12',
+	afc: 'g13',
+	disambig: 'g14',
+	nocontext: 'a1',
+	foreign: 'a2',
+	nocontent: 'a3',
+	transwiki: 'a5',
+	a7: 'a7',
+	person: 'a7',
+	corp: 'a7',
+	web: 'a7',
+	band: 'a7',
+	club: 'a7',
+	animal: 'a7',
+	event: 'a7',
+	a9: 'a9',
+	a10: 'a10',
+	madeup: 'a11',
+	rediruser: 'r2',
+	redirtypo: 'r3',
+	redircom: 'r4',
+	redundantimage: 'f1',
+	noimage: 'f2',
+	fpcfail: 'f2',
+	noncom: 'f3',
+	unksource: 'f4',
+	unfree: 'f5',
+	f5: 'f5',
+	norat: 'f6',
+	badfairuse: 'f7',
+	commons: 'f8',
+	imgcopyvio: 'f9',
+	badfiletype: 'f10',
+	nopermission: 'f11',
+	catempty: 'c1',
+	userreq: 'u1',
+	nouser: 'u2',
+	gallery: 'u3',
+	notwebhost: 'u5',
+	duplicatetemplate: 't3',
+	p1: 'p1',
+	emptyportal: 'p2'
 };
 
 Twinkle.speedy.callbacks = {
@@ -1348,11 +1348,11 @@ Twinkle.speedy.callbacks = {
 			// delete redirects
 			if (params.deleteRedirects) {
 				var query = {
-					'action': 'query',
-					'titles': mw.config.get('wgPageName'),
-					'prop': 'redirects',
-					'rdlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-					'format': 'json'
+					action: 'query',
+					titles: mw.config.get('wgPageName'),
+					prop: 'redirects',
+					rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+					format: 'json'
 				};
 				var wikipedia_api = new Morebits.wiki.api('getting list of redirects...', query, Twinkle.speedy.callbacks.sysop.deleteRedirectsMain,
 					new Morebits.status('Deleting redirects'));
@@ -1364,34 +1364,34 @@ Twinkle.speedy.callbacks = {
 			var $link, $bigtext;
 			if (mw.config.get('wgNamespaceNumber') === 6 && params.normalized !== 'f8') {
 				$link = $('<a/>', {
-					'href': '#',
-					'text': 'click here to go to the Unlink tool',
-					'css': { 'fontSize': '130%', 'fontWeight': 'bold' },
-					'click': function() {
+					href: '#',
+					text: 'click here to go to the Unlink tool',
+					css: { fontSize: '130%', fontWeight: 'bold' },
+					click: function() {
 						Morebits.wiki.actionCompleted.redirect = null;
 						Twinkle.speedy.dialog.close();
 						Twinkle.unlink.callback('Removing usages of and/or links to deleted file ' + Morebits.pageNameNorm);
 					}
 				});
 				$bigtext = $('<span/>', {
-					'text': 'To orphan backlinks and remove instances of file usage',
-					'css': { 'fontSize': '130%', 'fontWeight': 'bold' }
+					text: 'To orphan backlinks and remove instances of file usage',
+					css: { fontSize: '130%', fontWeight: 'bold' }
 				});
 				Morebits.status.info($bigtext[0], $link[0]);
 			} else if (params.normalized !== 'f8') {
 				$link = $('<a/>', {
-					'href': '#',
-					'text': 'click here to go to the Unlink tool',
-					'css': { 'fontSize': '130%', 'fontWeight': 'bold' },
-					'click': function() {
+					href: '#',
+					text: 'click here to go to the Unlink tool',
+					css: { fontSize: '130%', fontWeight: 'bold' },
+					click: function() {
 						Morebits.wiki.actionCompleted.redirect = null;
 						Twinkle.speedy.dialog.close();
 						Twinkle.unlink.callback('Removing links to deleted page ' + Morebits.pageNameNorm);
 					}
 				});
 				$bigtext = $('<span/>', {
-					'text': 'To orphan backlinks',
-					'css': { 'fontSize': '130%', 'fontWeight': 'bold' }
+					text: 'To orphan backlinks',
+					css: { fontSize: '130%', fontWeight: 'bold' }
 				});
 				Morebits.status.info($bigtext[0], $link[0]);
 			}

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1329,9 +1329,9 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 					// most likely because it's a cross-namespace redirect
 					// Supersedes the typical $autolevelMessage added in autolevelParseWikitext
 					var $noTalkPageNode = $('<strong/>', {
-						'text': 'Unable to load user talk page; it might be a cross-namespace redirect.  Autolevel detection will not work.',
-						'id': 'twinkle-warn-autolevel-message',
-						'css': {'color': 'red' }
+						text: 'Unable to load user talk page; it might be a cross-namespace redirect.  Autolevel detection will not work.',
+						id: 'twinkle-warn-autolevel-message',
+						css: {color: 'red' }
 					});
 					$noTalkPageNode.insertBefore($('#twinkle-warn-warning-messages'));
 					// If a preview was opened while in a different mode, close it
@@ -1581,7 +1581,7 @@ Twinkle.warn.callbacks = {
 			}
 		}
 
-		var $autolevelMessage = $('<div/>', {'id': 'twinkle-warn-autolevel-message'});
+		var $autolevelMessage = $('<div/>', {id: 'twinkle-warn-autolevel-message'});
 
 		if (isNaN(level)) { // No prior warnings found, this is the first
 			level = 1;
@@ -1603,10 +1603,10 @@ Twinkle.warn.callbacks = {
 					// and thus whether we can continue or need to display the warning and link
 					if (!statelem) {
 						var $link = $('<a/>', {
-							'href': '#',
-							'text': 'click here to open the ARV tool.',
-							'css': { 'fontWeight': 'bold' },
-							'click': function() {
+							href: '#',
+							text: 'click here to open the ARV tool.',
+							css: { fontWeight: 'bold' },
+							click: function() {
 								Morebits.wiki.actionCompleted.redirect = null;
 								Twinkle.warn.dialog.close();
 								Twinkle.arv.callback(mw.config.get('wgRelevantUserName'));
@@ -1615,8 +1615,8 @@ Twinkle.warn.callbacks = {
 							}
 						});
 						var statusNode = $('<div/>', {
-							'text': mw.config.get('wgRelevantUserName') + ' recently received a level 4 warning (' + latest.type + ') so it might be better to report them instead; ',
-							'css': {'color': 'red' }
+							text: mw.config.get('wgRelevantUserName') + ' recently received a level 4 warning (' + latest.type + ') so it might be better to report them instead; ',
+							css: {color: 'red' }
 						});
 						statusNode.append($link[0]);
 						$autolevelMessage.append(statusNode);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1817,9 +1817,9 @@ Twinkle.xfd.callbacks = {
 			// Used by regular redirects to find the target, but for all redirects,
 			// avoid relying on the client clock to build the log page
 			var query = {
-				'action': 'query',
-				'curtimestamp': true,
-				'format': 'json'
+				action: 'query',
+				curtimestamp: true,
+				format: 'json'
 			};
 			if (document.getElementById('softredirect')) {
 				// For soft redirects, define the target early
@@ -2028,13 +2028,13 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 		case 'afd': // AFD
 			query = {
-				'action': 'query',
-				'list': 'allpages',
-				'apprefix': 'Articles for deletion/' + Morebits.pageNameNorm,
-				'apnamespace': 4,
-				'apfilterredir': 'nonredirects',
-				'aplimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				list: 'allpages',
+				apprefix: 'Articles for deletion/' + Morebits.pageNameNorm,
+				apnamespace: 4,
+				apfilterredir: 'nonredirects',
+				aplimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			};
 			wikipedia_api = new Morebits.wiki.api('Tagging article with deletion tag', query, Twinkle.xfd.callbacks.afd.main);
 			wikipedia_api.params = params;
@@ -2071,13 +2071,13 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 		case 'mfd': // MFD
 			query = {
-				'action': 'query',
-				'list': 'allpages',
-				'apprefix': 'Miscellany for deletion/' + Morebits.pageNameNorm,
-				'apnamespace': 4,
-				'apfilterredir': 'nonredirects',
-				'aplimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-				'format': 'json'
+				action: 'query',
+				list: 'allpages',
+				apprefix: 'Miscellany for deletion/' + Morebits.pageNameNorm,
+				apnamespace: 4,
+				apfilterredir: 'nonredirects',
+				aplimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+				format: 'json'
 			};
 			wikipedia_api = new Morebits.wiki.api('Looking for prior nominations of this page', query, Twinkle.xfd.callbacks.mfd.main);
 			wikipedia_api.params = params;
@@ -2107,13 +2107,13 @@ Twinkle.xfd.callback.evaluate = function(e) {
 
 			// Used for customized actions in edit summaries and the notification template
 			var summaryActions = {
-				cfd: 'deletion',
+				'cfd': 'deletion',
 				'sfd-t': 'deletion',
-				cfm: 'merging',
-				cfr: 'renaming',
+				'cfm': 'merging',
+				'cfr': 'renaming',
 				'sfr-t': 'renaming',
-				cfs: 'splitting',
-				cfc: 'conversion'
+				'cfs': 'splitting',
+				'cfc': 'conversion'
 			};
 			params.action = summaryActions[params.xfdcat];
 

--- a/morebits.js
+++ b/morebits.js
@@ -1769,14 +1769,14 @@ Morebits.date.prototype = {
 		var D = udate.getDate(), M = udate.getMonth() + 1, Y = udate.getFullYear();
 		var h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? 'PM' : 'AM';
 		var replacementMap = {
-			'HH': pad(h24), 'H': h24, 'hh': pad(h12), 'h': h12, 'A': amOrPm,
-			'mm': pad(m), 'm': m,
-			'ss': pad(s), 's': s,
-			'SSS': pad(ms, 3),
-			'dddd': udate.getDayName(), 'ddd': udate.getDayNameAbbrev(), 'd': udate.getDay(),
-			'DD': pad(D), 'D': D,
-			'MMMM': udate.getMonthName(), 'MMM': udate.getMonthNameAbbrev(), 'MM': pad(M), 'M': M,
-			'YYYY': Y, 'YY': pad(Y % 100), 'Y': Y
+			HH: pad(h24), H: h24, hh: pad(h12), h: h12, A: amOrPm,
+			mm: pad(m), m: m,
+			ss: pad(s), s: s,
+			SSS: pad(ms, 3),
+			dddd: udate.getDayName(), ddd: udate.getDayNameAbbrev(), d: udate.getDay(),
+			DD: pad(D), D: D,
+			MMMM: udate.getMonthName(), MMM: udate.getMonthNameAbbrev(), MM: pad(M), M: M,
+			YYYY: Y, YY: pad(Y % 100), Y: Y
 		};
 
 		var unbinder = new Morebits.unbinder(formatstr); // escape stuff between [...]
@@ -3066,13 +3066,13 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.onLookupCreationSuccess = onSuccess;
 
 		var query = {
-			'action': 'query',
-			'prop': 'revisions',
-			'titles': ctx.pageName,
-			'rvlimit': 1,
-			'rvprop': 'user|timestamp',
-			'rvdir': 'newer',
-			'format': 'json'
+			action: 'query',
+			prop: 'revisions',
+			titles: ctx.pageName,
+			rvlimit: 1,
+			rvprop: 'user|timestamp',
+			rvdir: 'newer',
+			format: 'json'
 		};
 
 		// Only the wikitext content model can reliably handle
@@ -3830,13 +3830,13 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		var query = {
-			'action': 'move',
-			'from': pageTitle,
-			'to': ctx.moveDestination,
-			'token': token,
-			'reason': ctx.editSummary,
-			'watchlist': ctx.watchlistOption,
-			'format': 'json'
+			action: 'move',
+			from: pageTitle,
+			to: ctx.moveDestination,
+			token: token,
+			reason: ctx.editSummary,
+			watchlist: ctx.watchlistOption,
+			format: 'json'
 		};
 		if (ctx.changeTags) {
 			query.tags = ctx.changeTags;
@@ -3975,12 +3975,12 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		var query = {
-			'action': 'delete',
-			'title': pageTitle,
-			'token': token,
-			'reason': ctx.editSummary,
-			'watchlist': ctx.watchlistOption,
-			'format': 'json'
+			action: 'delete',
+			title: pageTitle,
+			token: token,
+			reason: ctx.editSummary,
+			watchlist: ctx.watchlistOption,
+			format: 'json'
 		};
 		if (ctx.changeTags) {
 			query.tags = ctx.changeTags;
@@ -4038,12 +4038,12 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		var query = {
-			'action': 'undelete',
-			'title': pageTitle,
-			'token': token,
-			'reason': ctx.editSummary,
-			'watchlist': ctx.watchlistOption,
-			'format': 'json'
+			action: 'undelete',
+			title: pageTitle,
+			token: token,
+			reason: ctx.editSummary,
+			watchlist: ctx.watchlistOption,
+			format: 'json'
 		};
 		if (ctx.changeTags) {
 			query.tags = ctx.changeTags;


### PR DESCRIPTION
Not done in #500 given the cosmetic nature and fairly mixed status of the project, but I've run into it a few times lately and have been mildly annoyed.  Adding `"keywords": true` seems reasonable, but it's not that common and I don't think in the end we really care.  Likewise with `numbers`.

https://eslint.org/docs/rules/quote-props

Separate commit for the actual application is just to make my life easier during the eventual rebasing.