### PR TITLE
tag: Italicize tags already present in form

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -532,7 +532,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 				{
 					value: tag,
 					label: '{{' + tag + '}}' + (description ? ': ' + description : ''),
-					checked: unCheckedTags.indexOf(tag) === -1
+					checked: unCheckedTags.indexOf(tag) === -1,
+					style: 'font-style: italic'
 				};
 
 			checkboxes.push(checkbox);


### PR DESCRIPTION
Put here for opinions: the quickfilter makes it possible to lose context, but I'm not sure this actually a good idea or if it's just visual clutter.