### PR TITLE
morebits: Preserve link coloring in previewbox

### DIFF
--- a/morebits.css
+++ b/morebits.css
@@ -294,7 +294,8 @@ body .ui-dialog.morebits-dialog .morebits-dialog-footerlinks a {
 	margin: .1em .4em -.2em 0;
 }
 
-.ui-dialog.morebits-dialog a, .ui-dialog.morebits-dialog .ui-widget-content a {
+/* Don't override rendered classes in preview boxes */
+.ui-dialog.morebits-dialog .ui-widget-content a :not(.morebits-previewbox) {
 	color: #0645AD;  /* jQuery imposes a ridiculous nearly-black colour on <a> tags... I don't understand it */
 }
 


### PR DESCRIPTION
Makes use of `:not()` to skip link coloring in `.preview-box`.  It looks like `.ui-dialog.morebits-dialog a` only had the `titlebar-close` elements, which don't need the coloring style, so we can remove that.