### PR TITLE
morebits: Don't overwrite link color CSS

### DIFF
--- a/morebits.css
+++ b/morebits.css
@@ -294,10 +294,6 @@ body .ui-dialog.morebits-dialog .morebits-dialog-footerlinks a {
 	margin: .1em .4em -.2em 0;
 }
 
-.ui-dialog.morebits-dialog a, .ui-dialog.morebits-dialog .ui-widget-content a {
-	color: #0645AD;  /* jQuery imposes a ridiculous nearly-black colour on <a> tags... I don't understand it */
-}
-
 .ui-icon {
 	vertical-align: -3px;
 }


### PR DESCRIPTION
This has its roots at [WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=947164475#Red_links), which was concerned with not seeing redlinks in the preview box (see #900 and #901).  That was because `morebits.css` was applying a `color` to `.ui-dialog.morebits-dialog a, .ui-dialog.morebits-dialog .ui-widget-content a`.  This obscured any link characteristics in the preview, including some such as `:visited` that #901 would have enabled, but this goes deeper, and indeed we do not even need to specify this CSS anymore.

Initially put in place with the CSS "extraction" in 511bd8f, the "ridiculous nearly-black colour" from jQuery was/were #362b36 and #222222, the default from jquery-ui (`.ui-widget-content`), but that was removed in 2015: see https://phabricator.wikimedia.org/T85857 and https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/189141.  Indeed, every skin on enWiki currently has at least some `color` specified for `a`:

* Vector: `#0645ad`, see https://gerrit.wikimedia.org/g/mediawiki/skins/Vector/+/b9dc654a4f25ea6d3e56ffc24099769616ddeb9e/variables.less#41 and https://gerrit.wikimedia.org/g/mediawiki/core/+/7c4a3f8aae57066236b83ec21dc0ef2f5f2c4ead/resources/src/mediawiki.skinning/elements.css#12
* Minerva: `#3366cc`, see https://gerrit.wikimedia.org/g/mediawiki/core/+/7c4a3f8aae57066236b83ec21dc0ef2f5f2c4ead/resources/src/mediawiki.less/mediawiki.ui/variables.less#41 via https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/skins/MinervaNeue/+/master/minerva.less/minerva.variables.less#95.  Some links (namely the preview that #901 likewise ignored) fall under `not:[href]` so end up with `#222222`
* Modern: `#003366`, see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/skins/Modern/+/master/resources/main.css#319
* Monobook: `#002bb8`, see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/skins/MonoBook/+/master/resources/variables.less#13, although in actuality it should use the Vector file
* Timeless: `#3366CC`, see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/skins/Timeless/+/master/resources/themes/wikimedia.less#19
* Cologne Blue: `#223366`, see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/skins/CologneBlue/+/master/resources/screen.css#182