### PR TITLE
morebits: Some tweaks to Morebits.date

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1363,7 +1363,7 @@ Morebits.date.localeData = {
 		nextDay: '[Tomorrow at] h:mm A',
 		thisWeek: 'dddd [at] h:mm A',
 		pastWeek: '[Last] dddd [at] h:mm A',
-		other: 'DD/MM/YYYY'
+		other: 'YYYY-MM-DD'
 	}
 };
 
@@ -1425,6 +1425,7 @@ $.extend(Morebits.date.prototype, {
 	add: function(number, unit) {
 		// mapping time units with getter/setter function names
 		var unitMap = {
+			seconds: 'Seconds',
 			minutes: 'Minutes',
 			hours: 'Hours',
 			days: 'Date',


### PR DESCRIPTION
As promised at https://github.com/azatoth/twinkle/pull/814#event-3176003347, opened for discussion.  Commit are separate for review, and ordered from what I consider most to least worthwhile:

1st commit: Use YYYY-MM-DD for Morebits.date in calendar localeData

`moment` on enWiki returns `DD/MM/YYYY` but that's just a locale specification I believe.  Given the US-centric-but-not-exclusive enWiki population, both `DD/MM` and `MM/DD` can lead to confusion (the MOS, for example, suggests avoiding these uses).  Doing `YYYY-MM-DD` should avoid any such confusion.

2nd commit: Allow adding/subtracting seconds

<s>3rd commit: Add `isSame` to Morebits.date to compliment `isAfter` and `isBefore`</s>