### PR TITLE
morebits: Morebits.quickForm.getInputData

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -36,7 +36,7 @@ Twinkle.shared.callback = function friendlysharedCallback() {
 	}
 	);
 	div.append({ type: 'header', label: 'Shared IP address templates' });
-	div.append({ type: 'radio', name: 'shared', list: Twinkle.shared.standardList,
+	div.append({ type: 'radio', name: 'template', list: Twinkle.shared.standardList,
 		event: function(e) {
 			Twinkle.shared.callback.change_shared(e);
 			e.stopPropagation();
@@ -131,7 +131,6 @@ Twinkle.shared.callbacks = {
 		var params = pageobj.getCallbackParameters();
 		var pageText = pageobj.getPageText();
 		var found = false;
-		var text = '{{';
 
 		for (var i = 0; i < Twinkle.shared.standardList.length; i++) {
 			var tagRe = new RegExp('(\\{\\{' + Twinkle.shared.standardList[i].value + '(\\||\\}\\}))', 'im');
@@ -146,16 +145,16 @@ Twinkle.shared.callbacks = {
 		}
 
 		Morebits.status.info('Info', 'Will add the shared IP address template to the top of the user\'s talk page.');
-		text += params.value + '|' + params.organization;
-		if (params.value === 'Shared IP edu' && params.contact !== '') {
+		var text = '{{' + params.template + '|' + params.organization;
+		if (params.contact) {
 			text += '|' + params.contact;
 		}
-		if (params.value !== 'Whois' && params.host !== '') {
+		if (params.host) {
 			text += '|host=' + params.host;
 		}
 		text += '}}\n\n';
 
-		var summaryText = 'Added {{[[Template:' + params.value + '|' + params.value + ']]}} template.';
+		var summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
 		pageobj.setPageText(text + pageText);
 		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
 		pageobj.setMinorEdit(Twinkle.getPref('markSharedIPAsMinor'));
@@ -165,25 +164,15 @@ Twinkle.shared.callbacks = {
 };
 
 Twinkle.shared.callback.evaluate = function friendlysharedCallbackEvaluate(e) {
-	var shared = e.target.getChecked('shared');
-	if (!shared || shared.length <= 0) {
+	var params = Morebits.quickForm.getInputData(e.target);
+	if (!params.template) {
 		alert('You must select a shared IP address template to use!');
 		return;
 	}
-
-	var value = shared[0];
-
-	if (e.target.organization.value === '') {
-		alert('You must input an organization for the {{' + value + '}} template!');
+	if (!params.organization) {
+		alert('You must input an organization for the {{' + params.template + '}} template!');
 		return;
 	}
-
-	var params = {
-		value: value,
-		organization: e.target.organization.value,
-		host: e.target.host.value,
-		contact: e.target.contact.value
-	};
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(e.target);

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -145,23 +145,23 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			Window.setTitle('File maintenance tagging');
 
 			form.append({ type: 'header', label: 'License and sourcing problem tags' });
-			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.licenseList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.file.licenseList });
 
 			form.append({ type: 'header', label: 'Wikimedia Commons-related tags' });
-			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.commonsList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.file.commonsList });
 
 			form.append({ type: 'header', label: 'Cleanup tags' });
-			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.cleanupList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.file.cleanupList });
 
 			form.append({ type: 'header', label: 'Image quality tags' });
-			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.qualityList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.file.qualityList });
 
 			form.append({ type: 'header', label: 'Replacement tags' });
-			form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.tag.file.replacementList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.file.replacementList });
 
 			if (Twinkle.getPref('customFileTagList').length) {
 				form.append({ type: 'header', label: 'Custom tags' });
-				form.append({ type: 'checkbox', name: 'fileTags', list: Twinkle.getPref('customFileTagList') });
+				form.append({ type: 'checkbox', name: 'tags', list: Twinkle.getPref('customFileTagList') });
 			}
 			break;
 
@@ -169,17 +169,17 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			Window.setTitle('Redirect tagging');
 
 			form.append({ type: 'header', label: 'Spelling, misspelling, tense and capitalization templates' });
-			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.spellingList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.spellingList });
 
 			form.append({ type: 'header', label: 'Alternative name templates' });
-			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.alternativeList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.alternativeList });
 
 			form.append({ type: 'header', label: 'Miscellaneous and administrative redirect templates' });
-			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.administrativeList });
+			form.append({ type: 'checkbox', name: 'tags', list: Twinkle.tag.administrativeList });
 
 			if (Twinkle.getPref('customRedirectTagList').length) {
 				form.append({ type: 'header', label: 'Custom tags' });
-				form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.getPref('customRedirectTagList') });
+				form.append({ type: 'checkbox', name: 'tags', list: Twinkle.getPref('customRedirectTagList') });
 			}
 			break;
 
@@ -194,8 +194,8 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			list: [
 				{
 					label: 'Mark the page as patrolled/reviewed',
-					value: 'patrolPage',
-					name: 'patrolPage',
+					value: 'patrol',
+					name: 'patrol',
 					checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
 				}
 			]
@@ -283,7 +283,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 	} else {
 		// Redirects and files: Add a link to each template's description page
-		Morebits.quickForm.getElements(result, Twinkle.tag.mode + 'Tags').forEach(generateLinks);
+		Morebits.quickForm.getElements(result, 'tags').forEach(generateLinks);
 	}
 };
 
@@ -295,7 +295,7 @@ var $allCheckboxDivs, $allHeaders;
 Twinkle.tag.updateSortOrder = function(e) {
 	var form = e.target.form;
 	var sortorder = e.target.value;
-	Twinkle.tag.checkedTags = form.getChecked('articleTags');
+	Twinkle.tag.checkedTags = form.getChecked('tags');
 
 	var container = new Morebits.quickForm.element({ type: 'fragment' });
 
@@ -525,7 +525,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		container.append({ type: 'header', id: 'tagHeader0', label: 'Tags already present' });
 		var subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
 		var checkboxes = [];
-		var unCheckedTags = e.target.form.getUnchecked('alreadyPresentArticleTags');
+		var unCheckedTags = e.target.form.getUnchecked('existingTags');
 		Twinkle.tag.alreadyPresentTags.forEach(function(tag) {
 			var description = Twinkle.tag.article.tags[tag];
 			var checkbox =
@@ -540,7 +540,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		});
 		subdiv.append({
 			type: 'checkbox',
-			name: 'alreadyPresentArticleTags',
+			name: 'existingTags',
 			list: checkboxes
 		});
 	};
@@ -557,7 +557,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 			});
 			subdiv.append({
 				type: 'checkbox',
-				name: 'articleTags',
+				name: 'tags',
 				list: checkboxes
 			});
 		};
@@ -592,7 +592,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		});
 		container.append({
 			type: 'checkbox',
-			name: 'articleTags',
+			name: 'tags',
 			list: checkboxes
 		});
 	}
@@ -600,7 +600,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	// append any custom tags
 	if (Twinkle.getPref('customTagList').length) {
 		container.append({ type: 'header', label: 'Custom tags' });
-		container.append({ type: 'checkbox', name: 'articleTags',
+		container.append({ type: 'checkbox', name: 'tags',
 			list: Twinkle.getPref('customTagList').map(function(el) {
 				el.checked = Twinkle.tag.checkedTags.indexOf(el.value) !== -1;
 				return el;
@@ -613,7 +613,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	$workarea.empty().append(rendered);
 
 	// for quick filter:
-	$allCheckboxDivs = $workarea.find('[name$=Tags]').parent();
+	$allCheckboxDivs = $workarea.find('[name=tags], [name=existingTags]').parent();
 	$allHeaders = $workarea.find('h5, .quickformDescription');
 	form.quickfilter.value = ''; // clear search, because the search results are not preserved over mode change
 	form.quickfilter.focus();
@@ -623,15 +623,15 @@ Twinkle.tag.updateSortOrder = function(e) {
 	$workarea.find('h5:not(:first-child)').css({ 'margin-top': '1em' });
 	$workarea.find('div').filter(':has(span.quickformDescription)').css({ 'margin-top': '0.4em' });
 
-	Morebits.quickForm.getElements(form, 'alreadyPresentArticleTags').forEach(generateLinks);
-	Morebits.quickForm.getElements(form, 'articleTags').forEach(generateLinks);
+	Morebits.quickForm.getElements(form, 'existingTags').forEach(generateLinks);
+	Morebits.quickForm.getElements(form, 'tags').forEach(generateLinks);
 
 	// tally tags added/removed, update statusNode text
 	var statusNode = document.getElementById('tw-tag-status');
-	$('[name=articleTags], [name=alreadyPresentArticleTags]').click(function() {
-		if (this.name === 'articleTags') {
+	$('[name=tags], [name=existingTags]').click(function() {
+		if (this.name === 'tags') {
 			Twinkle.tag.status.numAdded += this.checked ? 1 : -1;
-		} else if (this.name === 'alreadyPresentArticleTags') {
+		} else if (this.name === 'existingTags') {
 			Twinkle.tag.status.numRemoved += this.checked ? -1 : 1;
 		}
 
@@ -1958,32 +1958,12 @@ Twinkle.tag.callbacks = {
 
 Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 	var form = e.target;
-	var params = {};
-	if (form.patrolPage) {
-		params.patrol = form.patrolPage.checked;
-	}
-
-	// Don't return null if there aren't any available tags
-	params.tags = form.getChecked(Twinkle.tag.mode + 'Tags');
-
-	// Save values of input fields into params object. This works as quickform input
-	// fields within subgroups of elements with name 'articleTags' (say) have their
-	// name attribute as 'articleTags.' + name of the subgroup element
-
-	var name_prefix = Twinkle.tag.mode + 'Tags.';
-	$(form).find("[name^='" + name_prefix + "']:not(div)").each(function(idx, el) {
-		// el are the HTMLInputElements, el.name gives the name attribute
-		params[el.name.slice(name_prefix.length)] =
-			el.type === 'checkbox' ? form[el.name].checked : form[el.name].value;
-	});
+	var params = Morebits.quickForm.getInputData(form);
 
 	switch (Twinkle.tag.mode) {
 		case 'article':
-			params.tagsToRemove = form.getUnchecked('alreadyPresentArticleTags');
-			params.tagsToRemain = form.getChecked('alreadyPresentArticleTags');
-			params.reason = form.reason.value.trim();
-
-			params.group = form.group.checked;
+			params.tagsToRemove = form.getUnchecked('existingTags'); // not in `input`
+			params.tagsToRemain = params.existingTags;
 
 			// Validation
 			if ((params.tags.indexOf('Merge') !== -1) || (params.tags.indexOf('Merge from') !== -1) ||

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -295,7 +295,7 @@ var $allCheckboxDivs, $allHeaders;
 Twinkle.tag.updateSortOrder = function(e) {
 	var form = e.target.form;
 	var sortorder = e.target.value;
-	Twinkle.tag.checkedTags = form.getChecked('articleTags') || [];
+	Twinkle.tag.checkedTags = form.getChecked('articleTags');
 
 	var container = new Morebits.quickForm.element({ type: 'fragment' });
 
@@ -525,7 +525,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		container.append({ type: 'header', id: 'tagHeader0', label: 'Tags already present' });
 		var subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
 		var checkboxes = [];
-		var unCheckedTags = e.target.form.getUnchecked('alreadyPresentArticleTags') || [];
+		var unCheckedTags = e.target.form.getUnchecked('alreadyPresentArticleTags');
 		Twinkle.tag.alreadyPresentTags.forEach(function(tag) {
 			var description = Twinkle.tag.article.tags[tag];
 			var checkbox =
@@ -623,15 +623,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 	$workarea.find('h5:not(:first-child)').css({ 'margin-top': '1em' });
 	$workarea.find('div').filter(':has(span.quickformDescription)').css({ 'margin-top': '0.4em' });
 
-	var alreadyPresentTags = Morebits.quickForm.getElements(form, 'alreadyPresentArticleTags');
-	if (alreadyPresentTags) {
-		alreadyPresentTags.forEach(generateLinks);
-	}
-	// in the unlikely case that *every* tag is already on the page
-	var notPresentTags = Morebits.quickForm.getElements(form, 'articleTags');
-	if (notPresentTags) {
-		notPresentTags.forEach(generateLinks);
-	}
+	Morebits.quickForm.getElements(form, 'alreadyPresentArticleTags').forEach(generateLinks);
+	Morebits.quickForm.getElements(form, 'articleTags').forEach(generateLinks);
 
 	// tally tags added/removed, update statusNode text
 	var statusNode = document.getElementById('tw-tag-status');
@@ -1971,7 +1964,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 	}
 
 	// Don't return null if there aren't any available tags
-	params.tags = form.getChecked(Twinkle.tag.mode + 'Tags') || [];
+	params.tags = form.getChecked(Twinkle.tag.mode + 'Tags');
 
 	// Save values of input fields into params object. This works as quickform input
 	// fields within subgroups of elements with name 'articleTags' (say) have their
@@ -1986,8 +1979,8 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 
 	switch (Twinkle.tag.mode) {
 		case 'article':
-			params.tagsToRemove = form.getUnchecked('alreadyPresentArticleTags') || [];
-			params.tagsToRemain = form.getChecked('alreadyPresentArticleTags') || [];
+			params.tagsToRemove = form.getUnchecked('alreadyPresentArticleTags');
+			params.tagsToRemain = form.getChecked('alreadyPresentArticleTags');
 			params.reason = form.reason.value.trim();
 
 			params.group = form.group.checked;

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -599,7 +599,8 @@ Twinkle.welcome.callbacks = {
 		previewDialog.setContent(previewdiv);
 
 		var previewer = new Morebits.wiki.preview(previewdiv);
-		previewer.beginRender(Twinkle.welcome.getTemplateWikitext(form.type.value, form.getChecked('template'), form.article.value), 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
+		var input = Morebits.quickForm.getInputData(form);
+		previewer.beginRender(Twinkle.welcome.getTemplateWikitext(input.type, input.template, input.article), 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
 
 		var submit = document.createElement('input');
 		submit.setAttribute('type', 'submit');
@@ -623,7 +624,7 @@ Twinkle.welcome.callbacks = {
 			return;
 		}
 
-		var welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.value, params.article);
+		var welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
 
 		if (Twinkle.getPref('topWelcomes')) {
 			text = welcomeText + '\n\n' + text;
@@ -643,12 +644,8 @@ Twinkle.welcome.callbacks = {
 Twinkle.welcome.callback.evaluate = function friendlywelcomeCallbackEvaluate(e) {
 	var form = e.target;
 
-	var params = {
-		type: form.type.value,
-		value: form.getChecked('template'),
-		article: form.article.value,
-		mode: 'manual'
-	};
+	var params = Morebits.quickForm.getInputData(form); // : type, template, article
+	params.mode = 'manual';
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -445,82 +445,66 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		return;
 	}
 
-	var pages = form.getChecked('pages');
-	var subpages = form.getChecked('pages.subpages');
-	var reason = form.reason.value;
-	var delete_page = form.delete_page.checked;
-	var delete_talk, delete_redirects, delete_subpages;
-	var delete_subpage_redirects, delete_subpage_talks, unlink_subpages;
-	if (delete_page) {
-		delete_talk = form.delete_talk.checked;
-		delete_redirects = form.delete_redirects.checked;
-		delete_subpages = form.delete_subpages.checked;
-		if (delete_subpages) {
-			delete_subpage_redirects = form.delete_subpage_redirects.checked;
-			delete_subpage_talks = form.delete_subpage_talks.checked;
-			unlink_subpages = form.unlink_subpages.checked;
-		}
-	}
-	var unlink_page = form.unlink_page.checked;
-	var unlink_file = form.unlink_file.checked;
-	if (!reason) {
+	var input = Morebits.quickForm.getInputData(form);
+
+	if (!input.reason) {
 		alert('You need to give a reason, you cabal crony!');
 		return;
 	}
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
-	if (pages.length === 0) {
+	if (input.pages.length === 0) {
 		Morebits.status.error('Error', 'nothing to delete, aborting');
 		return;
 	}
 
-	var pageDeleter = new Morebits.batchOperation(delete_page ? 'Deleting pages' : 'Initiating requested tasks');
+	var pageDeleter = new Morebits.batchOperation(input.delete_page ? 'Deleting pages' : 'Initiating requested tasks');
 	pageDeleter.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
 	// we only need the initial status lines if we're deleting the pages in the pages array
-	pageDeleter.setOption('preserveIndividualStatusLines', delete_page);
-	pageDeleter.setPageList(pages);
+	pageDeleter.setOption('preserveIndividualStatusLines', input.delete_page);
+	pageDeleter.setPageList(input.pages);
 	pageDeleter.run(function worker(pageName) {
 		var params = {
 			page: pageName,
-			delete_page: delete_page,
-			delete_talk: delete_talk,
-			delete_redirects: delete_redirects,
-			unlink_page: unlink_page,
-			unlink_file: unlink_file && /^(File|Image):/i.test(pageName),
-			reason: reason,
+			delete_page: input.delete_page,
+			delete_talk: input.delete_talk,
+			delete_redirects: input.delete_redirects,
+			unlink_page: input.unlink_page,
+			unlink_file: input.unlink_file && /^(File|Image):/i.test(pageName),
+			reason: input.reason,
 			pageDeleter: pageDeleter
 		};
 
 		var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
-		if (delete_page) {
-			wikipedia_page.setEditSummary(reason + Twinkle.getPref('deletionSummaryAd'));
+		if (input.delete_page) {
+			wikipedia_page.setEditSummary(input.reason + Twinkle.getPref('deletionSummaryAd'));
 			wikipedia_page.suppressProtectWarning();
 			wikipedia_page.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
 		} else {
 			Twinkle.batchdelete.callbacks.doExtras(wikipedia_page);
 		}
 	}, function postFinish() {
-		if (delete_subpages) {
+		if (input.delete_subpages) {
 			var subpageDeleter = new Morebits.batchOperation('Deleting subpages');
 			subpageDeleter.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
 			subpageDeleter.setOption('preserveIndividualStatusLines', true);
-			subpageDeleter.setPageList(subpages);
+			subpageDeleter.setPageList(input.subpages);
 			subpageDeleter.run(function(pageName) {
 				var params = {
 					page: pageName,
 					delete_page: true,
-					delete_talk: delete_subpage_talks,
-					delete_redirects: delete_subpage_redirects,
-					unlink_page: unlink_subpages,
+					delete_talk: input.delete_subpage_talks,
+					delete_redirects: input.delete_subpage_redirects,
+					unlink_page: input.unlink_subpages,
 					unlink_file: false,
-					reason: reason,
+					reason: input.reason,
 					pageDeleter: subpageDeleter
 				};
 
 				var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting subpage ' + pageName);
 				wikipedia_page.setCallbackParameters(params);
-				wikipedia_page.setEditSummary(reason + Twinkle.getPref('deletionSummaryAd'));
+				wikipedia_page.setEditSummary(input.reason + Twinkle.getPref('deletionSummaryAd'));
 				wikipedia_page.suppressProtectWarning();
 				wikipedia_page.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
 			});

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -234,7 +234,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		var result = form.render();
 		apiobj.params.Window.setContent(result);
 
-		var pageCheckboxes = Morebits.quickForm.getElements(result, 'pages') || [];
+		var pageCheckboxes = Morebits.quickForm.getElements(result, 'pages');
 		pageCheckboxes.forEach(generateArrowLinks);
 		Morebits.checkboxShiftClickSupport(pageCheckboxes);
 
@@ -299,11 +299,11 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
 			$('#tw-dbatch-pages').replaceWith(newPageList);
 
-			pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages') || [];
+			pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages');
 			pageCheckboxes.forEach(generateArrowLinks);
 			Morebits.checkboxShiftClickSupport(pageCheckboxes);
 
-			subpageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages.subpages') || [];
+			subpageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages.subpages');
 			subpageCheckboxes.forEach(generateArrowLinks);
 			Morebits.checkboxShiftClickSupport(subpageCheckboxes);
 
@@ -396,11 +396,11 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
 			$('#tw-dbatch-pages').replaceWith(newPageList);
 
-			pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages') || [];
+			pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages');
 			pageCheckboxes.forEach(generateArrowLinks);
 			Morebits.checkboxShiftClickSupport(pageCheckboxes);
 
-			subpageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages.subpages') || [];
+			subpageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages.subpages');
 			subpageCheckboxes.forEach(generateArrowLinks);
 			Morebits.checkboxShiftClickSupport(subpageCheckboxes);
 
@@ -426,7 +426,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		newPageList = Twinkle.batchdelete.generateNewPageList(form);
 		$('#tw-dbatch-pages').replaceWith(newPageList);
 
-		pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages') || [];
+		pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages');
 		pageCheckboxes.forEach(generateArrowLinks);
 		Morebits.checkboxShiftClickSupport(pageCheckboxes);
 
@@ -469,7 +469,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 	}
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
-	if (!pages) {
+	if (pages.length === 0) {
 		Morebits.status.error('Error', 'nothing to delete, aborting');
 		return;
 	}

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -392,7 +392,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	if (!pages) {
+	if (pages.length === 0) {
 		Morebits.status.error('Error', 'Nothing to protect, aborting');
 		return;
 	}

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -33,12 +33,12 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 	var form = new Morebits.quickForm(Twinkle.batchprotect.callback.evaluate);
 	form.append({
 		type: 'checkbox',
-		name: 'editmodify',
 		event: Twinkle.protect.formevents.editmodify,
 		list: [
 			{
 				label: 'Modify edit protection',
 				value: 'editmodify',
+				name: 'editmodify',
 				tooltip: 'Only for existing pages.',
 				checked: true
 			}
@@ -108,12 +108,12 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 	form.append({
 		type: 'checkbox',
-		name: 'movemodify',
 		event: Twinkle.protect.formevents.movemodify,
 		list: [
 			{
 				label: 'Modify move protection',
 				value: 'movemodify',
+				name: 'movemodify',
 				tooltip: 'Only for existing pages.',
 				checked: true
 			}
@@ -178,7 +178,6 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 	form.append({
 		type: 'checkbox',
-		name: 'createmodify',
 		event: function twinklebatchprotectFormCreatemodifyEvent(e) {
 			e.target.form.createlevel.disabled = !e.target.checked;
 			e.target.form.createexpiry.disabled = !e.target.checked || (e.target.form.createlevel.value === 'all');
@@ -188,6 +187,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			{
 				label: 'Modify create protection',
 				value: 'createmodify',
+				name: 'createmodify',
 				tooltip: 'Only for pages that do not exist.',
 				checked: true
 			}
@@ -372,19 +372,9 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 		return;
 	}
 
-	var pages = form.getChecked('pages');
-	var reason = form.reason.value;
-	var editmodify = form.editmodify.checked;
-	var editlevel = form.editlevel.value;
-	var editexpiry = form.editexpiry.value;
-	var movemodify = form.movemodify.checked;
-	var movelevel = form.movelevel.value;
-	var moveexpiry = form.moveexpiry.value;
-	var createmodify = form.createmodify.checked;
-	var createlevel = form.createlevel.value;
-	var createexpiry = form.createexpiry.value;
+	var input = Morebits.quickForm.getInputData(form);
 
-	if (!reason) {
+	if (!input.reason) {
 		alert("You've got to give a reason, you rouge admin!");
 		return;
 	}
@@ -392,7 +382,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	if (pages.length === 0) {
+	if (input.pages.length === 0) {
 		Morebits.status.error('Error', 'Nothing to protect, aborting');
 		return;
 	}
@@ -400,7 +390,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 	var batchOperation = new Morebits.batchOperation('Applying protection settings');
 	batchOperation.setOption('chunkSize', Twinkle.getPref('batchProtectChunks'));
 	batchOperation.setOption('preserveIndividualStatusLines', true);
-	batchOperation.setPageList(pages);
+	batchOperation.setPageList(input.pages);
 	batchOperation.run(function(pageName) {
 		var query = {
 			'action': 'query',
@@ -408,20 +398,10 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 		};
 		var wikipedia_api = new Morebits.wiki.api('Checking if page ' + pageName + ' exists', query,
 			Twinkle.batchprotect.callbacks.main, null, batchOperation.workerFailure);
-		wikipedia_api.params = {
+		wikipedia_api.params = $.extend({
 			page: pageName,
-			reason: reason,
-			editmodify: editmodify,
-			editlevel: editlevel,
-			editexpiry: editexpiry,
-			movemodify: movemodify,
-			movelevel: movelevel,
-			moveexpiry: moveexpiry,
-			createmodify: createmodify,
-			createlevel: createlevel,
-			createexpiry: createexpiry,
 			batchOperation: batchOperation
-		};
+		}, input);
 		wikipedia_api.post();
 	});
 };

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -131,7 +131,7 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(event.target);
 
-	if (!pages) {
+	if (pages.length === 0) {
 		Morebits.status.error('Error', 'nothing to undelete, aborting');
 		return;
 	}

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -108,7 +108,7 @@ Twinkle.deprod.callback = function() {
 
 		var rendered = apiobj.params.form.render();
 		apiobj.params.Window.setContent(rendered);
-		$(Morebits.quickForm.getElements(rendered, 'pages')).each(function(index, checkbox) {
+		Morebits.quickForm.getElements(rendered, 'pages').forEach(function(checkbox) {
 			var $checkbox = $(checkbox);
 			var link = Morebits.htmlNode('a', $checkbox.val());
 			link.setAttribute('class', 'deprod-page-link');

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -123,7 +123,7 @@ Twinkle.deprod.callback = function() {
 };
 
 var callback_commit = function(event) {
-		var pages = event.target.getChecked('pages');
+		var pages = Morebits.quickForm.getInputData(event.target).pages;
 		Morebits.status.init(event.target);
 
 		var batchOperation = new Morebits.batchOperation('Deleting pages');

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -121,10 +121,10 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 		case 'no source':
 			work_area.append({
 				type: 'checkbox',
-				name: 'non_free',
 				list: [
 					{
 						label: 'Non-free',
+						name: 'non_free',
 						tooltip: 'File is licensed under a fair use claim'
 					}
 				]
@@ -133,9 +133,9 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 		case 'no license':
 			work_area.append({
 				type: 'checkbox',
-				name: 'derivative',
 				list: [
 					{
+						name: 'derivative',
 						label: 'Derivative work which lacks a source for incorporated works',
 						tooltip: 'File is a derivative of one or more other works whose source is not specified'
 					}
@@ -179,35 +179,12 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 };
 
 Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
-	var type, non_free, source, reason, replacement, derivative;
 
-	var notify = event.target.notify.checked;
-	var types = event.target.type;
-	for (var i = 0; i < types.length; ++i) {
-		if (types[i].checked) {
-			type = types[i].values;
-			break;
-		}
-	}
-	if (event.target.non_free) {
-		non_free = event.target.non_free.checked;
-	}
-	if (event.target.source) {
-		source = event.target.source.value;
-	}
-	if (event.target.reason) {
-		reason = event.target.reason.value;
-	}
-	if (event.target.replacement && event.target.replacement.value.trim()) {
-		replacement = event.target.replacement.value;
-		replacement = /^\s*(Image|File):/i.test(replacement) ? replacement : 'File:' + replacement;
-	}
-	if (event.target.derivative) {
-		derivative = event.target.derivative.checked;
-	}
+	var input = Morebits.quickForm.getInputData(event.target);
+	input.replacement = (/^(Image|File):/i.test(input.replacement) ? '' : 'File:') + input.replacement;
 
 	var csdcrit;
-	switch (type) {
+	switch (input.type) {
 		case 'no source no license':
 		case 'no source':
 		case 'no license':
@@ -231,18 +208,14 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 	}
 
 	var lognomination = Twinkle.getPref('logSpeedyNominations') && Twinkle.getPref('noLogOnSpeedyNomination').indexOf(csdcrit.toLowerCase()) === -1;
-	var templatename = derivative ? 'dw ' + type : type;
+	var templatename = input.derivative ? 'dw ' + input.type : input.type;
 
-	var params = {
-		'type': type,
-		'templatename': templatename,
-		'normalized': csdcrit,
-		'non_free': non_free,
-		'source': source,
-		'reason': reason,
-		'replacement': replacement,
-		'lognomination': lognomination
-	};
+	var params = $.extend({
+		templatename: templatename,
+		normalized: csdcrit,
+		lognomination: lognomination
+	}, input);
+
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(event.target);
 
@@ -255,7 +228,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 	wikipedia_page.load(Twinkle.image.callbacks.taggingImage);
 
 	// Notifying uploader
-	if (notify) {
+	if (input.notify) {
 		wikipedia_page.lookupCreation(Twinkle.image.callbacks.userNotification);
 	} else {
 		// add to CSD log if desired

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -396,23 +396,13 @@ Twinkle.prod.callbacks = {
 
 Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	var form = e.target;
-	var prodtype;
-
-	if (namespace === 'article') {
-		var prodtypes = form.prodtype;
-		for (var i = 0; i < prodtypes.length; i++) {
-			if (prodtypes[i].checked) {
-				prodtype = prodtypes[i].values;
-				break;
-			}
-		}
-	}
+	var input = Morebits.quickForm.getInputData(form);
 
 	var params = {
-		usertalk: form.notify.checked,
-		blp: prodtype === 'prodblp',
+		usertalk: input.notify,
+		blp: input.prodtype === 'prodblp',
 		book: namespace === 'book',
-		reason: prodtype === 'prodblp' ? '' : form.reason.value  // using an empty string here as fallback will help with prod-2.
+		reason: input.reason || '' // using an empty string here as fallback will help with prod-2.
 	};
 
 	Morebits.simpleWindow.setButtonsEnabled(false);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1413,13 +1413,14 @@ Twinkle.warn.callbacks = {
 		return text + ' ~~~~';
 	},
 	showPreview: function(form, templatename) {
+		var input = Morebits.quickForm.getInputData(form);
 		// Provided on autolevel, not otherwise
-		templatename = templatename || form.sub_group.value;
-		var linkedarticle = form.article.value;
+		templatename = templatename || input.sub_group;
+		var linkedarticle = input.article;
 		var templatetext;
 
 		templatetext = Twinkle.warn.callbacks.getWarningWikitext(templatename, linkedarticle,
-			form.reason.value, form.main_group.value === 'custom');
+			input.reason, input.main_group === 'custom');
 
 		form.previewer.beginRender(templatetext, 'User_talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
 	},
@@ -1714,24 +1715,18 @@ Twinkle.warn.callbacks = {
 Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 	var userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
-	// First, check to make sure a reason was filled in if uw-username was selected
+	// reason, main_group, sub_group, article
+	var params = Morebits.quickForm.getInputData(e.target);
 
-	if (e.target.sub_group.value === 'uw-username' && e.target.article.value.trim() === '') {
+	// Check that a reason was filled in if uw-username was selected
+	if (params.sub_group === 'uw-username' && !params.article) {
 		alert('You must supply a reason for the {{uw-username}} template.');
 		return;
 	}
 
 	// Find the selected <option> element so we can fetch the data structure
-	var selectedEl = $(e.target.sub_group).find('option[value="' + $(e.target.sub_group).val() + '"]');
-
-	// Then, grab all the values provided by the form
-	var params = {
-		reason: e.target.reason.value,
-		main_group: e.target.main_group.value,
-		sub_group: e.target.sub_group.value,
-		article: e.target.article.value,  // .replace( /^(Image|Category):/i, ':$1:' ),  -- apparently no longer needed...
-		messageData: selectedEl.data('messageData')
-	};
+	var $selectedEl = $(e.target.sub_group).find('option[value="' + $(e.target.sub_group).val() + '"]');
+	params.messageData = $selectedEl.data('messageData');
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(e.target);

--- a/morebits.js
+++ b/morebits.js
@@ -728,15 +728,13 @@ Morebits.quickForm.element.generateTooltip = function QuickFormElementGenerateTo
  */
 Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) {
 	var $form = $(form);
+	fieldName = $.escapeSelector(fieldName); // sanitize input
 	var $elements = $form.find('[name="' + fieldName + '"]');
 	if ($elements.length > 0) {
 		return $elements.toArray();
 	}
 	$elements = $form.find('#' + fieldName);
-	if ($elements.length > 0) {
-		return $elements.toArray();
-	}
-	return null;
+	return $elements.toArray();
 };
 
 /**
@@ -881,15 +879,11 @@ Morebits.quickForm.setElementTooltipVisibility = function QuickFormSetElementToo
  * please)
  * Type is optional and can specify if either radio or checkbox (for the event
  * that both checkboxes and radiobuttons have the same name.
- *
- * XXX: Doesn't seem to work reliably across all browsers at the moment. -- see getChecked2
- * in twinkleunlink.js, which is better
  */
 HTMLFormElement.prototype.getChecked = function(name, type) {
 	var elements = this.elements[name];
 	if (!elements) {
-		// if the element doesn't exists, return null.
-		return null;
+		return [];
 	}
 	var return_array = [];
 	var i;
@@ -936,8 +930,7 @@ HTMLFormElement.prototype.getChecked = function(name, type) {
 HTMLFormElement.prototype.getUnchecked = function(name, type) {
 	var elements = this.elements[name];
 	if (!elements) {
-		// if the element doesn't exists, return null.
-		return null;
+		return [];
 	}
 	var return_array = [];
 	var i;


### PR DESCRIPTION
New function to efficiently retrieve all data entered in a form (any form, not necessarily a `quickForm`).

This should get rid of the need to:
- write repetitive `var x = form.x.value` like statements.
- manually `.trim()` text/textarea input values
- use the custom-defined `HTMLFormElement.prototype.getChecked` function (though still used in a few places). 