### PR TITLE
Display G13 on Redirects

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1057,7 +1057,7 @@ Twinkle.speedy.generalList = [
 		label: 'G13: Page in draft namespace or userspace AfC submission, stale by over 6 months',
 		value: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC submission in userspace or any non-redirect page in draft namespace, that has not been edited for more than 6 months. Blank drafts in either namespace are also included.',
-		hideWhenRedirect: true,
+		hideWhenRedirect: false,
 		showInNamespaces: [2, 118]  // user, draft namespaces only
 	},
 	{


### PR DESCRIPTION
G13 is still applicable in draft and userspace redirects, this will avoid having to tag with G6 or manually.