### PR TITLE
fluff: Fix revert coming from contribs if diffonly is used

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -88,7 +88,7 @@ Twinkle.fluff.restoreThisRevision = function (element, revType) {
 
 
 Twinkle.fluff.auto = function twinklefluffauto() {
-	if (mw.config.get('wgRevisionId') !== mw.config.get('wgCurRevisionId')) {
+	if (parseInt(mw.util.getParamValue('oldid'), 10) !== mw.config.get('wgCurRevisionId')) {
 		// not latest revision
 		alert("Can't rollback, page has changed in the meantime.");
 		return;


### PR DESCRIPTION
Fixes #913, same basic issue as #627/#628: if a user has "Do not show page content below diffs" selected in Special:Preferences, wgRevisionId is set to 0 on diffs.  While #628 took care of that for the links on diff pages themselves, trying to rollback from a contribs page was left unfixed.  Those links load the diff page then `auto`matically revert, so will run into the same issue.  This essentialy reverts back to the check before 3e5ec5b2 (#561), albeit by using `mw.util.getParamValue` rather than the no-longer-existing `Morebits.queryString.get` (#725).