### PR TITLE
deletion modules: Don't follow cross-ns redirect while notifying user

### DIFF
--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -345,7 +345,7 @@ Twinkle.image.callbacks = {
 					usertalkpage.setWatchlistFromPreferences(true);
 					break;
 			}
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append();
 		}
 

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -282,7 +282,7 @@ Twinkle.prod.callbacks = {
 					usertalkpage.setAppendText(notifytext);
 					usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
 					usertalkpage.setCreateOption('recreate');
-					usertalkpage.setFollowRedirect(true);
+					usertalkpage.setFollowRedirect(true, false);
 					usertalkpage.setCallbackParameters(params);
 					usertalkpage.append(function onNotifySuccess() {
 						// add nomination to the userspace log, if the user has enabled it

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1291,7 +1291,7 @@ Twinkle.speedy.callbacks = {
 			usertalkpage.setAppendText(notifytext);
 			usertalkpage.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -993,7 +993,7 @@ Twinkle.xfd.callbacks = {
 			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|nomination]] of [[:' + Morebits.pageNameNorm + ']]  at [[WP:AFD|articles for deletion]].' + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {
@@ -1096,7 +1096,7 @@ Twinkle.xfd.callbacks = {
 			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + pageobj.getPageName() + ']] at [[WP:TFD|templates for discussion]].' + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 
 			// Add this nomination to user's userspace log, if the user has enabled it
 			// and it isn't the second template in a TfM nomination
@@ -1260,7 +1260,7 @@ Twinkle.xfd.callbacks = {
 			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|nomination]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:MFD|miscellany for deletion]].' + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 			// Only log once, using the initial creator's notification as our barometer
 			if (params.initialContrib === userTarget && params.lognomination) {
 				usertalkpage.append(function onNotifySuccess() {
@@ -1302,7 +1302,7 @@ Twinkle.xfd.callbacks = {
 					usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:FFD|files for discussion]].' + Twinkle.getPref('summaryAd'));
 					usertalkpage.setCreateOption('recreate');
 					Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
-					usertalkpage.setFollowRedirect(true);
+					usertalkpage.setFollowRedirect(true, false);
 					usertalkpage.append(function onNotifySuccess() {
 						// add this nomination to the user's userspace log, if the user has enabled it
 						if (params.lognomination) {
@@ -1426,7 +1426,7 @@ Twinkle.xfd.callbacks = {
 			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:CFD|categories for discussion]].' + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {
@@ -1629,7 +1629,7 @@ Twinkle.xfd.callbacks = {
 			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:RFD|redirects for discussion]].' + Twinkle.getPref('summaryAd'));
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
-			usertalkpage.setFollowRedirect(true);
+			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {


### PR DESCRIPTION
1st commit: add ability in morebits to detect cross-ns redirects and treat them separtely. 

2nd commit: apply that in xfd, speedy, prod, and image modules.

Partially addresses #912.