### PR TITLE
sync.pl: Change how push/pull/deploy parameters are used

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -58,39 +58,40 @@ Each Twinkle module and dependency lives on the wiki as a separate file. The lis
 
 ### Synchronization using `sync.pl`
 
-There is a synchronization script called `sync.pl`, which can be used to update on-wiki gadgets, or update the repository based on on-wiki changes.
+There is a synchronization script called `sync.pl`, which can be used to deploy updates to on-wiki gadgets, or update the repository based on on-wiki changes. For more detauls, run `perl sync.pl --help`.
 
-The program depends on a few Perl modules, namely [`MediaWiki::API`][MediaWiki::API], [`Git::Repository`][Git::Repository], [`File::Slurper`][File::Slurper], and [`Getopt::Long::Descriptive`][Getopt::Long::Descriptive]. These can be installed easily using [`App::cpanminus`][App::cpanminus]:
+The program depends on a few Perl modules, namely [`MediaWiki::API`][MediaWiki::API], [`Git::Repository`][Git::Repository], [`File::Slurper`][File::Slurper], and [`Config::General`][Config::General]. These can be installed easily using [`App::cpanminus`][App::cpanminus]:
 
-    cpanm --sudo install MediaWiki::API Git::Repository File::Slurper Getopt::Long::Descriptive
+    cpanm --sudo install MediaWiki::API Git::Repository File::Slurper Config::General
 
-You may prefer to install them through your operating system's packaing tool (e.g. `apt-get install libgetopt-long-descriptive-perl`) although you can install them through cpanm too.
+You may prefer to install them through your operating system's packaing tool (e.g. `apt-get install libconfig-general-perl`) although you can install them through cpanm too.
 
 When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a `.twinklerc` file, either in this directory or in your `~` home, using the following format:
 
     username = username
     password = password
+	mode     = deploy|push|pull
     lang     = en
     family   = wikipedia
     base     = User:Username
 
-where `base` is the wiki path to prefix the files for `pull` and `push`. The script ignores the `modules/` part of the file path when downloading/uploading.
+`username`, `password`, and `mode` (one of `deploy`, `push`, or `pull`) are required, either through the command line or configuration file; lang and family default to `en.wikipedia`. Note that your working directory **must** be clean; if not, either `stash` or `commit` your changes. The script automatically handles the directory (e.g. `modules/`) from the file path when downloading/uploading.
 
 Note that your working directory **must** be clean; if not, either `stash` or `commit` your changes.
 
 To `pull` user Foobar's changes (i.e. `User:Foobar/morebits.js`) down from the wiki, do:
 
-    ./sync.pl --base User:Foobar --pull twinkle.js morebits.js ...
+    ./sync.pl --base User:Foobar --mode=pull twinkle.js morebits.js ...
 
 To `push` your changes to user Foobar's wiki page, do:
 
-    ./sync.pl --base User:Foobar --push twinkle.js morebits.js ...
+    ./sync.pl --base User:Foobar --mode=push twinkle.js morebits.js ...
 
 #### Deploying to the sitewide gadget
 
-There is also a `deploy` command for [interface-admins][intadmin] to deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
+There is also a `deploy` mode for [interface-admins][intadmin] to deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
 
-    ./sync.pl --deploy twinkle.js morebits.js ...
+    ./sync.pl --mode=deploy twinkle.js morebits.js ...
 
 You may also `deploy` all files via
 
@@ -135,7 +136,7 @@ When `deploy`ing or `push`ing, the script will attempt to parse the latest on-wi
 [MediaWiki::API]: https://metacpan.org/pod/MediaWiki::API
 [Git::Repository]: https://metacpan.org/pod/Git::Repository
 [File::Slurper]: https://metacpan.org/pod/File::Slurper
-[Getopt::Long::Descriptive]: https://metacpan.org/pod/Getopt::Long::Descriptive
+[Config::General]: https://metacpan.org/pod/Config::General
 [App::cpanminus]: https://metacpan.org/pod/App::cpanminus
 [intadmin]: https://en.wikipedia.org/wiki/Wikipedia:Interface_administrators
 [special_botpass]: https://en.wikipedia.org/wiki/Special:BotPasswords

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -66,30 +66,18 @@ The program depends on a few Perl modules, namely [`MediaWiki::API`][MediaWiki::
 
 You may prefer to install them through your operating system's packaing tool (e.g. `apt-get install libconfig-general-perl`) although you can install them through cpanm too.
 
-When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a `.twinklerc` file, either in this directory or in your `~` home, using the following format:
+When running the program, you can enter your credentials on the command line using the `--username` and `--password` parameters, but it is recommended to save them in a `.twinklerc` file, either in this directory or in your `~` home, using the following format (also the defaults):
 
     username = username
     password = password
 	mode     = deploy|push|pull
     lang     = en
     family   = wikipedia
-    base     = User:Username
+    base     = User:AzaToth/
 
 `username`, `password`, and `mode` (one of `deploy`, `push`, or `pull`) are required, either through the command line or configuration file; lang and family default to `en.wikipedia`. Note that your working directory **must** be clean; if not, either `stash` or `commit` your changes. The script automatically handles the directory (e.g. `modules/`) from the file path when downloading/uploading.
 
-Note that your working directory **must** be clean; if not, either `stash` or `commit` your changes.
-
-To `pull` user Foobar's changes (i.e. `User:Foobar/morebits.js`) down from the wiki, do:
-
-    ./sync.pl --base User:Foobar --mode=pull twinkle.js morebits.js ...
-
-To `push` your changes to user Foobar's wiki page, do:
-
-    ./sync.pl --base User:Foobar --mode=push twinkle.js morebits.js ...
-
-#### Deploying to the sitewide gadget
-
-There is also a `deploy` mode for [interface-admins][intadmin] to deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
+Using the `deploy` mode, [interface-admins][intadmin] can deploy Twinkle files live to their MediaWiki:Gadget locations. You will need to set up a bot password at [Special:BotPasswords][special_botpass].
 
     ./sync.pl --mode=deploy twinkle.js morebits.js ...
 
@@ -102,6 +90,15 @@ Note that for syncing to a non-Enwiki project, you will also need to specify the
     make ARGS="--lang=test --family=wmflabs" deploy
 
 When `deploy`ing or `push`ing, the script will attempt to parse the latest on-wiki edit summary for the commit of the last update, and will use that to create an edit summary using the changes committed since then. If it cannot find anything that looks like a commit hash, it will give you the most recent commits for each file and prompt you to enter an edit summary manually.
+
+To `pull` user Foobar's changes (i.e. `User:Foobar/morebits.js`) down from the wiki, do:
+
+    ./sync.pl --base User:Foobar/ --mode=pull twinkle.js morebits.js ...
+
+To `push` your changes to user Foobar's wiki page, do:
+
+    ./sync.pl --base User:Foobar/ --mode=push twinkle.js morebits.js ...
+
 
 [MediaWiki:Gadgets-definition]: https://en.wikipedia.org/wiki/MediaWiki:Gadgets-definition
 [MediaWiki:Gadget-Twinkle.js]: https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.js

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ modules = modules/twinkleconfig.js \
 		  modules/friendlywelcome.js
 
 deploy: twinkle.js twinkle.css twinkle-pagestyles.css morebits.js morebits.css select2/select2.min.js select2/select2.min.css $(modules)
-	./sync.pl ${ARGS} --deploy $^
+	./sync.pl ${ARGS} --mode=deploy $^
 
 .PHONY: deploy all

--- a/sync.pl
+++ b/sync.pl
@@ -23,7 +23,7 @@ my %conf = (
             mode => q{},
             lang => 'en',
             family => 'wikipedia',
-            base => 'User:AzaToth'
+            base => 'User:AzaToth/'
            );
 
 my $rc = '.twinklerc';
@@ -42,10 +42,6 @@ foreach my $dot (@dotLocales) {
 GetOptions (\%conf, 'username|s=s', 'password|p=s', 'lang|l=s', 'family|f=s', 'base|b=s',
             'mode=s', 'help|h' => \&usage);
 
-# Make sure we know what we're doing before doing it
-# Includes checks for required parameters
-forReal();
-
 # Ensure we've got a clean branch
 my $repo = Git::Repository->new();
 my @status = $repo->run(status => '--porcelain');
@@ -53,6 +49,10 @@ if (scalar @status) {
   print colored ['red'], "Repository is not clean, aborting\n";
   exit;
 }
+
+# Make sure we know what we're doing before doing it
+# Includes checks for required parameters
+forReal();
 
 # Open API and log in before anything else
 my $mw = MediaWiki::API->new({
@@ -63,58 +63,62 @@ my $mw = MediaWiki::API->new({
 $mw->{ua}->agent('Twinkle/sync.pl ('.$mw->{ua}->agent.')');
 $mw->login({lgname => $conf{username}, lgpassword => $conf{password}});
 
-### Main loop to parse options
-if ($conf{mode} eq 'deploy') {
-  # Build file->page hashes from __DATA__
-  my %deploys;
-  while (<DATA>) {
-    chomp;
-    my @map = split;
-    $deploys{$map[0]} = $map[1];
-  }
 
-  # Follow order when deploying, useful mainly for keeping twinkle.js and
-  # morebits.js first with make deploy
-  foreach my $file (@ARGV) {
-    if (!defined $deploys{$file}) {
-      print colored ['yellow'], "$file not deployable, skipping\n";
-      next;
-    }
-    my $page = $deploys{$file};
-    next if saltNPepa($page, $file);
+### Main loop through each file
+foreach my $file (@ARGV) {
+  next if checkFile($file);
+  my $page = $file;
+  if ($page =~ /^twinkle/) {
+    $page =~ s/^twinkle\b/Twinkle/; # twinkle.js, etc. files are capitalized on-wiki
+  } else {
+    $page =~ s/\w+\///;         # Remove directories (modules/, select2/)
   }
-} else {
-  # Remove 'modules/' from ARGV input filenames
-  my %pages = map {+(my $s = $_) =~ s/modules\///; $_ => "$conf{base}/$s"} @ARGV;
+  $page = $conf{base}.$page; # base set to MediaWiki:Gadget- for deploy in &forReal
 
-  if ($conf{mode} eq 'pull') {
-    while (my ($file, $page) = each %pages) {
-      my $wikiPage = checkPage($page);
-      next if !$wikiPage;
-      print "Grabbing $page";
-      my $text = $wikiPage->{q{*}}."\n"; # MediaWiki doesn't have trailing newlines
-      # Might be faster to check this using git and eof, but here makes sense
-      if ($text eq read_text($file)) {
-        print colored ['blue'], "... No changes found, skipping\n";
-        next;
+  my $wikiPage = checkPage($page);
+  next if !$wikiPage;
+
+  my $fileText = read_text($file);
+  my $wpText = $wikiPage->{q{*}}."\n"; # MediaWiki doesn't have trailing newlines
+
+  if ($conf{mode} eq 'deploy' || $conf{mode} eq 'push') {
+    print ucfirst $conf{mode}."ing $file to $page...";
+
+    if ($fileText eq $wpText) {
+      print colored ['blue'], " No changes needed, skipping\n";
+    } else {
+      print "\n";
+      my $summary = buildEditSummary($page, $file, $wikiPage->{comment});
+      my $editReturn = editPage($page, $fileText, $summary, $wikiPage->{timestamp});
+      if ($editReturn->{_msg} eq 'OK') {
+        print colored ['green'], "\t$file successfully $conf{mode}ed to $page\n";
       } else {
-        print "\n";
-        write_text($file, $text);
+        print colored ['red'], "Error $conf{mode}ing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
       }
     }
-    # Show a summary of any changes
-    my $cmd = $repo->command(diff => '--stat', '--color');
-    my $s = $cmd->stdout;
-    while (<$s>) {
-      print;
-    }
-    $cmd->close;
-  } elsif ($conf{mode} eq 'push') {
-    while (my ($file, $page) = each %pages) {
-      next if saltNPepa($page, $file);
+  } elsif ($conf{mode} eq 'pull') {
+    print "Pulling from $page to $file";
+    # Might be faster to check this using git and eof, but here makes sense
+    if ($wpText eq $fileText) {
+      print colored ['blue'], "... No changes found, skipping\n";
+      next;
+    } else {
+      print "... Done!\n";
+      write_text($file, $wpText);
     }
   }
 }
+
+# Show a summary of any changes
+if ($conf{base} eq 'pull') {
+  my $cmd = $repo->command(diff => '--stat', '--color');
+  my $s = $cmd->stdout;
+  while (<$s>) {
+    print;
+  }
+  $cmd->close;
+}
+
 
 
 ### SUBROUTINES
@@ -151,11 +155,10 @@ sub forReal {
     print colored ['bright_magenta'], 'LIVE';
     print ' to the ';
     print colored ['bright_white'], 'MediaWiki gadget';
-  } elsif ($conf{mode} eq 'pull') {
-    print 'from subpages of ';
-    print colored ['bright_white'], $conf{base};
-  } elsif ($conf{mode} eq 'push') {
-    print 'to subpages of ';
+    $conf{base} = 'MediaWiki:Gadget-';
+  } else {
+    print $conf{mode} eq 'pull' ? 'from' : 'to';
+    print ' pages prefixed by ';
     print colored ['bright_white'], $conf{base};
   }
   print ' at ';
@@ -203,7 +206,7 @@ sub checkFile {
   if (-e -f -r $file) {
     return 0;
   } else {
-    print colored ['red'], "$file does not exist, skipping\n";
+    print colored ['yellow'], "$file does not exist, skipping\n";
     return 1;
   }
 }
@@ -213,7 +216,7 @@ sub checkPage {
   my $page = shift;
   my $wikiPage = $mw->get_page({title => $page});
   if (defined $wikiPage->{missing}) {
-    print colored ['red'], "$page does not exist, skipping\n";
+    print colored ['yellow'], "$page does not exist, skipping\n";
     return 0;
   } else {
     return $wikiPage;
@@ -249,7 +252,7 @@ sub buildEditSummary {
   # Prompt for manual entry
   if (!$editSummary) {
     my @log = $repo->run(log => '-5', '--pretty=format:%s (%h)', '--no-merges', '--no-color', $file);
-    print colored ['red'], "Unable to autogenerate edit summary for $page\n\n";
+    print colored ['yellow'], "Unable to autogenerate edit summary for $page\n\n";
     print "The most recent ON-WIKI edit summary is:\n";
     print colored ['bright_cyan'], "\t$oldCommitish\n";
     print "The most recent GIT LOG entries are:\n";
@@ -295,33 +298,6 @@ sub editPage {
   return $mw->{response};
 }
 
-# All together now!
-sub saltNPepa {
-  my ($page, $file) = @_;
-  return 1 if checkFile($file);
-  my $text = read_text($file);
-  my $wikiPage = checkPage($page);
-  return 1 if !$wikiPage;
-  # print "$file -> $conf{lang}.$conf{family}.org/wiki/$page";
-  print ucfirst $conf{mode};
-  print "ing $file to $page...";
-
-  my $wp = $wikiPage->{q{*}}."\n"; # MediaWiki doesn't have trailing newlines
-  if ($text eq $wp) {
-    print colored ['blue'], " No changes needed, skipping\n";
-    return 1;
-  } else {
-    print "\n";
-    my $summary = buildEditSummary($page, $file, $wikiPage->{comment});
-    my $editReturn = editPage($page, $text, $summary, $wikiPage->{timestamp});
-    if ($editReturn->{_msg} eq 'OK') {
-      print colored ['green'], "\t$file successfully pushed to $page\n";
-    } else {
-      print colored ['red'], "Error pushing $file: $mw->{error}->{code}: $mw->{error}->{details}\n";
-    }
-    return 0;
-  }
-}
 
 #### Usage statement ####
 # Escapes not necessary but ensure pretty colors
@@ -332,16 +308,16 @@ sub usage {
 $PROGRAM_NAME --mode=deploy|pull|push [-u username] [-p password] [-l language] [-f family] [-b base]
 
     --mode What action to perform, one of deploy, pull, or push. Required.
-        deploy: Push changes on-wiki as gadget
-        pull: Pull changes from base location
-        push: Push changes on-wiki to base location
+        deploy: Push changes live to the gadget
+        pull: Pull changes from base-prefixed location
+        push: Push changes to base-prefixed location
 
     --username, -u Username for account. Required.
     --password, -p Password for account. Required.
 
     --lang, -l Target language, default 'en'
     --family, -f Target family, default 'wikipedia'
-    --base, -b Base location on-wiki where user files exist, default 'User:AzaToth'
+    --base, -b Base page prefix where on-wiki files exist, default 'User:AzaToth/'
 
     These options can be provided in a config file, .twinklerc, in either this script's
     or your home directory.  It should be a simple file consisting of keys and values:
@@ -353,37 +329,3 @@ $PROGRAM_NAME --mode=deploy|pull|push [-u username] [-p password] [-l language] 
 USAGE
   exit;
 }
-
-
-## The lines below do not represent Perl code, and are not examined by the
-## compiler.  Rather, they are used by %deploys to map filenames from the
-## Twinkle git repo to their corresponding location in the MediaWiki Gadget
-## psuedonamespace.
-__DATA__
-twinkle.js MediaWiki:Gadget-Twinkle.js
-  twinkle.css MediaWiki:Gadget-Twinkle.css
-  twinkle-pagestyles.css MediaWiki:Gadget-Twinkle-pagestyles.css
-  morebits.js MediaWiki:Gadget-morebits.js
-  morebits.css MediaWiki:Gadget-morebits.css
-  select2/select2.min.js MediaWiki:Gadget-select2.min.js
-  select2/select2.min.css MediaWiki:Gadget-select2.min.css
-  modules/twinklearv.js MediaWiki:Gadget-twinklearv.js
-  modules/twinklebatchdelete.js MediaWiki:Gadget-twinklebatchdelete.js
-  modules/twinklebatchprotect.js MediaWiki:Gadget-twinklebatchprotect.js
-  modules/twinklebatchundelete.js MediaWiki:Gadget-twinklebatchundelete.js
-  modules/twinkleblock.js MediaWiki:Gadget-twinkleblock.js
-  modules/twinkleconfig.js MediaWiki:Gadget-twinkleconfig.js
-  modules/twinkledeprod.js MediaWiki:Gadget-twinkledeprod.js
-  modules/twinklediff.js MediaWiki:Gadget-twinklediff.js
-  modules/twinklefluff.js MediaWiki:Gadget-twinklefluff.js
-  modules/twinkleimage.js MediaWiki:Gadget-twinkleimage.js
-  modules/twinkleprod.js MediaWiki:Gadget-twinkleprod.js
-  modules/twinkleprotect.js MediaWiki:Gadget-twinkleprotect.js
-  modules/twinklespeedy.js MediaWiki:Gadget-twinklespeedy.js
-  modules/twinkleunlink.js MediaWiki:Gadget-twinkleunlink.js
-  modules/twinklewarn.js MediaWiki:Gadget-twinklewarn.js
-  modules/twinklexfd.js MediaWiki:Gadget-twinklexfd.js
-  modules/friendlyshared.js MediaWiki:Gadget-friendlyshared.js
-  modules/friendlytag.js MediaWiki:Gadget-friendlytag.js
-  modules/friendlytalkback.js MediaWiki:Gadget-friendlytalkback.js
-  modules/friendlywelcome.js MediaWiki:Gadget-friendlywelcome.js


### PR DESCRIPTION
I'm the only one who really uses this, but I wanted to open a PR to at least document the fact that the way parameters should be given will change.

1. Rather than `--deploy` or `--push`, you now do `--mode=deploy`, etc.
1. The `base` parameter is now a prefix, so if you want to reference user subpage, you should do `--base=User:AzaToth/` (with the trailing `/`)
1. Duplicate parameters are now okay; the last one provided will be used