### PR TITLE
Add pagetriage in place of patrol for NPP

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -193,7 +193,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			type: 'checkbox',
 			list: [
 				{
-					label: 'Mark the page as patrolled',
+					label: 'Mark the page as patrolled/reviewed',
 					value: 'patrolPage',
 					name: 'patrolPage',
 					checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
@@ -1426,7 +1426,7 @@ Twinkle.tag.callbacks = {
 			});
 
 			if (params.patrol) {
-				pageobj.patrol();
+				pageobj.triage();
 			}
 		};
 
@@ -1858,7 +1858,7 @@ Twinkle.tag.callbacks = {
 		pageobj.save();
 
 		if (params.patrol) {
-			pageobj.patrol();
+			pageobj.triage();
 		}
 
 	},
@@ -1959,7 +1959,7 @@ Twinkle.tag.callbacks = {
 		pageobj.save();
 
 		if (params.patrol) {
-			pageobj.patrol();
+			pageobj.triage();
 		}
 	}
 };

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -427,10 +427,10 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.markSpeedyPagesAsPatrolled (boolean)
-			// If, when applying speedy template to page, to mark the page as patrolled (if the page was reached from NewPages)
+			// If, when applying speedy template to page, to mark the page as triaged/patrolled (if the page was reached from NewPages)
 			{
 				name: 'markSpeedyPagesAsPatrolled',
-				label: 'Mark page as patrolled when tagging (if possible)',
+				label: 'Mark page as patrolled/reviewed when tagging (if possible)',
 				type: 'boolean'
 			},
 
@@ -564,7 +564,7 @@ Twinkle.config.sections = [
 			},
 			{
 				name: 'markTaggedPagesAsPatrolled',
-				label: 'Check the "mark page as patrolled" box by default',
+				label: 'Check the "mark page as patrolled/reviewed" box by default',
 				type: 'boolean'
 			},
 			{
@@ -831,7 +831,7 @@ Twinkle.config.sections = [
 
 			{
 				name: 'markXfdPagesAsPatrolled',
-				label: 'Mark page as patrolled when nominating for AFD (if possible)',
+				label: 'Mark page as patrolled/reviewed when nominating for AFD (if possible)',
 				type: 'boolean'
 			}
 		]

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -296,6 +296,15 @@ Twinkle.config.sections = [
 				type: 'boolean'
 			},
 
+			// TwinkleConfig.markProdPagesAsPatrolled (boolean)
+			// If, when applying prod template to page, to mark the page as curated/patrolled (if the page was reached from NewPages)
+			{
+				name: 'markProdPagesAsPatrolled',
+				label: 'Mark page as patrolled/reviewed when tagging (if possible)',
+				helptip: 'This should probably not be checked as doing so is against best practice consensus',
+				type: 'boolean'
+			},
+
 			// TwinkleConfig.prodReasonDefault (string)
 			// The prefilled PROD reason.
 			{
@@ -431,6 +440,7 @@ Twinkle.config.sections = [
 			{
 				name: 'markSpeedyPagesAsPatrolled',
 				label: 'Mark page as patrolled/reviewed when tagging (if possible)',
+				helptip: 'This should probably not be checked as doing so is against best practice consensus',
 				type: 'boolean'
 			},
 

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -347,6 +347,11 @@ Twinkle.prod.callbacks = {
 			}
 		}
 
+		// curate/patrol the page
+		if (Twinkle.getPref('markProdPagesAsPatrolled')) {
+			pageobj.triage();
+		}
+
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
 		pageobj.setWatchlist(Twinkle.getPref('watchProdPages'));

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1490,10 +1490,9 @@ Twinkle.speedy.callbacks = {
 				code = buildData[0];
 			params.utparams = buildData[1];
 
-			var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
-			// patrol the page, if reached from Special:NewPages
+			// patrol the page
 			if (Twinkle.getPref('markSpeedyPagesAsPatrolled')) {
-				thispage.patrol();
+				pageobj.patrol();
 			}
 
 			// Wrap SD template in noinclude tags if we are in template space.

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1490,9 +1490,9 @@ Twinkle.speedy.callbacks = {
 				code = buildData[0];
 			params.utparams = buildData[1];
 
-			// patrol the page
+			// curate/patrol the page
 			if (Twinkle.getPref('markSpeedyPagesAsPatrolled')) {
-				pageobj.patrol();
+				pageobj.triage();
 			}
 
 			// Wrap SD template in noinclude tags if we are in template space.

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -774,9 +774,9 @@ Twinkle.xfd.callbacks = {
 
 			// Now we know we want to go ahead with it, trigger the other AJAX requests
 
-			// Mark the page as patrolled, if wanted
+			// Mark the page as curated/patrolled, if wanted
 			if (Twinkle.getPref('markXfdPagesAsPatrolled')) {
-				pageobj.patrol();
+				pageobj.triage();
 			}
 
 			// Starting discussion page

--- a/morebits.js
+++ b/morebits.js
@@ -1997,6 +1997,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		csrfToken: null,
 		loadTime: null,
 		lastEditTime: null,
+		pageID: null,
 		revertCurID: null,
 		revertUser: null,
 		fullyProtected: false,
@@ -2487,6 +2488,14 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
+	 * @returns {string} Page ID of the page loaded. 0 if the page doesn't
+	 * exist.
+	 */
+	this.getPageID = function() {
+		return ctx.pageID;
+	};
+
+	/**
 	 * @returns {string} ISO 8601 timestamp at which the page was last loaded
 	 */
 	this.getLoadTime = function() {
@@ -2867,8 +2876,10 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.pageExists = $(xml).find('page').attr('missing') !== '';
 		if (ctx.pageExists) {
 			ctx.pageText = $(xml).find('rev').text();
+			ctx.pageID = $(xml).find('page').attr('pageid');
 		} else {
 			ctx.pageText = '';  // allow for concatenation, etc.
+			ctx.pageID = 0; // nonexistent in response, matches wgArticleId
 		}
 		ctx.csrfToken = $(xml).find('tokens').attr('csrftoken');
 		if (!ctx.csrfToken) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -75,6 +75,7 @@ Twinkle.defaultConfig = {
 
 	// PROD
 	watchProdPages: true,
+	markProdPagesAsPatrolled: false,
 	prodReasonDefault: '',
 	logProdPages: false,
 	prodLogPageName: 'PROD log',


### PR DESCRIPTION
A bunch of improvements growing out of the discussion at [Wikipedia talk:New pages patrol/Reviewers#Advice on deletions](http://en.wikipedia.org/wiki/Special:Permalink/950279840#Advice_on_deletions).

1. morebits: Fix `.patrol()` by grabbing/querying for the `revid` if `rcid` is unavailable.  Per @siddharthvp at WT:NPPR, this is a major source of missed patrols.  `revid` wasn't available as an option when this was added in cae9a73 (Apr 2011) and it hasn't been touched since.
1. morebits: `getPageID` getter for `pageid`, matches `wgArticleId`
1. morebits: Add triage/curation action to mark pages as reviewed with PageTriage extension.  Uses above getter, ignores errors like `.patrol`.  Requested at WT:NPPR so as to remove from both Special:NewPages and Special:NewPagesFeed.
1. xfd/csd/tag: Use `triage` instead of `patrol`
1. prod: Add option to `triage`, basically just mirroring CSD behavior (off by default).