### PR TITLE
morebits.date: Fix bug parsing parens around UTC timestamps

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1346,8 +1346,8 @@ Morebits.date = function() {
 	this._d = new (Function.prototype.bind.apply(Date, [Date].concat(args)));
 
 	if (isNaN(this._d.getTime()) && typeof args[0] === 'string') {
-		// Try again after removing a comma, to get MediaWiki timestamps to parse
-		this._d = new (Function.prototype.bind.call(Date, Date, args[0].replace(/(\d\d:\d\d),/, '$1')));
+		// Try again after removing a comma and paren-wrapped timezone, to get MediaWiki timestamps to parse
+		this._d = new (Function.prototype.bind.call(Date, Date, args[0].replace(/(\d\d:\d\d),/, '$1').replace(/\(UTC\)/, 'UTC')));
 	}
 
 };


### PR DESCRIPTION
Not sure how this was missed in #814, but js date will see the parentheses in `(UTC)` and completely ignore the whole thing, setting the timezone local.  Should cause issues anywhere, but particularly problematic for the warn module.

Vaguely related discussion: https://github.com/azatoth/twinkle/pull/814/files#r374359937