### PR TITLE
warn: Ignore case when parsing warning history

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1351,7 +1351,7 @@ Twinkle.warn.callbacks = {
 		var params = pageobj.getCallbackParameters();
 		var messageData = params.messageData;
 
-		var history_re = /<!-- Template:(uw-.*?) -->.*?(\d{1,2}:\d{1,2}, \d{1,2} \w+ \d{4} \(UTC\))/g;
+		var history_re = /<!--\s?Template:([uU]w-.*?)\s?-->.*?(\d{1,2}:\d{1,2}, \d{1,2} \w+ \d{4} \(UTC\))/g;
 		var history = {};
 		var latest = { date: new Morebits.date(0), type: '' };
 		var current;


### PR DESCRIPTION
Most templates have a hidden comment of the form `Template:uw-templatename`, but some have `Template:Uw-templatenme`; this adjusts the regex to account for those cases, as well as missing spaces.