### PR TITLE
morebits: Only triage or patrol if page is available for doing so

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1877,7 +1877,7 @@ Morebits.wiki.api.setApiUserAgent = function(ua) {
  *
  * patrol(): Patrols a page; ignores errors
  *
- * triage(): Marks page as reviewed using PageTriage, which implies patrolled; ignores errors
+ * triage(): Marks page as reviewed using PageTriage, which implies patrolled; ignores most errors
  *
  * deletePage([onSuccess], [onFailure]): Deletes a page (for admins only)
  *
@@ -2647,13 +2647,10 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			return;
 		}
 
-		// If patrolling current page, don't need to query for latest revID
+		// If a link is present, don't need to check if it's patrolled
 		if ($('.patrollink').length) {
 			var patrolhref = $('.patrollink a').attr('href');
 			ctx.rcid = mw.util.getParamValue('rcid', patrolhref);
-			fnProcessPatrol(this, this);
-		} else if (new mw.Title(Morebits.pageNameNorm).getPrefixedText() === new mw.Title(ctx.pageName).getPrefixedText()) {
-			ctx.revid = mw.config.get('wgRevisionId') || mw.config.get('wgCurRevisionId');
 			fnProcessPatrol(this, this);
 		} else {
 			var patrolQuery = {
@@ -2661,7 +2658,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				prop: 'info',
 				meta: 'tokens',
 				type: 'patrol', // as long as we're querying, might as well get a token
-				titles: ctx.pageName
+				list: 'recentchanges', // check if the page is unpatrolled
+				titles: ctx.pageName,
+				rcprop: 'patrolled',
+				rctitle: ctx.pageName,
+				rclimit: 1
 			};
 
 			ctx.patrolApi = new Morebits.wiki.api('retrieving token...', patrolQuery, fnProcessPatrol);
@@ -2676,7 +2677,8 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	 *
 	 * Referred to as "review" on-wiki
 	 *
-	 * Will, by it's nature, mark as patrolled as well.
+	 * Will, by it's nature, mark as patrolled as well. Falls back to
+	 * patrolling if not in an appropriate namespace.
 	 *
 	 * Doesn't inherently rely on loading the page in question; simply
 	 * passing a pageid to the API is sufficient, so in those cases just
@@ -2685,20 +2687,25 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	 * No error handling since we don't actually care about the errors
 	 */
 	this.triage = function() {
-		if (!Morebits.userIsSysop && !Morebits.userIsInGroup('patroller')) {
-			return;
-		}
-
-		// If on the page in question, don't need to query for page ID
-		if (new mw.Title(Morebits.pageNameNorm).getPrefixedText() === new mw.Title(ctx.pageName).getPrefixedText()) {
-			ctx.pageID = mw.config.get('wgArticleId');
-			fnProcessTriage(this, this);
+		// Fall back to patrol if not a valid triage namespace
+		if (mw.config.get('pageTriageNamespaces').indexOf(mw.config.get('wgNamespaceNumber')) === -1) {
+			this.patrol();
 		} else {
-			var query = fnNeedTokenInfoQuery('triage');
+			if (!Morebits.userIsSysop && !Morebits.userIsInGroup('patroller')) {
+				return;
+			}
 
-			ctx.triageApi = new Morebits.wiki.api('retrieving token...', query, fnProcessTriage);
-			ctx.triageApi.setParent(this);
-			ctx.triageApi.post();
+			// If on the page in question, don't need to query for page ID
+			if (new mw.Title(Morebits.pageNameNorm).getPrefixedText() === new mw.Title(ctx.pageName).getPrefixedText()) {
+				ctx.pageID = mw.config.get('wgArticleId');
+				fnProcessTriage(this, this);
+			} else {
+				var query = fnNeedTokenInfoQuery('triage');
+
+				ctx.triageApi = new Morebits.wiki.api('retrieving token...', query, fnProcessTriage);
+				ctx.triageApi.setParent(this);
+				ctx.triageApi.post();
+			}
 		}
 	};
 
@@ -3281,11 +3288,13 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		if (ctx.rcid) {
 			query.rcid = ctx.rcid;
 			query.token = mw.user.tokens.get('patrolToken');
-		} else if (ctx.revid) {
-			query.revid = ctx.revid;
-			query.token = mw.user.tokens.get('patrolToken');
 		} else {
 			var xml = ctx.patrolApi.getResponse();
+
+			// Don't patrol if not unpatrolled
+			if ($(xml).find('rc').attr('unpatrolled') !== '') {
+				return;
+			}
 
 			var lastrevid = $(xml).find('page').attr('lastrevid');
 			if (!lastrevid) {
@@ -3337,9 +3346,17 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		var triageStat = new Morebits.status('Marking page as curated');
 
-		ctx.triageProcessApi = new Morebits.wiki.api('curating page...', query, null, triageStat);
+		ctx.triageProcessApi = new Morebits.wiki.api('curating page...', query, null, triageStat, fnProcessTriageError);
 		ctx.triageProcessApi.setParent(this);
 		ctx.triageProcessApi.post();
+	};
+
+	// callback from triageProcessApi.post()
+	var fnProcessTriageError = function() {
+		// Ignore error if page not in queue, see https://github.com/azatoth/twinkle/pull/930
+		if (ctx.triageProcessApi.getErrorCode() === 'bad-pagetriage-page') {
+			ctx.triageProcessApi.getStatusElement().unlink();
+		}
 	};
 
 	var fnProcessDelete = function() {


### PR DESCRIPTION
Fallout from #917, in particular with the `triage` action.

`triage`: When AfD-ing an article that was already reviewed, Twinkle would throw a scary bold error saying that the article wasn't in the queue.  Which, of course, is true, <s>so we should check first.  There's an order-of-operations annoyance here, since `pagetriagelist` and `pagetriageaction` both require `pageid`, so we *have* to query for that first.  Basically, this introduces `triageProcessListApi` as an intermediary to check if the page is uncurated.</s>

We could check the API each time to see if the apge is uncurated (e.g. introduce `triageProcessListApi` as an intermediary), but there's an order-of-operations annoyance there, since `pagetriagelist` and `pagetriageaction` both require `pageid`, so we would *have* to query for that first and wait.  Instead, this just ignores the specific error (`bad-pagetriage-page`); it will still output a note in the console, but should be faster/smoother on the user end.

`patrol`: Doesn't throw up an error, but just notes the action as successfully done.  We can query the `recentchanges` list in the same query wherein we get a token/etc., although doing so removes the option for a query-less patrol action when we're on the page but the rcid link isn't available, e.g. history.