### PR TITLE
arv: Update SPI tooltips

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -247,20 +247,20 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				type: 'textarea',
 				label: 'Evidence:',
 				name: 'evidence',
-				tooltip: 'Enter your evidence. It should make clear that each of these users is likely to be abusing multiple accounts. Usually this means diffs, page histories or other information that justifies why the users are a) the same and b) disruptive. This should purely be evidence and information needed to judge the matter. Avoid all other discussion that is not evidence of sockpuppetry or other multiple account abuse.'
+				tooltip: 'Your evidence should make it clear that each of these users is likely to be abusing multiple accounts. Usually this means diffs, page histories or other information that justifies why the users are a) the same and b) disruptive. This should purely be evidence and information needed to judge the matter. Avoid all other discussion that is not evidence of sockpuppetry.'
 			});
 			work_area.append({
 				type: 'checkbox',
 				list: [
 					{
-						label: 'Request CheckUser evidence',
+						label: 'Request CheckUser',
 						name: 'checkuser',
-						tooltip: 'CheckUser is a tool used to obtain technical evidence related to a sock-puppetry allegation. It will not be used without good cause, which you must clearly demonstrate. Make sure your evidence explains why CheckUser is appropriate.'
+						tooltip: 'CheckUser is a tool used to obtain technical evidence related to a sockpuppetry allegation. It will not be used without good cause, which you must clearly demonstrate. Make sure your evidence explains why using the tool is appropriate. It is only used to connect user accounts and not IP addresses.'
 					},
 					{
 						label: 'Notify reported users',
 						name: 'notify',
-						tooltip: 'Notification is not mandatory. In many cases, especially of chronic sockpuppeteers, notification may be counterproductive. However, especially in less egregious cases involving users who has not been reported before, notification may make the cases fairer and also appear to be fairer in the eyes of the accused. Use your judgment.'
+						tooltip: 'Notification is not mandatory. In many cases, especially of chronic sockpuppeteers, notification may be counterproductive. However, especially in less egregious cases involving users who have not been reported before, notification may make the cases fairer and also appear to be fairer in the eyes of the accused. Use your judgement.'
 					}
 				]
 			});
@@ -286,18 +286,18 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				type: 'textarea',
 				label: 'Evidence:',
 				name: 'evidence',
-				tooltip: 'Enter your evidence. It should make clear that each of these users is likely to be abusing multiple accounts. Usually this means diffs, page histories or other information that justifies why the users are a) the same and b) disruptive. This should purely be evidence and information needed to judge the matter. Avoid all other discussion that is not evidence of sockpuppetry or other multiple account abuse.'
+				tooltip: 'Your evidence should make it clear that each of these users is likely to be abusing multiple accounts. Usually this means diffs, page histories or other information that justifies why the users are a) the same and b) disruptive. This should purely be evidence and information needed to judge the matter. Avoid all other discussion that is not evidence of sockpuppetry.'
 			});
 			work_area.append({
 				type: 'checkbox',
 				list: [ {
-					label: 'Request CheckUser evidence',
+					label: 'Request CheckUser',
 					name: 'checkuser',
-					tooltip: 'CheckUser is a tool used to obtain technical evidence related to a sock-puppetry allegation. It will not be used without good cause, which you must clearly demonstrate. Make sure your evidence explains why CheckUser is appropriate.'
+					tooltip: 'CheckUser is a tool used to obtain technical evidence related to a sockpuppetry allegation. It will not be used without good cause, which you must clearly demonstrate. Make sure your evidence explains why using the tool is appropriate. It is only used to connect user accounts and not IP addresses.'
 				}, {
 					label: 'Notify reported users',
 					name: 'notify',
-					tooltip: 'Notification is not mandatory. In many cases, especially of chronic sockpuppeteers, notification may be counterproductive. However, especially in less egregious cases involving users who has not been reported before, notification may make the cases fairer and also appear to be fairer in the eyes of the accused. Use your judgment.'
+					tooltip: 'Notification is not mandatory. In many cases, especially of chronic sockpuppeteers, notification may be counterproductive. However, especially in less egregious cases involving users who have not been reported before, notification may make the cases fairer and also appear to be fairer in the eyes of the accused. Use your judgement.'
 				} ]
 			});
 			work_area = work_area.render();


### PR DESCRIPTION
Mostly to add "It is only used to connect user accounts and not IP addresses," given the frequency of requests we encounter relating to this. Rest are grammar/wording fixes.