### PR TITLE
morebits: Fix date parsing for Firefox 75

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1362,13 +1362,12 @@ Date.prototype.getUTCMonthNameAbbrev = function() {
 Morebits.date = function() {
 	var args = Array.prototype.slice.call(arguments);
 
-	this._d = new (Function.prototype.bind.apply(Date, [Date].concat(args)));
-
-	if (isNaN(this._d.getTime()) && typeof args[0] === 'string') {
-		// Try again after removing a comma and paren-wrapped timezone, to get MediaWiki timestamps to parse
-		this._d = new (Function.prototype.bind.call(Date, Date, args[0].replace(/(\d\d:\d\d),/, '$1').replace(/\(UTC\)/, 'UTC')));
+	if (typeof args[0] === 'string') {
+		// Attempt to remove a comma and paren-wrapped timezone, to get MediaWiki timestamps to parse
+		// Firefox (at least in 75) seems to be okay with the comma, though
+		args[0] = args[0].replace(/(\d\d:\d\d),/, '$1').replace(/\(UTC\)/, 'UTC');
 	}
-
+	this._d = new (Function.prototype.bind.apply(Date, [Date].concat(args)));
 };
 
 Morebits.date.localeData = {


### PR DESCRIPTION
See https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=954707038

As noted in #921, mediawiki on enwiki uses dates formatted like `19:37, 3 May 2020 (UTC)`, which is an invalid date for two reasons. The first is that (UTC±offset) isn't correct for a timezone, and the native Date converts it to a local date; that is, 17:00 (UTC) become 17:00 (local). The second is that the comma after the time is just plain wrong. Twinkle's new date function handles both of those, except that apparently Firefox 75 will actually now accept the comma as valid. Thus, Firefox was short-circuiting our initial check to see if we had a valid date, before we could clean up mediawiki's parenthesis crap, which was leading to local timezone issues.