### PR TITLE
friendlywelcome:  Add welcome-retro

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -233,6 +233,11 @@ Twinkle.welcome.templates = {
 				linkedArticle: true,
 				syntax: '{{subst:welcome|$USERNAME$|art=$ARTICLE$}} ~~~~'
 			},
+			'welcome-retro': {
+				description: 'a welcome message with a small list of helpful links',
+				linkedArticle: true,
+				syntax: '{{subst:welcome-retro|$USERNAME$|art=$ARTICLE$}} ~~~~'
+			},
 			'welcome-short': {
 				description: 'a shorter welcome message',
 				syntax: '{{subst:welcome-short|$USERNAME$}} $EXTRA$ ~~~~'


### PR DESCRIPTION
Add the option to use the {{Welcome-retro}} instead of {{Welcome}} since the welcome template was changed recently to exclude several links and to use buttons instead of the list of links.