### PR TITLE
fluff: fix two ancient bugs: typo and type

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -284,11 +284,11 @@ Twinkle.fluff.callbacks = {
 			var touched = $(xmlDoc).find('page').attr('touched');
 			var loadtimestamp = $(xmlDoc).find('api').attr('curtimestamp');
 			var csrftoken = $(xmlDoc).find('tokens').attr('csrftoken');
-			var revertToRevID = $(xmlDoc).find('rev').attr('revid');
+			var revertToRevID = parseInt($(xmlDoc).find('rev').attr('revid'), 10);
 			var revertToUser = $(xmlDoc).find('rev').attr('user');
 
 			if (revertToRevID !== self.params.rev) {
-				self.statitem.error('The retrieved revision does not match the requested revision. Stopping revert.');
+				self.statelem.error('The retrieved revision does not match the requested revision. Stopping revert.');
 				return;
 			}
 


### PR DESCRIPTION
- Typo: `statitem` -> `statelem`.  This stems back to 2011 (54347f92/98240d17), although there was another instance present from the initial import that was fixed later that year in be5d8ffe
- Type: `parseInt` `revid`.  Fix potential type issue treating `revid` as a string, missed in 37cd0c68 (2011)