### PR TITLE
fluff: Add rollback links to Special:Recentchanges and history pages

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -395,13 +395,13 @@ Twinkle.config.sections = [
 
 			// TwinkleConfig.showRollbackLinks (array)
 			// Where Twinkle should show rollback links:
-			// diff, others, mine, contribs, recent
+			// diff, others, mine, contribs, history, recent
 			// Note from TTO: |contribs| seems to be equal to |others| + |mine|, i.e. redundant, so I left it out heres
 			{
 				name: 'showRollbackLinks',
 				label: 'Show rollback links on these pages',
 				type: 'set',
-				setValues: { diff: 'Diff pages', others: 'Contributions pages of other users', mine: 'My contributions page', recent: 'Recent changes and related changes special pages' }
+				setValues: { diff: 'Diff pages', others: 'Contributions pages of other users', mine: 'My contributions page', recent: 'Recent changes and related changes special pages', history: 'History pages' }
 			}
 		]
 	},

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -351,11 +351,11 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.openTalkPageOnAutoRevert (bool)
-			// Defines if talk page should be opened when calling revert from contrib page, because from there, actions may be multiple, and opening talk page not suitable. If set to true, openTalkPage defines then if talk page will be opened.
+			// Defines if talk page should be opened when calling revert from contribs or recent changes pages. If set to true, openTalkPage defines then if talk page will be opened.
 			{
 				name: 'openTalkPageOnAutoRevert',
-				label: 'Open user talk page when invoking rollback from user contributions',
-				helptip: "Often, you may be rolling back many pages at a time from a vandal's contributions page, so it would be unsuitable to open the user talk page. Hence, this option is off by default. When this is on, the desired options must be enabled in the previous setting for this to work.",
+				label: 'Open user talk page when invoking rollback from user contributions or recent changes',
+				helptip: 'When this is on, the desired options must be enabled in the previous setting for this to work.',
 				type: 'boolean'
 			},
 
@@ -394,13 +394,14 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.showRollbackLinks (array)
-			// Where Twinkle should show rollback links (diff, others, mine, contribs)
+			// Where Twinkle should show rollback links:
+			// diff, others, mine, contribs, recent
 			// Note from TTO: |contribs| seems to be equal to |others| + |mine|, i.e. redundant, so I left it out heres
 			{
 				name: 'showRollbackLinks',
 				label: 'Show rollback links on these pages',
 				type: 'set',
-				setValues: { diff: 'Diff pages', others: 'Contributions pages of other users', mine: 'My contributions page' }
+				setValues: { diff: 'Diff pages', others: 'Contributions pages of other users', mine: 'My contributions page', recent: 'Recent changes and related changes special pages' }
 			}
 		]
 	},

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -8,8 +8,9 @@
  ****************************************
  *** twinklefluff.js: Revert/rollback module
  ****************************************
- * Mode of invocation:     Links on history, contributions, and diff pages
- * Active on:              Diff pages, history pages, contributions pages
+ * Mode of invocation:     Links on contributions, recent changes, history, and diff pages
+ * Active on:              Diff pages, history pages, Special:RecentChanges(Linked),
+                           and Special:Contributions
  */
 
 /**
@@ -36,6 +37,14 @@ Twinkle.fluff = function twinklefluff() {
 		}
 	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Contributions') {
 		Twinkle.fluff.addLinks.contributions();
+	} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Recentchanges' || mw.config.get('wgCanonicalSpecialPageName') === 'Recentchangeslinked') {
+		// Reload with recent changes updates
+		// structuredChangeFilters.ui.initialized is just on load
+		mw.hook('wikipage.content').add(function(item) {
+			if (item.is('div')) {
+				Twinkle.fluff.addLinks.recentchanges();
+			}
+		});
 	} else if (mw.config.get('wgIsProbablyEditable')) {
 		// Only proceed if the user can actually edit the page
 		// in question (ignored for contributions, see #632).
@@ -132,6 +141,36 @@ Twinkle.fluff.addLinks = {
 					current.appendChild(tmpNode);
 				});
 			}
+		}
+	},
+
+	recentchanges: function() {
+		if (Twinkle.getPref('showRollbackLinks').indexOf('recent') !== -1) {
+			// Latest and revertable (not page creations, logs, categorizations, etc.)
+			var list = $('.mw-changeslist .mw-changeslist-last.mw-changeslist-src-mw-edit');
+			// Exclude top-level header if "group changes" preference is used
+			// and find only individual lines or nested lines
+			list = list.not('.mw-rcfilters-ui-highlights-enhanced-toplevel').find('.mw-changeslist-line-inner, td.mw-enhanced-rc-nested');
+
+			var revNode = document.createElement('strong');
+			var revLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
+			revNode.appendChild(revLink);
+
+			var revVandNode = document.createElement('strong');
+			var revVandLink = Twinkle.fluff.buildLink('Red', 'vandalism');
+			revVandNode.appendChild(revVandLink);
+
+			list.each(function(key, current) {
+				current.appendChild(document.createTextNode(' '));
+				var href = $(current).find('.mw-changeslist-diff').attr('href');
+				var tmpNode = revNode.cloneNode(true);
+				tmpNode.firstChild.setAttribute('href', href + '&twinklerevert=norm');
+				current.appendChild(tmpNode);
+				current.appendChild(document.createTextNode(' '));
+				tmpNode = revVandNode.cloneNode(true);
+				tmpNode.firstChild.setAttribute('href', href + '&twinklerevert=vand');
+				current.appendChild(tmpNode);
+			});
 		}
 	},
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -58,6 +58,8 @@ Twinkle.fluff = function twinklefluff() {
 			});
 		} else if (mw.config.get('wgAction') === 'view' && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId')) {
 			Twinkle.fluff.addLinks.oldid();
+		} else if (mw.config.get('wgAction') === 'history') {
+			Twinkle.fluff.addLinks.history();
 		}
 	}
 };
@@ -171,6 +173,74 @@ Twinkle.fluff.addLinks = {
 				tmpNode.firstChild.setAttribute('href', href + '&twinklerevert=vand');
 				current.appendChild(tmpNode);
 			});
+		}
+	},
+
+	history: function() {
+		if (Twinkle.getPref('showRollbackLinks').indexOf('history') !== -1) {
+			// All revs
+			var histList = $('#pagehistory li').toArray();
+
+			// On first page of results, so add revert/rollback
+			// links to the top revision
+			if (!$('.mw-firstlink').length) {
+				var first = histList.shift();
+				var vandal = first.querySelector('.mw-userlink').text;
+
+				var agfNode = document.createElement('strong');
+				var vandNode = document.createElement('strong');
+				var normNode = document.createElement('strong');
+
+				var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', 'rollback (AGF)');
+				var vandLink = Twinkle.fluff.buildLink('Red', 'rollback (VANDAL)');
+				var normLink = Twinkle.fluff.buildLink('SteelBlue', 'rollback');
+
+				agfLink.href = '#';
+				vandLink.href = '#';
+				normLink.href = '#';
+				$(agfLink).click(function() {
+					Twinkle.fluff.revert('agf', vandal);
+				});
+				$(vandLink).click(function() {
+					Twinkle.fluff.revert('vand', vandal);
+				});
+				$(normLink).click(function() {
+					Twinkle.fluff.revert('norm', vandal);
+				});
+
+				agfNode.appendChild(agfLink);
+				vandNode.appendChild(vandLink);
+				normNode.appendChild(normLink);
+
+				first.appendChild(document.createTextNode(' '));
+				first.appendChild(agfNode);
+				first.appendChild(document.createTextNode(' '));
+				first.appendChild(normNode);
+				first.appendChild(document.createTextNode(' '));
+				first.appendChild(vandNode);
+			}
+
+			// oldid
+			histList.forEach(function(rev) {
+				// From restoreThisRevision, non-transferable
+
+				var href = rev.querySelector('.mw-changeslist-date').href;
+				var oldid = parseInt(mw.util.getParamValue('oldid', href), 10);
+
+				var revertToRevisionNode = document.createElement('strong');
+				var revertToRevisionLink = Twinkle.fluff.buildLink('SaddleBrown', 'restore this version');
+
+				revertToRevisionLink.href = '#';
+				$(revertToRevisionLink).click(function() {
+					Twinkle.fluff.revertToRevision(oldid.toString());
+				});
+				revertToRevisionNode.appendChild(revertToRevisionLink);
+
+				rev.appendChild(document.createTextNode(' '));
+				rev.appendChild(revertToRevisionNode);
+			});
+
+
 		}
 	},
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -88,7 +88,7 @@ Twinkle.fluff.restoreThisRevision = function (element, revType) {
 
 
 Twinkle.fluff.auto = function twinklefluffauto() {
-	if (parseInt(mw.util.getParamValue('oldid'), 10) !== mw.config.get('wgCurRevisionId')) {
+	if (parseInt(mw.util.getParamValue('oldid', $('#mw-diff-ntitle1 a:first').attr('href')), 10) !== mw.config.get('wgCurRevisionId')) {
 		// not latest revision
 		alert("Can't rollback, page has changed in the meantime.");
 		return;

--- a/twinkle.js
+++ b/twinkle.js
@@ -423,7 +423,7 @@ $.ajax({
 Twinkle.load = function () {
 	// Don't activate on special pages other than those on the whitelist so that
 	// they load faster, especially the watchlist.
-	var specialPageWhitelist = [ 'Block', 'Contributions' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+	var specialPageWhitelist = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
 	if (Morebits.userIsSysop) {
 		specialPageWhitelist = specialPageWhitelist.concat([ 'DeletedContributions', 'Prefixindex' ]);
 	}


### PR DESCRIPTION
Both off by default; these commits can be squashed, but are separate for perusal.

**1st commit:** Use the provided diff url to get oldid.  Avoids issues with arcane diffs urls, and with urls on recent changes where oldid/curid/diff are each provided, and oddly besides.

(this is just a setup necessary for the next commit, doesn't necessarily stand out in the diff)

**2nd commit:** Add ability to enable rollback links on Recentchanges(linked)

Adds new `recent` option, off by default.  Most of the complexity in the selectors comes from having to handle two preferences: using the new or old (no js) RC system, and the grouped or ungrouped preference.  Uses the `wikipage.content` hook to (re)generate links when new diffs are loaded.

Also expands `openTalkPageOnAutoRevert` to apply at RC/RCL, just like with contribs.  The text for that has been tweaked as well, as it was a misleading description around behavior for contributions pages.  The language stemmed from 0746c05 in 2011, but it wasn't an accurate description of how this preference is helpful.  It *does* define whether the user talk page is opened, but it doesn't help do multiple things on the contributions page, because a single revert will still redirect you away from the contributions page (and now recent changes).

**3rd commit:** Add links to history pages, off by default

----

One thing to note is that RC/RCL can be comparatively slow loading pages (albeit faster than the watchlist).  With Twinkle loading on them, that means they'll be even slower, and no other modules are active there.  In my testing it's not so bad, especially not compared to the new/fancy/slow JS on the page itself, but one thing we could do is introduce a non-standard check of the pref in twinkle.js so that recent changes isn't slowed down:

```js
if (Twinkle.getPref('showRollbackLinks').indexOf('recent') !== -1) {
        specialPageWhitelist = specialPageWhitelist.concat([ 'Recentchanges', Recentchangeslinked' ]);
}
```

Not sure it's net-positive in the broader picture, but wanted to put it out there.