### PR TITLE
add script for easily creating localhost test loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ stash*.txt
 stash*.diff
 *.jsX
 .vscode/
+patch-test-loader.js
 
 # Windows
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "azatoth/twinkle",
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "patchtest": "node patch-test.js"
   },
   "devDependencies": {
     "eslint": "7.2.0",

--- a/patch-test.js
+++ b/patch-test.js
@@ -1,0 +1,90 @@
+/* eslint-env node, es6 */
+/* eslint-disable no-console */
+/* eslint-disable es5/no-destructuring */
+/* eslint-disable es5/no-template-literals */
+/* eslint-disable es5/no-es6-methods */
+/* eslint-disable es5/no-shorthand-properties */
+/* eslint-disable es5/no-block-scoping */
+
+/**
+ * Creates a file patch-test-loader.js with the necessary import statements
+ * to test the changes made in a pull request or in the current working state
+ *
+ * How to use:
+ * - Run `npm run patchtest` which generates patch-test-loader.js
+ * - Set up a localhost server (such as by using server.js or by running
+ *   php -S localhost:5500) and load patch-test-loader.js in the wiki environment,
+ *   using the browser console or the common.js page.
+ */
+
+const fs = require('fs');
+const {execSync} = require('child_process');
+
+const server = 'http://127.0.0.1:5500';
+
+// find the last common commit between this branch and master, and get the list
+// of files changed since that commit
+try {
+	var stdout = execSync('git diff $(git merge-base $(git rev-parse --abbrev-ref HEAD) master) --name-only').toString();
+	let changedFiles = stdout.split(/\r?\n/);
+	createTestLoader(changedFiles);
+} catch (err) {
+	console.log(err.toString());
+}
+
+/** @param {string[]} changedFiles */
+function createTestLoader(changedFiles) {
+
+	let importsCount = 0; // for the message written to the console in the ends
+	let importLine = function(file) {
+		if (!changedFiles.includes(file)) {
+			return '';
+		}
+		if (file.endsWith('.js')) {
+			importsCount++;
+			if (file.startsWith('modules/')) {
+				return `mw.loader.getScript('${server}/${file}');`;
+			}
+			return `return mw.loader.getScript('${server}/${file}');`;
+		} else if (file.endsWith('.css')) {
+			importsCount++;
+			return `mw.loader.load('${server}/${file}', 'text/css');`;
+		}
+	};
+
+	let jsLoaderSource = `// Wait for Twinkle gadget to load, so that we can then overwrite it
+	mw.loader.using('ext.gadget.Twinkle').then(function() {
+		${importLine('morebits.css')}
+		${importLine('morebits.js')}
+
+	}).then(function() {
+		${importLine('twinkle.css')}
+		${importLine('twinkle.js')}
+
+	}).then(function() {
+		${importLine('modules/friendlyshared.js')}
+		${importLine('modules/friendlytag.js')}
+		${importLine('modules/friendlytalkback.js')}
+		${importLine('modules/friendlywelcome.js')}
+		${importLine('modules/twinklearv.js')}
+		${importLine('modules/twinklebatchdelete.js')}
+		${importLine('modules/twinklebatchprotect.js')}
+		${importLine('modules/twinklebatchundelete.js')}
+		${importLine('modules/twinkleblock.js')}
+		${importLine('modules/twinkleconfig.js')}
+		${importLine('modules/twinkledeprod.js')}
+		${importLine('modules/twinklediff.js')}
+		${importLine('modules/twinklefluff.js')}
+		${importLine('modules/twinkleimage.js')}
+		${importLine('modules/twinkleprod.js')}
+		${importLine('modules/twinkleprotect.js')}
+		${importLine('modules/twinklespeedy.js')}
+		${importLine('modules/twinkleunlink.js')}
+		${importLine('modules/twinklewarn.js')}
+		${importLine('modules/twinklexfd.js')}
+	});`.replace(/^\t/mg, '').replace(/^\s*$/mg, '');
+
+	fs.writeFileSync('./patch-test-loader.js', jsLoaderSource, console.log);
+
+	console.log(`Wrote import statements for ${importsCount} modified file${importsCount > 1 ? 's' : ''} to patch-test-loader.js`);
+}


### PR DESCRIPTION
Script for automatically generating localhost test file configuration, coz I'm fed up of messing it up while doing it manually...

If you have permanently set up patch-test-loader.js to load up in the wiki (eg. I do that by permanently loading 127.0.0.1:5500/local.js from my common.js. When the server is turned on - using a switch in VS code, local.js in turn loads patch-test-loader.js), then you all you need to do to test the current branch is to run `npm run patchtest`, and switch on the server (root dir: twinkle, host: 127.0.0.1, port: 5500). One way to do that easily is to use `server.js` (`npm run server`) after PR #911 is merged.