### PR TITLE
Decentralise module initialisations

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,7 +17,7 @@ There are two ways to upload Twinkle scripts to Wikipedia or another destination
 
 After the files are synced, ensure that [MediaWiki:Gadgets-definition][] contains the following lines:
 
-    * Twinkle[ResourceLoader|dependencies=ext.gadget.morebits,ext.gadget.select2,mediawiki.api,mediawiki.language|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|Twinkle.js|twinkleprod.js|twinkleimage.js|twinklebatchundelete.js|twinklewarn.js|twinklespeedy.js|friendlyshared.js|twinklediff.js|twinkleunlink.js|friendlytag.js|twinkledeprod.js|friendlywelcome.js|twinklexfd.js|twinklebatchdelete.js|twinklebatchprotect.js|twinkleconfig.js|twinklefluff.js|twinkleprotect.js|twinklearv.js|twinkleblock.js|friendlytalkback.js|Twinkle.css
+    * Twinkle[ResourceLoader|dependencies=ext.gadget.morebits,ext.gadget.select2,mediawiki.api,mediawiki.language|rights=autoconfirmed|type=general|peers=Twinkle-pagestyles]|Twinkle.js|Twinkle.css|twinklearv.js|twinklewarn.js|twinkleblock.js|friendlywelcome.js|friendlyshared.js|friendlytalkback.js|twinklespeedy.js|twinkleprod.js|twinklexfd.js|twinkleimage.js|twinkleprotect.js|friendlytag.js|twinklediff.js|twinkleunlink.js|twinklefluff.js|twinkledeprod.js|twinklebatchdelete.js|twinklebatchprotect.js|twinklebatchundelete.js|twinkleconfig.js
     * morebits[ResourceLoader|dependencies=mediawiki.user,mediawiki.util,mediawiki.Title,jquery.ui,jquery.tipsy|hidden]|morebits.js|morebits.css
     * Twinkle-pagestyles[hidden|skins=vector]|Twinkle-pagestyles.css
     * select2[ResourceLoader|hidden]|select2.min.js|select2.min.css

--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -20,6 +20,7 @@ Twinkle.shared = function friendlyshared() {
 		}, 'Shared IP', 'friendly-shared', 'Shared IP tagging');
 	}
 };
+Twinkle.addInitCallback(Twinkle.shared, 'shared');
 
 Twinkle.shared.callback = function friendlysharedCallback() {
 	var Window = new Morebits.simpleWindow(600, 420);

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -32,6 +32,7 @@ Twinkle.tag = function friendlytag() {
 		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add or remove article maintenance tags');
 	}
 };
+Twinkle.addInitCallback(Twinkle.tag, 'tag');
 
 Twinkle.tag.checkedTags = [];
 

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -21,6 +21,7 @@ Twinkle.talkback = function() {
 
 	Twinkle.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
 };
+Twinkle.addInitCallback(Twinkle.talkback, 'talkback');
 
 Twinkle.talkback.callback = function() {
 	if (mw.config.get('wgRelevantUserName') === mw.config.get('wgUserName') && !confirm("Is it really so bad that you're talking back to yourself?")) {

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -24,6 +24,7 @@ Twinkle.welcome = function friendlywelcome() {
 		Twinkle.welcome.normal();
 	}
 };
+Twinkle.addInitCallback(Twinkle.welcome, 'welcome');
 
 Twinkle.welcome.auto = function() {
 	if (mw.util.getParamValue('action') !== 'edit') {

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -24,6 +24,7 @@ Twinkle.arv = function twinklearv() {
 		Twinkle.arv.callback(username);
 	}, 'ARV', 'tw-arv', title);
 };
+Twinkle.addInitCallback(Twinkle.arv, 'arv');
 
 Twinkle.arv.callback = function (uid) {
 	var Window = new Morebits.simpleWindow(600, 500);

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -22,6 +22,7 @@ Twinkle.batchdelete = function twinklebatchdelete() {
 		Twinkle.addPortletLink(Twinkle.batchdelete.callback, 'D-batch', 'tw-batch', 'Delete pages found in this category/on this page');
 	}
 };
+Twinkle.addInitCallback(Twinkle.batchdelete, 'batchdelete');
 
 Twinkle.batchdelete.unlinkCache = {};
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -21,6 +21,7 @@ Twinkle.batchprotect = function twinklebatchprotect() {
 		Twinkle.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');
 	}
 };
+Twinkle.addInitCallback(Twinkle.batchprotect, 'batchprotect');
 
 Twinkle.batchprotect.unlinkCache = {};
 Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -21,6 +21,7 @@ Twinkle.batchundelete = function twinklebatchundelete() {
 	}
 	Twinkle.addPortletLink(Twinkle.batchundelete.callback, 'Und-batch', 'tw-batch-undel', "Undelete 'em all");
 };
+Twinkle.addInitCallback(Twinkle.batchundelete, 'batchundelete');
 
 Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 	var Window = new Morebits.simpleWindow(600, 400);

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -21,6 +21,7 @@ Twinkle.block = function twinkleblock() {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };
+Twinkle.addInitCallback(Twinkle.block, 'block');
 
 Twinkle.block.callback = function twinkleblockCallback() {
 	if (mw.config.get('wgRelevantUserName') === mw.config.get('wgUserName') &&

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1320,6 +1320,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 		}
 	}
 };
+Twinkle.addInitCallback(Twinkle.config.init);
 
 // custom list-related stuff
 

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -22,6 +22,7 @@ Twinkle.deprod = function() {
 	}
 	Twinkle.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
 };
+Twinkle.addInitCallback(Twinkle.deprod, 'deprod');
 
 var concerns = {};
 

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -31,6 +31,7 @@ Twinkle.diff = function twinklediff() {
 		Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: oldid}), 'Current', 'tw-curdiff', 'Show difference to current revision');
 	}
 };
+Twinkle.addInitCallback(Twinkle.diff, 'diff');
 
 Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -52,6 +52,8 @@ Twinkle.fluff = function twinklefluff() {
 	}
 };
 
+Twinkle.addInitCallback(Twinkle.fluff, 'fluff');
+
 // A list of usernames, usually only bots, that vandalism revert is jumped
 // over; that is, if vandalism revert was chosen on such username, then its
 // target is on the revision before.  This is for handling quick bots that

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -17,6 +17,7 @@ Twinkle.image = function twinkleimage() {
 		Twinkle.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
 	}
 };
+Twinkle.addInitCallback(Twinkle.image, 'image');
 
 Twinkle.image.callback = function twinkleimageCallback() {
 	var Window = new Morebits.simpleWindow(600, 330);

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -21,6 +21,7 @@ Twinkle.prod = function twinkleprod() {
 
 	Twinkle.addPortletLink(Twinkle.prod.callback, 'PROD', 'tw-prod', 'Propose deletion via WP:PROD');
 };
+Twinkle.addInitCallback(Twinkle.prod, 'prod');
 
 // Used in edit summaries, for comparisons, etc.
 var namespace;

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -22,6 +22,7 @@ Twinkle.protect = function twinkleprotect() {
 	Twinkle.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
 		Morebits.userIsSysop ? 'Protect page' : 'Request page protection');
 };
+Twinkle.addInitCallback(Twinkle.protect, 'protect');
 
 Twinkle.protect.callback = function twinkleprotectCallback() {
 	var Window = new Morebits.simpleWindow(620, 530);

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -28,6 +28,7 @@ Twinkle.speedy = function twinklespeedy() {
 
 	Twinkle.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
 };
+Twinkle.addInitCallback(Twinkle.speedy, 'speedy');
 
 // This function is run when the CSD tab/header link is clicked
 Twinkle.speedy.callback = function twinklespeedyCallback() {

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -20,6 +20,7 @@ Twinkle.unlink = function twinkleunlink() {
 	}
 	Twinkle.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');
 };
+Twinkle.addInitCallback(Twinkle.unlink, 'unlink');
 
 // the parameter is used when invoking unlink from admin speedy
 Twinkle.unlink.callback = function(presetReason) {

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -45,6 +45,7 @@ Twinkle.warn = function twinklewarn() {
 		}
 	}
 };
+Twinkle.addInitCallback(Twinkle.warn, 'warn');
 
 // Used to close window when switching to ARV in autolevel
 Twinkle.warn.dialog = null;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -23,6 +23,7 @@ Twinkle.xfd = function twinklexfd() {
 
 	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a deletion discussion');
 };
+Twinkle.addInitCallback(Twinkle.xfd, 'xfd');
 
 Twinkle.xfd.num2order = function twinklexfdNum2order(num) {
 	switch (num) {


### PR DESCRIPTION
Initialise the modules from the module files' themselves rather than centrally from twinkle.js. Doing it this way makes testing of twinkle.js and of custom Twinkle installations (like on other wikis) less cumbersome as one no longer needs to comment out or modify the initialisation lines in twinkle.js (as mentioned [here](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_42#How_to_use_as_a_user_script?) and [here](https://github.com/azatoth/twinkle/pull/462#issuecomment-462495588)). This also fixes the issue https://github.com/azatoth/twinkle/pull/944#issuecomment-627359133 allowing for automated setup for a test file for changes that affect twinkle.js.

To do this, we re-purpose Twinkle.addInitCallback() function ~~(presently unused anywhere within TW or from user scripts), such that it takes (part of) the name of the function (rather than the function itself)~~ <ins>such that it takes the name of the function as well</ins> - so that we can check if the module was disabled. twinkleconfig and any "custom modules" (usually none) can't be disabled, so will always be loaded.

The order in which the menu buttons appear is still within our control through MediaWiki:Gadgets-definition - the files are executed in the order in which they appear in the gadget definition line. **The gadget definition on-wiki will need to be tweaked as done in DEVELOPER.md file.**