### PR TITLE
fluff: Unify link creation functions, add rollbackInPlace option for Contribs/RC

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -359,6 +359,15 @@ Twinkle.config.sections = [
 				type: 'boolean'
 			},
 
+			// TwinkleConfig.rollbackInPlace (bool)
+			//
+			{
+				name: 'rollbackInPlace',
+				label: "Don't reload the page when rolling back from contributions or recent changes",
+				helptip: "When this is on, Twinkle won't reload the contributions or recent changes feed after reverting, allowing you to revert more than one edit at a time.",
+				type: 'boolean'
+			},
+
 			// TwinkleConfig.markRevertedPagesAsMinor (array)
 			// What types of actions that should result in marking edit as minor
 			{

--- a/twinkle.js
+++ b/twinkle.js
@@ -63,6 +63,7 @@ Twinkle.defaultConfig = {
 	autoMenuAfterRollback: false,
 	openTalkPage: [ 'agf', 'norm', 'vand' ],
 	openTalkPageOnAutoRevert: false,
+	rollbackInPlace: false,
 	markRevertedPagesAsMinor: [ 'vand' ],
 	watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
 	offerReasonOnNormalRevert: true,


### PR DESCRIPTION
The first three commits are mostly (but not entirely!) structural changes and can be squashed to a degree, but are presented separately for clarity in diffs and testing.

----

**1st commit:** Consolidate and genericize link creation functions

- two links (`rollback vandalism`): Multiple pages present, inline span, makes use of the `twinklerevert` parameter for `Twinkle.fluff.auto()` (contribs, recent)
- three links (`rollback (AGF) || rollback || rollback (VANDAL)`): Only one page present, inline span or div, makes use of `Twinkle.fluff.revert` (diffs, history)
- `restoreThisRevision`: Inline span or div.  Also simplifies `toRevision` in `Twinkle.fluff.callback`, which was unnecessarily nested as the only member of the object (leftover cruft from 98240d1 in 2011).

This commit (specifically, removal of `toString`) is what was causing me grief in #941/16e077b.

**2nd commit:** Restructure twinklerevert links to use `Twinkle.fluff.revert`, remove `auto` function

As far as I can tell, all the desired information is already available, thanks to some classes, so there should be no need to unnecessarily load a page.  The revert query itself should be able to handle the case where someone else has edited the page, so we don't really need the `auto` behavior now that we have the information ready.  The other loss is handling of pages that fail `wgIsProbablyEditable`, but this is manageable by making use of `intestactions=edit` (see also #632 and #658).  By not relying on auto-processing `twinklerevert` urls, we can prevent malicious providing of a link with `&twinklerevert=vand` to entice someone to revert something.  Low-profile, and I've never heard of it, but possible.

Given the above, `autorevert` has been removed in favor of a `skipTalk` item modified on contribs and recent changes to more appropriately represent what `openTalkPageOnAutoRevert` does.  That config is unfortunately named, but isn't visible so shouldn't be an issue beyond maintenance.

**3rd commit:** Restructure to use one function for rollback links

Not strictly necessary but it's clearer to not separate functions because of largely artificial differences.  Converts one function with 3 parameters and another with 2 to one with 2-4 parameters.

NB: This changes the new links on history pages (#942) from three to two rollback links, as all inline links are now done as pairs rather than triplets (the latter now only showing up on diffs).  Also renames the red vandalism link in the triplet/on diffs from `rollback (VANDAL)` to `vandalism`, matching behavior elsewhere and taking up less space overall.

**4th commit** Add rollbackInPlace pref to not reload contribs/RC after reversion, uses mw.notify

Would be quite helpful, in particular as it's the sort of behavior we should have been providing (noted in 7983d0f).  I don't want to set a precedent for using `mw.notify`, but it's a good idea here and works well.  Already-clicked links are disabled rather than removed.  MUCH faster.