### PR TITLE
fluff: Don't say reversion completed if there's no change

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -546,7 +546,7 @@ Twinkle.fluff.callbacks = {
 		if ($(xml).find('captcha').length > 0) {
 			apiobj.statelem.error('Could not rollback, because the wiki server wanted you to fill out a CAPTCHA.');
 		} else if ($edit.attr('nochange') === '') {
-			apiobj.statelem.warn('Revision we are reverting to is identical to current revision, stopping revert.');
+			apiobj.statelem.error('Revision we are reverting to is identical to current revision, stopping revert.');
 		} else {
 			apiobj.statelem.info('done');
 


### PR DESCRIPTION
The check was added in 9bf38bc3c and is fine, but using `statelem.warn` means the prior function continues and the `actionCompleted.notice` gets treated as successful, which is misleading.