### PR TITLE
block: Fix bug showing erroneous input box on a reblock form initialization

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -543,7 +543,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		}
 		Morebits.status.warn(statusStr, infoStr);
 		Twinkle.block.callback.update_form(e, Twinkle.block.currentBlockInfo);
-	} else if (templateBox) {
+	}
+	if (templateBox) {
 		// make sure all the fields are correct based on defaults
 		if (blockBox) {
 			Twinkle.block.callback.change_preset(e);


### PR DESCRIPTION
The `area` box would show on initialization if the user was already blocked, when it should only show iff the user is receiving a partial block template but *not* a block.  Changing the template or preset would kick the checks into action, but they weren't being processed on a reblock.  Original sin is from the initial adding of partial blocks in #813/61b5269.