### PR TITLE
xfd: Fix bug formatting whitespace match in MfD dateheader regex

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1087,7 +1087,7 @@ Twinkle.xfd.callbacks = {
 
 			var date = new Morebits.date(pageobj.getLoadTime());
 			var date_header = date.format('===MMMM D, YYYY===\n', 'utc');
-			var date_header_regex = new RegExp(date.format('(===\\s*MMMM\\s+D,\\s+YYYY\\s*===)', 'utc'));
+			var date_header_regex = new RegExp(date.format('(===[\\s]*MMMM[\\s]+D,[\\s]+YYYY[\\s]*===)', 'utc'));
 			var new_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
 
 			if (date_header_regex.test(text)) { // we have a section already


### PR DESCRIPTION
`\\s` in `Morebits.date().format` gets matched to seconds, resulting in the regex never matching the current date.  First reported at [WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=958390123#Twinkle_keeps_reposting_the_same_date_header_at_MfD)