### PR TITLE
warn: Restore uw-ewsoft after DRV

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1060,6 +1060,10 @@ Twinkle.warn.messages = {
 			label: 'Edit warring (stronger wording)',
 			summary: 'Warning: Edit warring'
 		},
+		'uw-ewsoft': {
+			label: 'Edit warring (softer wording for newcomers)',
+			summary: 'Warning: Edit warring'
+		},
 		'uw-hijacking': {
 			label: 'Hijacking articles',
 			summary: 'Warning: Hijacking articles'


### PR DESCRIPTION
This reverts commit b81d3958172f9d231811af7d886ed2fcd5fcaec6.

- Deleted at TfD 6 May: https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2020_April_29#Template:Uw-3rr-alt
- Relisted at DRV 20 May: https://en.wikipedia.org/wiki/Wikipedia:Deletion_review/Log/2020_May_11#Template:Uw-ewsoft
- Kept at TfD: https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2020_May_20#Template:Uw-ewsoft

Okay, it's not kept *yet*