### PR TITLE
morebits: Use background-color instead of a dataurl

### DIFF
--- a/morebits.css
+++ b/morebits.css
@@ -182,8 +182,8 @@ div.morebits-previewbox .mw-editsection
 .morebits-dialog {
 	border: 1px #666 solid;
 	font: small sans-serif;
-	background-color: #F0F8FF !important;
-	background-image: none !important;
+	background-color: #F0F8FF;
+	background-image: none;
 }
 
 body.skin-monobook .morebits-dialog {
@@ -192,10 +192,11 @@ body.skin-monobook .morebits-dialog {
 
 body .ui-dialog.morebits-dialog .ui-dialog-titlebar {
 	height: 1em;
-	background: repeat-x 50% 80% #cfd6e1 !important;  /* the actual image is specified in morebits.js - ResourceLoader mangles data: URIs in CSS */
+	background-color: #BCCADF;
+	background-image: none;
 	font: bold 1em sans-serif;
 	overflow: hidden;
-	padding: .4em .3em .5em !important;
+	padding: .4em .3em .5em;
 	white-space: nowrap;
 }
 
@@ -228,7 +229,7 @@ body .ui-dialog.morebits-dialog .ui-dialog-buttonpane {
 	background-color: #BCCADF;
 	margin: 0;
 	min-height: .5em;
-	padding-left: 1.2em !important;
+	padding-left: 1.2em;
 }
 
 body .ui-dialog.morebits-dialog .ui-dialog-buttonpane button {

--- a/morebits.js
+++ b/morebits.js
@@ -4512,11 +4512,6 @@ Morebits.simpleWindow = function SimpleWindow(width, height) {
 
 	var $widget = $(this.content).dialog('widget');
 
-	// add background gradient to titlebar
-	var $titlebar = $widget.find('.ui-dialog-titlebar');
-	var oldstyle = $titlebar.attr('style');
-	$titlebar.attr('style', (oldstyle ? oldstyle : '') + '; background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAkCAMAAAB%2FqqA%2BAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAEhQTFRFr73ZobTPusjdsMHZp7nVwtDhzNbnwM3fu8jdq7vUt8nbxtDkw9DhpbfSvMrfssPZqLvVztbno7bRrr7W1d%2Fs1N7qydXk0NjpkW7Q%2BgAAADVJREFUeNoMwgESQCAAAMGLkEIi%2FP%2BnbnbpdB59app5Vdg0sXAoMZCpGoFbK6ciuy6FX4ABAEyoAef0BXOXAAAAAElFTkSuQmCC) !important;');
-
 	// delete the placeholder button (it's only there so the buttonpane gets created)
 	$widget.find('button').each(function(key, value) {
 		value.parentNode.removeChild(value);


### PR DESCRIPTION
This stretches all the way back to 846b7277 and bc64fc34 (with a lot of intervening history), but it seems like an over-complication, especially if someone wanted to change the CSS.  In place of the data url, the same color as the footer (#BCCADF) is used, rather than previous fallback (cfd6e1).

Also removes some unnecessary `!important`s