### PR TITLE
speedy: Align A7 criteria labels with the actual criteria

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -696,49 +696,49 @@ Twinkle.speedy.articleList = [
 		}
 	},
 	{
-		label: 'A7: No indication of importance or significance (people, groups, companies, web content, individual animals, or organized events)',
+		label: 'A7: No indication of importance (people, groups, companies, web content, individual animals, or organized events)',
 		value: 'a7',
 		tooltip: 'An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenSingle: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (person)',
+		label: 'A7: No indication of importance (person)',
 		value: 'person',
 		tooltip: 'An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (musician(s) or band)',
+		label: 'A7: No indication of importance (musician(s) or band)',
 		value: 'band',
 		tooltip: 'Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (club, society or group)',
+		label: 'A7: No indication of importance (club, society or group)',
 		value: 'club',
 		tooltip: 'Article about a club, society or group that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (company or organization)',
+		label: 'A7: No indication of importance (company or organization)',
 		value: 'corp',
 		tooltip: 'Article about a company or organization that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (website or web content)',
+		label: 'A7: No indication of importance (website or web content)',
 		value: 'web',
 		tooltip: 'Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (individual animal)',
+		label: 'A7: No indication of importance (individual animal)',
 		value: 'animal',
 		tooltip: 'Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance (organized event)',
+		label: 'A7: No indication of importance (organized event)',
 		value: 'event',
 		tooltip: 'Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -696,49 +696,49 @@ Twinkle.speedy.articleList = [
 		}
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (people, groups, companies, web content, individual animals, or organized events)',
+		label: 'A7: No indication of importance or significance (people, groups, companies, web content, individual animals, or organized events)',
 		value: 'a7',
 		tooltip: 'An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenSingle: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (person)',
+		label: 'A7: No indication of importance or significance (person)',
 		value: 'person',
 		tooltip: 'An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (musician(s) or band)',
+		label: 'A7: No indication of importance or significance (musician(s) or band)',
 		value: 'band',
 		tooltip: 'Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (club, society or group)',
+		label: 'A7: No indication of importance or significance (club, society or group)',
 		value: 'club',
 		tooltip: 'Article about a club, society or group that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (company or organization)',
+		label: 'A7: No indication of importance or significance (company or organization)',
 		value: 'corp',
 		tooltip: 'Article about a company or organization that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (website or web content)',
+		label: 'A7: No indication of importance or significance (website or web content)',
 		value: 'web',
 		tooltip: 'Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (individual animal)',
+		label: 'A7: No indication of importance or significance (individual animal)',
 		value: 'animal',
 		tooltip: 'Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: No indication of importance or significance of subject (organized event)',
+		label: 'A7: No indication of importance or significance (organized event)',
 		value: 'event',
 		tooltip: 'Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -696,49 +696,49 @@ Twinkle.speedy.articleList = [
 		}
 	},
 	{
-		label: 'A7: Unremarkable people, groups, companies, web content, individual animals, or organized events',
+		label: 'A7: No indication of importance or significance of subject (people, groups, companies, web content, individual animals, or organized events)',
 		value: 'a7',
 		tooltip: 'An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenSingle: true
 	},
 	{
-		label: 'A7: Unremarkable person',
+		label: 'A7: No indication of importance or significance of subject (person)',
 		value: 'person',
 		tooltip: 'An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: Unremarkable musician(s) or band',
+		label: 'A7: No indication of importance or significance of subject (musician(s) or band)',
 		value: 'band',
 		tooltip: 'Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: Unremarkable club',
+		label: 'A7: No indication of importance or significance of subject (club, society or group)',
 		value: 'club',
-		tooltip: 'Article about a club that does not assert the importance or significance of the subject',
+		tooltip: 'Article about a club, society or group that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: Unremarkable company or organization',
+		label: 'A7: No indication of importance or significance of subject (company or organization)',
 		value: 'corp',
 		tooltip: 'Article about a company or organization that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: Unremarkable website or web content',
+		label: 'A7: No indication of importance or significance of subject (website or web content)',
 		value: 'web',
 		tooltip: 'Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: Unremarkable individual animal',
+		label: 'A7: No indication of importance or significance of subject (individual animal)',
 		value: 'animal',
 		tooltip: 'Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
-		label: 'A7: Unremarkable organized event',
+		label: 'A7: No indication of importance or significance of subject (organized event)',
 		value: 'event',
 		tooltip: 'Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true


### PR DESCRIPTION
CSD A7 "applies to any article about a [list of things omitted] that does not indicate why its subject is important or significant". However, currently Twinkle summarizes A7 as "Unremarkable", which isn't accurate -- there are plenty of unremarkable things that do not satisfy the very low bar of A7 (which "does not apply to any article that makes any credible claim of significance or importance even if the claim is not supported by a reliable source or does not qualify on Wikipedia's notability guidelines.")

I propose changing "Unremarkable" to "No indication of importance or significance of subject".