### PR TITLE
talkback: Add Template:EFFPReply

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -338,6 +338,11 @@ Twinkle.talkback.noticeboards = {
 		label: 'WP:OTRS/N (OTRS noticeboard)',
 		text: '{{OTRSreply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies at the [[Wikipedia:OTRS noticeboard|OTRS noticeboard]]'
+	},
+	'effp' {
+		label: 'WP:EFFP/R (Edit filter false positive report)',
+		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
+		editSummary: 'You have replies at the [[WP:EFFP/R|Edit filters false positive report]] page'
 	}
 };
 

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -339,7 +339,7 @@ Twinkle.talkback.noticeboards = {
 		text: '{{OTRSreply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies at the [[Wikipedia:OTRS noticeboard|OTRS noticeboard]]'
 	},
-	'effp' {
+	'effp': {
 		label: 'WP:EFFP/R (Edit filter false positive report)',
 		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies at the [[WP:EFFP/R|Edit filters false positive report]] page'

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -342,7 +342,7 @@ Twinkle.talkback.noticeboards = {
 	'effp': {
 		label: 'WP:EFFP/R (Edit filter false positive report)',
 		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
-		editSummary: 'You have replies at the [[WP:EFFP/R|Edit filters false positive report]] page'
+		editSummary: 'You have replies at the [[Wikipedia:Edit filter/False positives/Reports|Edit filters false positive report]] page'
 	}
 };
 

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -324,6 +324,11 @@ Twinkle.talkback.noticeboards = {
 		text: '{{subst:DRN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Dispute resolution noticeboard]]'
 	},
+	'effp': {
+		label: 'WP:EFFP/R (Edit filter false positive report)',
+		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
+		editSummary: 'You have replies to your [[Wikipedia:Edit filter/False positives/Reports|edit filter false positive report]]'
+	},
 	'hd': {
 		label: 'WP:HD (Help desk)',
 		text: '== Your question at the Help desk ==\n' + '{{helpdeskreply|1=$SECTION|ts=~~~~~}}',
@@ -338,11 +343,6 @@ Twinkle.talkback.noticeboards = {
 		label: 'WP:OTRS/N (OTRS noticeboard)',
 		text: '{{OTRSreply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies at the [[Wikipedia:OTRS noticeboard|OTRS noticeboard]]'
-	},
-	'effp': {
-		label: 'WP:EFFP/R (Edit filter false positive report)',
-		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
-		editSummary: 'You have replies at the [[Wikipedia:Edit filter/False positives/Reports|Edit filters false positive report]] page'
 	}
 };
 


### PR DESCRIPTION
Sometimes, I want to give talkback messages to IP users from [WP:EFFP/R](https://en.wikipedia.org/wiki/Wikipedia:Edit_filter/False_positives/Reports). I made [this template](https://en.wikipedia.org/wiki/Template:EFFPReply) for it, and would like to use it from Twinkle. Cheers, Michael (User:Mdaniels5757)