### PR TITLE
xfd: Link chosen delsort cats to their pages, expand tooltip

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -249,7 +249,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				multiple: true,
 				name: 'delsort',
 				label: 'Choose deletion sorting categories: ',
-				tooltip: 'Select a few categories that are relevant to the subject of the article'
+				tooltip: 'Select a few categories that are specifically relevant to the subject of the article. Be as precise as possible; categories like People and USA should only be used when no other categories apply.'
 			});
 
 			$.each(delsortCategories, function(groupname, list) {
@@ -271,6 +271,13 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 					templateResult: Morebits.select2.highlightSearchMatches,
 					language: {
 						searching: Morebits.select2.queryInterceptor
+					},
+					// Link text to the page itself
+					templateSelection: function(choice) {
+						return $('<a>').text(choice.text).attr({
+							href: mw.util.getUrl('Wikipedia:WikiProject_Deletion_sorting/' + choice.text),
+							target: '_blank'
+						});
 					}
 				});
 


### PR DESCRIPTION
The tooltip specifically notes two pages that are often misused, see discussion at [WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=961305268#Deletion_sorting_notice).