### PR TITLE
twinkle.js: Use HTML5 nav instead of div+role=navigation

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -287,8 +287,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	}
 
 	// Build the DOM elements.
-	var outerDiv = document.createElement('div');
-	outerDiv.setAttribute('role', 'navigation');
+	var outerDiv = document.createElement('nav');
 	outerDiv.setAttribute('aria-labelledby', id + '-label');
 	outerDiv.className = outerDivClass + ' emptyPortlet';
 	outerDiv.id = id;


### PR DESCRIPTION
This is all probably unnecessary, but change to match new Vector: https://phabricator.wikimedia.org/T66477 specifically https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/594819 (although (temporarily) reverted in https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/595627 and restored in https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/596312).  I've just gone and removed the `role`.

Of course, `outerDiv` is now poorly named.  Worth renaming all of this, or just busy work?  See also #962 for changes in the menu classes.