### PR TITLE
fluff: Actually use revertMaxRevisions, ignored for 13 years

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -325,7 +325,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		'prop': ['info', 'revisions', 'flagged'],
 		'titles': pagename,
 		'intestactions': 'edit',
-		'rvlimit': 50, // intentionally limited
+		'rvlimit': Twinkle.getPref('revertMaxRevisions'),
 		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
 		'curtimestamp': '',
 		'meta': 'tokens',

--- a/twinkle.js
+++ b/twinkle.js
@@ -124,8 +124,8 @@ Twinkle.defaultConfig = {
 	markXfdPagesAsPatrolled: true,
 
 	// Hidden preferences
-	revertMaxRevisions: 50,
 	autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
+	revertMaxRevisions: 50, // intentionally limited
 	batchMax: 5000,
 	batchdeleteChunks: 50,
 	batchProtectChunks: 50,


### PR DESCRIPTION
It seems to have been removed from use in [September 2007](https://en.wikipedia.org/w/index.php?title=User:AzaToth/twinklefluff.js&diff=156141985&oldid=146497464).

I'm not sure we even need this, since it's only *used* once, so I'm open to a discussion on that end.  The value is referenced in an error message, and in theory hardcoding a value in two places is bad, but so is a mostly-unused preference, even if hidden.