### PR TITLE
config: Remove obsolete torev option from openTalkPage

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -347,7 +347,7 @@ Twinkle.config.sections = [
 				name: 'openTalkPage',
 				label: 'Open user talk page after these types of reversions',
 				type: 'set',
-				setValues: { agf: 'AGF rollback', norm: 'Normal rollback', vand: 'Vandalism rollback', torev: '"Restore this version"' }
+				setValues: { agf: 'AGF rollback', norm: 'Normal rollback', vand: 'Vandalism rollback' }
 			},
 
 			// TwinkleConfig.openTalkPageOnAutoRevert (bool)


### PR DESCRIPTION
When reverting to a revision, by definition there isn't a straightforward way to define who was in error, at least not if there more than one revision is being undone (and even then, it's not straightforward).  This hasn't been a functional option for well over a decade (https://en.wikipedia.org/w/index.php?title=User:AzaToth/twinklefluff.js&diff=104232943&oldid=103392000); I vaguely recall realizing this before I became a sysop.  There are plenty of users who have opted for it in their preferences, but it hasn't worked for anyone since well before the current preferences system was created!