### PR TITLE
fluff/warn: Pass timestamp from fluff to warn, allow skipping stale API check

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -325,7 +325,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		'titles': pagename,
 		'intestactions': 'edit',
 		'rvlimit': Twinkle.getPref('revertMaxRevisions'),
-		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
+		'rvprop': [ 'ids', 'timestamp', 'user' ],
 		'curtimestamp': '',
 		'meta': 'tokens',
 		'type': 'csrf'
@@ -345,7 +345,7 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 		'titles': mw.config.get('wgPageName'),
 		'rvlimit': 1,
 		'rvstartid': oldrev,
-		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
+		'rvprop': [ 'ids', 'user' ],
 		'format': 'xml',
 		'curtimestamp': '',
 		'meta': 'tokens',
@@ -567,6 +567,8 @@ Twinkle.fluff.callbacks = {
 		if (!Twinkle.fluff.skipTalk && Twinkle.getPref('openTalkPage').indexOf(params.type) !== -1 &&
 				mw.config.get('wgUserName') !== params.user) {
 			params.notifyUser = true;
+			// Pass along to the warn module
+			params.vantimestamp = top.getAttribute('timestamp');
 		}
 
 		// figure out whether we need to/can review the edit
@@ -624,6 +626,7 @@ Twinkle.fluff.callbacks = {
 					'preview': 'yes',
 					'vanarticle': params.pagename.replace(/_/g, ' '),
 					'vanarticlerevid': params.revid,
+					'vantimestamp': params.vantimestamp,
 					'vanarticlegoodrevid': params.goodid,
 					'type': params.type,
 					'count': params.count

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -138,14 +138,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		}
 
 		// Confirm edit wasn't too old for a warning
-		query = {
-			action: 'query',
-			prop: 'revisions',
-			rvprop: 'timestamp',
-			revids: vanrevid
-		};
-		new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
-			var vantimestamp = $(apiobj.getResponse()).find('revisions rev').attr('timestamp');
+		var checkStale = function(vantimestamp) {
 			var revDate = new Morebits.date(vantimestamp);
 			if (vantimestamp && revDate.isValid()) {
 				if (revDate.add(24, 'hours').isBefore(new Date())) {
@@ -153,7 +146,24 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 					$('#twinkle-warn-warning-messages').text('Note:' + message);
 				}
 			}
-		}).post();
+		};
+
+		var vantimestamp = mw.util.getParamValue('vantimestamp');
+		// Provided from a fluff module-based revert, no API lookup necessary
+		if (vantimestamp) {
+			checkStale(vantimestamp);
+		} else {
+			query = {
+				action: 'query',
+				prop: 'revisions',
+				rvprop: 'timestamp',
+				revids: vanrevid
+			};
+			new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
+				vantimestamp = $(apiobj.getResponse()).find('revisions rev').attr('timestamp');
+				checkStale(vantimestamp);
+			}).post();
+		}
 	}
 
 	var more = form.append({ type: 'field', name: 'reasonGroup', label: 'Warning information' });


### PR DESCRIPTION
`timestamp` and `comment` have been in fluff's lookup queries since the module began, but they have been entirely unused since nearly the beginning.  I don't think the `comment` was ever used, while `timestamp` was removed just a few days after [inception](https://en.wikipedia.org/w/index.php?title=User:AzaToth/twinklefluff.js&diff=102706684&oldid=102702487).  It was then added to `revertToRevision` a [few days later](https://en.wikipedia.org/w/index.php?title=User:AzaToth/twinklefluff.js&diff=104232943&oldid=103392000) but was likewise not used there.  We can make use of it when rollbacking, though, if only to pass it to the warn module (a la `vanarticlerevid`, etc.), which will allow warn to avoid an API lookup when checking if the diff is stale (#757).

`timestamp` has been removed from the `revertToRevision` query, and `comment` has been removed from both; they're not unuseful, per se, we're just not using them.