### PR TITLE
warn/welcome: Remove uses of Object.values, not supported by IE

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -212,9 +212,8 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 
 	var firstRadio = e.target.form.template[0];
 	firstRadio.checked = true;
-	e.target.form.article.disabled = Object.values(sets)[0][firstRadio.value] ?
-		!Object.values(sets)[0][firstRadio.value].linkedArticle :
-		true;
+	var vals = sets[Object.keys(sets)[0]];
+	e.target.form.article.disabled = vals[firstRadio.value] ? !vals[firstRadio.value].linkedArticle : true;
 };
 
 // A list of welcome templates and their properties and syntax

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1207,7 +1207,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			break;
 		case 'kitchensink':
 			['level1', 'level2', 'level3', 'level4', 'level4im'].forEach(function(lvl) {
-				Object.values(Twinkle.warn.messages.levels).forEach(function(levelGroup) {
+				$.each(Twinkle.warn.messages.levels, function(_, levelGroup) {
 					createEntries(levelGroup, sub_group, true, lvl);
 				});
 			});


### PR DESCRIPTION
One use in warn (#773), and two related uses in welcome (#747).

In hindsight, I think this is why I originally wrote https://github.com/azatoth/twinkle/pull/773#discussion_r352202099 so weird (amusingly, referenced in https://github.com/azatoth/twinkle/pull/747#discussion_r359567205), but forgot in the review implementation.  There've been no complaints, although these are fairly under-used aspects of Twinkle, but that could tell us something about the IE user-base.