### PR TITLE
Add ESLint plugin to warn on ES6+

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
-	"extends": ["eslint:recommended"],
+	"plugins": ["es5"],
+	"extends": ["eslint:recommended", "plugin:es5/no-es2015"],
 	"root": true,
 	"env": {
 		"browser": true,

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ Things to watch out for:
 
 - Items and processes laid out in [CONTRIBUTING.md](./CONTRIBUTING.md) are followed.
 - Twinkle is meant to run on the latest weekly version of MediaWiki as rolled out every Thursday on the English Wikipedia.  Backwards compatibility is not guaranteed.
-- The goal is for Twinkle and Morebits to support the same [browsers that MediaWiki supports](https://www.mediawiki.org/wiki/Browser_compatibility).  In particular, collaborators should look out for [unsupported additions](https://kangax.github.io/compat-table/es6/) from ES6 (aka ES2015); `.includes` and `.find` are among the most likely to show up, although the jQuery `$.find()` is fine.
+- The goal is for Twinkle and Morebits to support the same [browsers that MediaWiki supports](https://www.mediawiki.org/wiki/Browser_compatibility).  In particular, collaborators should avoid [unsupported additions](https://kangax.github.io/compat-table/es6/) from ES6 (aka ES2015); `.includes` and `.find` are among the most likely to show up, although the jQuery `$.find()` is fine. Our ESLint configuration includes a [plugin](https://github.com/nkt/eslint-plugin-es5) that should catch most cases.
 - Certain positional jQuery selectors like `:first`, `:last`, and `:eq` were [deprecated in jQuery version 3.4.0](https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/) and should probably not be reintroduced.  Instead, use methods like `.first()`, `.last()`, or `.eq()`.
 
 ## Updating scripts on Wikipedia

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -176,9 +176,9 @@ Twinkle.fluff.addLinks = {
 			if (Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
 				(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1) ||
 				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
-				var list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
+				var $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
 
-				list.each(function(key, current) {
+				$list.each(function(key, current) {
 					// revid is also available in the href of both
 					// .mw-changeslist-date or .mw-changeslist-diff
 					var page = $(current).find('.mw-contributions-title').text();
@@ -191,12 +191,12 @@ Twinkle.fluff.addLinks = {
 	recentchanges: function() {
 		if (Twinkle.getPref('showRollbackLinks').indexOf('recent') !== -1) {
 			// Latest and revertable (not page creations, logs, categorizations, etc.)
-			var list = $('.mw-changeslist .mw-changeslist-last.mw-changeslist-src-mw-edit');
+			var $list = $('.mw-changeslist .mw-changeslist-last.mw-changeslist-src-mw-edit');
 			// Exclude top-level header if "group changes" preference is used
 			// and find only individual lines or nested lines
-			list = list.not('.mw-rcfilters-ui-highlights-enhanced-toplevel').find('.mw-changeslist-line-inner, td.mw-enhanced-rc-nested');
+			$list = $list.not('.mw-rcfilters-ui-highlights-enhanced-toplevel').find('.mw-changeslist-line-inner, td.mw-enhanced-rc-nested');
 
-			list.each(function(key, current) {
+			$list.each(function(key, current) {
 				var vandal = $(current).find('.mw-userlink').text();
 				var href = $(current).find('.mw-changeslist-diff').attr('href');
 				var rev = mw.util.getParamValue('diff', href);

--- a/package-lock.json
+++ b/package-lock.json
@@ -326,6 +326,12 @@
         "v8-compile-cache": "^2.0.3"
       }
     },
+    "eslint-plugin-es5": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz",
+      "integrity": "sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
-    "eslint": "7.2.0"
+    "eslint": "7.2.0",
+    "eslint-plugin-es5": "^1.5.0"
   }
 }


### PR DESCRIPTION
I stumbled on https://github.com/nkt/eslint-plugin-es5 about a year ago but it had too many false-positives when used with jQuery.  Most of that (https://github.com/nkt/eslint-plugin-es5/issues/12) appears to have been resolved with v1.5.0, specifically https://github.com/nkt/eslint-plugin-es5/pull/36.  This won't catch everything but I *think* it shouldn't have many false positives, as long as things like jQuery's `.find` are used on the same line as `$`, whether `jQuery` or as a variable name; we're inconsistent on that front, but it's not a bad idea to encourage it.