### PR TITLE
Add support for change tags, remove `summaryAd`

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -156,7 +156,8 @@ Twinkle.shared.callbacks = {
 
 		var summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
 		pageobj.setPageText(text + pageText);
-		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary(summaryText);
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setMinorEdit(Twinkle.getPref('markSharedIPAsMinor'));
 		pageobj.setCreateOption('recreate');
 		pageobj.save();

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1194,12 +1194,12 @@ Twinkle.tag.callbacks = {
 			}
 
 			// avoid truncated summaries
-			if (summaryText.length > (499 - Twinkle.getPref('summaryAd').length)) {
+			if (summaryText.length > 499) {
 				summaryText = summaryText.replace(/\[\[[^|]+\|([^\]]+)\]\]/g, '$1');
 			}
 
 			pageobj.setPageText(pageText);
-			pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary(summaryText);
 			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 			pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 			pageobj.setCreateOption('nocreate');
@@ -1211,7 +1211,8 @@ Twinkle.tag.callbacks = {
 					talkpageText += params.mergeReason.trim() + ' ~~~~';
 					var talkpage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					talkpage.setAppendText(talkpageText);
-					talkpage.setEditSummary('/* ' + params.talkDiscussionTitle + ' */ new section' + Twinkle.getPref('summaryAd'));
+					talkpage.setEditSummary('/* ' + params.talkDiscussionTitle + ' */ new section');
+					talkpage.setChangeTags(Twinkle.changeTags);
 					talkpage.setWatchlist(Twinkle.getPref('watchMergeDiscussions'));
 					talkpage.setCreateOption('recreate');
 					talkpage.append();
@@ -1235,6 +1236,7 @@ Twinkle.tag.callbacks = {
 					};
 					var otherpage = new Morebits.wiki.page(params.mergeTarget, 'Tagging other page (' +
 						params.mergeTarget + ')');
+					otherpage.setChangeTags(Twinkle.changeTags);
 					otherpage.setCallbackParameters(newParams);
 					otherpage.load(Twinkle.tag.callbacks.article);
 				}
@@ -1269,7 +1271,8 @@ Twinkle.tag.callbacks = {
 							return;
 						}
 						pageobj.setPageText(text);
-						pageobj.setEditSummary(summary + ' [[:' + Morebits.pageNameNorm + ']]' + Twinkle.getPref('summaryAd'));
+						pageobj.setEditSummary(summary + ' [[:' + Morebits.pageNameNorm + ']]');
+						pageobj.setChangeTags(Twinkle.changeTags);
 						pageobj.setCreateOption('recreate');
 						pageobj.save();
 					});
@@ -1290,8 +1293,8 @@ Twinkle.tag.callbacks = {
 							'{{subst:uw-notenglish|1=' + Morebits.pageNameNorm +
 							(params.translationPostAtPNT ? '' : '|nopnt=yes') + '}} ~~~~';
 						userTalkPage.setAppendText(notifytext);
-						userTalkPage.setEditSummary('Notice: Please use English when contributing to the English Wikipedia.' +
-							Twinkle.getPref('summaryAd'));
+						userTalkPage.setEditSummary('Notice: Please use English when contributing to the English Wikipedia.');
+						userTalkPage.setChangeTags(Twinkle.changeTags);
 						userTalkPage.setCreateOption('recreate');
 						userTalkPage.setFollowRedirect(true, false);
 						userTalkPage.append();
@@ -1707,12 +1710,12 @@ Twinkle.tag.callbacks = {
 		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : 'rcat shell') + ' to redirect';
 
 		// avoid truncated summaries
-		if (summaryText.length > (499 - Twinkle.getPref('summaryAd').length)) {
+		if (summaryText.length > 499) {
 			summaryText = summaryText.replace(/\[\[[^|]+\|([^\]]+)\]\]/g, '$1');
 		}
 
 		pageobj.setPageText(pageText);
-		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary(summaryText);
 		pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 		pageobj.setCreateOption('nocreate');
@@ -1812,7 +1815,8 @@ Twinkle.tag.callbacks = {
 		}
 
 		pageobj.setPageText(text);
-		pageobj.setEditSummary(summary.substring(0, summary.length - 2) + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary(summary.substring(0, summary.length - 2));
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 		pageobj.setCreateOption('nocreate');
@@ -1997,6 +2001,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 
 	var wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + Twinkle.tag.mode);
 	wikipedia_page.setCallbackParameters(params);
+	wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 	wikipedia_page.load(Twinkle.tag.callbacks[Twinkle.tag.mode]);
 
 };

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -363,25 +363,25 @@ Twinkle.talkback.evaluate = function(e) {
 
 	switch (input.tbtarget) {
 		case 'notice':
-			talkpage.setEditSummary(Twinkle.talkback.noticeboards[input.noticeboard].editSummary + Twinkle.getPref('summaryAd'));
+			talkpage.setEditSummary(Twinkle.talkback.noticeboards[input.noticeboard].editSummary);
 			break;
 		case 'mail':
-			talkpage.setEditSummary("Notification: You've got mail" + Twinkle.getPref('summaryAd'));
+			talkpage.setEditSummary("Notification: You've got mail");
 			break;
 		case 'see':
 			talkpage.setEditSummary('Please check the discussion at [[:' + input.page +
-			(input.section ? '#' + input.section : '') + ']]' + Twinkle.getPref('summaryAd'));
+			(input.section ? '#' + input.section : '') + ']]');
 			break;
 		default:  // tbtarget one of mytalk, usertalk, other
 			var editSummary = 'Talkback ([[:';
 			if (input.tbtarget !== 'other' && !/^\s*user talk:/i.test(input.page)) {
 				editSummary += 'User talk:';
 			}
-			editSummary += input.page + (input.section ? '#' + input.section : '') + ']])';
-			talkpage.setEditSummary(editSummary + Twinkle.getPref('summaryAd'));
+			talkpage.setEditSummary(editSummary + input.page + (input.section ? '#' + input.section : '') + ']])');
 	}
 
 	talkpage.setAppendText('\n\n' + Twinkle.talkback.getNoticeWikitext(input));
+	talkpage.setChangeTags(Twinkle.changeTags);
 	talkpage.setCreateOption('recreate');
 	talkpage.setMinorEdit(Twinkle.getPref('markTalkbackAsMinor'));
 	talkpage.setFollowRedirect(true);

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -634,7 +634,8 @@ Twinkle.welcome.callbacks = {
 
 		var summaryText = 'Welcome to Wikipedia!';
 		pageobj.setPageText(text);
-		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary(summaryText);
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setWatchlist(Twinkle.getPref('watchWelcomes'));
 		pageobj.setCreateOption('recreate');
 		pageobj.save();

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -545,7 +545,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 					}
 
 					aivPage.getStatusElement().status('Adding new report...');
-					aivPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].' + Twinkle.getPref('summaryAd'));
+					aivPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].');
+					aivPage.setChangeTags(Twinkle.changeTags);
 					aivPage.setAppendText('\n*{{' + (mw.util.isIPAddress(uid) ? 'IPvandal' : 'vandal') + '|' + (/=/.test(uid) ? '1=' : '') + uid + '}} &ndash; ' + reason);
 					aivPage.append();
 				});
@@ -601,7 +602,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 					return;
 				}
 				uaaPage.getStatusElement().status('Adding new report...');
-				uaaPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].' + Twinkle.getPref('summaryAd'));
+				uaaPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].');
+				uaaPage.setChangeTags(Twinkle.changeTags);
 				uaaPage.setPageText(text + '\n' + reason);
 				uaaPage.save();
 			});
@@ -776,13 +778,14 @@ Twinkle.arv.processSock = function(params) {
 	// notify all user accounts if requested
 	if (params.notify && params.sockpuppets.length > 0) {
 
-		var notifyEditSummary = 'Notifying about suspicion of sockpuppeteering.' + Twinkle.getPref('summaryAd');
+		var notifyEditSummary = 'Notifying about suspicion of sockpuppeteering.';
 		var notifyText = '\n\n{{subst:socksuspectnotice|1=' + params.uid + '}} ~~~~';
 
 		// notify user's master account
 		var masterTalkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying suspected sockpuppeteer');
 		masterTalkPage.setFollowRedirect(true);
 		masterTalkPage.setEditSummary(notifyEditSummary);
+		masterTalkPage.setChangeTags(Twinkle.changeTags);
 		masterTalkPage.setAppendText(notifyText);
 		masterTalkPage.append();
 
@@ -807,6 +810,7 @@ Twinkle.arv.processSock = function(params) {
 			var sockTalkPage = new Morebits.wiki.page('User talk:' + socks[i], 'Notification for ' + socks[i]);
 			sockTalkPage.setFollowRedirect(true);
 			sockTalkPage.setEditSummary(notifyEditSummary);
+			sockTalkPage.setChangeTags(Twinkle.changeTags);
 			sockTalkPage.setAppendText(notifyText);
 			sockTalkPage.append(onSuccess);
 		}
@@ -830,7 +834,8 @@ Twinkle.arv.processSock = function(params) {
 
 	var spiPage = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
 	spiPage.setFollowRedirect(true);
-	spiPage.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].' + Twinkle.getPref('summaryAd'));
+	spiPage.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
+	spiPage.setChangeTags(Twinkle.changeTags);
 	spiPage.setAppendText(text);
 	switch (Twinkle.getPref('spiWatchReport')) {
 		case 'yes':
@@ -967,18 +972,19 @@ Twinkle.arv.processAN3 = function(params) {
 
 		var an3Page = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
 		an3Page.setFollowRedirect(true);
-		an3Page.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].' + Twinkle.getPref('summaryAd'));
+		an3Page.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
+		an3Page.setChangeTags(Twinkle.changeTags);
 		an3Page.setAppendText(text);
 		an3Page.append();
 
 		// notify user
 
-		var notifyEditSummary = 'Notifying about edit warring noticeboard discussion.' + Twinkle.getPref('summaryAd');
 		var notifyText = '\n\n{{subst:an3-notice|1=' + mw.util.wikiUrlencode(params.uid) + '|auto=1}} ~~~~';
 
 		var talkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying edit warrior');
 		talkPage.setFollowRedirect(true);
-		talkPage.setEditSummary(notifyEditSummary);
+		talkPage.setEditSummary('Notifying about edit warring noticeboard discussion.');
+		talkPage.setChangeTags(Twinkle.changeTags);
 		talkPage.setAppendText(notifyText);
 		talkPage.append();
 		Morebits.wiki.removeCheckpoint();  // all page updates have been started

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -466,7 +466,8 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
 		if (input.delete_page) {
-			wikipedia_page.setEditSummary(input.reason + Twinkle.getPref('deletionSummaryAd'));
+			wikipedia_page.setEditSummary(input.reason);
+			wikipedia_page.setChangeTags(Twinkle.changeTags);
 			wikipedia_page.suppressProtectWarning();
 			wikipedia_page.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
 		} else {
@@ -492,7 +493,8 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 
 				var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting subpage ' + pageName);
 				wikipedia_page.setCallbackParameters(params);
-				wikipedia_page.setEditSummary(input.reason + Twinkle.getPref('deletionSummaryAd'));
+				wikipedia_page.setEditSummary(input.reason);
+				wikipedia_page.setChangeTags(Twinkle.changeTags);
 				wikipedia_page.suppressProtectWarning();
 				wikipedia_page.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
 			});
@@ -581,7 +583,8 @@ Twinkle.batchdelete.callbacks = {
 		redirectDeleter.setPageList(pages);
 		redirectDeleter.run(function(pageName) {
 			var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
-			wikipedia_page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"' + Twinkle.getPref('deletionSummaryAd'));
+			wikipedia_page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
+			wikipedia_page.setChangeTags(Twinkle.changeTags);
 			wikipedia_page.deletePage(redirectDeleter.workerSuccess, redirectDeleter.workerFailure);
 		});
 	},
@@ -595,7 +598,8 @@ Twinkle.batchdelete.callbacks = {
 		}
 
 		var page = new Morebits.wiki.page(apiobj.params.talkPage, 'Deleting talk page of article ' + apiobj.params.page);
-		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"' + Twinkle.getPref('deletionSummaryAd'));
+		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"');
+		page.setChangeTags(Twinkle.changeTags);
 		page.deletePage();
 	},
 	unlinkBacklinksMain: function(apiobj) {
@@ -643,7 +647,8 @@ Twinkle.batchdelete.callbacks = {
 			params.unlinker.workerSuccess(pageobj);
 			return;
 		}
-		pageobj.setEditSummary('Removing link(s) to deleted page ' + params.page + Twinkle.getPref('deletionSummaryAd'));
+		pageobj.setEditSummary('Removing link(s) to deleted page ' + params.page);
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setPageText(text);
 		pageobj.setCreateOption('nocreate');
 		pageobj.setMaxConflictRetries(10);
@@ -695,7 +700,8 @@ Twinkle.batchdelete.callbacks = {
 			params.unlinker.workerFailure(pageobj);
 			return;
 		}
-		pageobj.setEditSummary('Removing instance of file ' + image + ' that has been deleted because "' + params.reason + '")' + Twinkle.getPref('deletionSummaryAd'));
+		pageobj.setEditSummary('Removing instance of file ' + image + ' that has been deleted because "' + params.reason + '")');
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setPageText(text);
 		pageobj.setCreateOption('nocreate');
 		pageobj.setMaxConflictRetries(10);

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -437,6 +437,7 @@ Twinkle.batchprotect.callbacks = {
 		}
 
 		page.setEditSummary(apiobj.params.reason);
+		page.setChangeTags(Twinkle.changeTags);
 		page.protect(apiobj.params.batchOperation.workerSuccess, apiobj.params.batchOperation.workerFailure);
 	}
 };

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -149,7 +149,8 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 
 		var wikipedia_page = new Morebits.wiki.page(pageName, 'Undeleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
-		wikipedia_page.setEditSummary(input.reason + Twinkle.getPref('deletionSummaryAd'));
+		wikipedia_page.setEditSummary(input.reason);
+		wikipedia_page.setChangeTags(Twinkle.changeTags);
 		wikipedia_page.suppressProtectWarning();
 		wikipedia_page.setMaxRetries(3); // temporary increase from 2 to make batchundelete more likely to succeed [[phab:T222402]] #613
 		wikipedia_page.undeletePage(Twinkle.batchundelete.callbacks.doExtras, pageUndeleter.workerFailure);
@@ -196,7 +197,8 @@ Twinkle.batchundelete.callbacks = {
 		}
 
 		var page = new Morebits.wiki.page(apiobj.params.talkPage, 'Undeleting talk page of ' + apiobj.params.page);
-		page.setEditSummary('Undeleting [[Help:Talk page|talk page]] of "' + apiobj.params.page + '"' + Twinkle.getPref('deletionSummaryAd'));
+		page.setEditSummary('Undeleting [[Help:Talk page|talk page]] of "' + apiobj.params.page + '"');
+		page.setChangeTags(Twinkle.changeTags);
 		page.undeletePage();
 	}
 };

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1519,7 +1519,9 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 				}
 				blockoptions.reblock = 1; // Writing over a block will fail otherwise
 			}
+
 			// execute block
+			blockoptions.tags = Twinkle.changeTags;
 			blockoptions.token = mw.user.tokens.get('csrfToken');
 			var mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
 				statusElement.info('Completed');
@@ -1671,10 +1673,11 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 	if (messageData.suppressArticleInSummary !== true && params.article) {
 		summary += ' on [[:' + params.article + ']]';
 	}
-	summary += '.' + Twinkle.getPref('summaryAd');
+	summary += '.';
 
 	pageobj.setPageText(text);
 	pageobj.setEditSummary(summary);
+	pageobj.setChangeTags(Twinkle.changeTags);
 	pageobj.setWatchlist(Twinkle.getPref('watchWarnings'));
 	pageobj.save();
 };

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1663,7 +1663,8 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 		'// End of twinkleoptions.js\n';
 
 	pageobj.setPageText(text);
-	pageobj.setEditSummary('Saving Twinkle preferences: automatic edit from [[:' + Morebits.pageNameNorm + ']] ([[WP:TW|TW]])');
+	pageobj.setEditSummary('Saving Twinkle preferences: automatic edit from [[:' + Morebits.pageNameNorm + ']]');
+	pageobj.setChangeTags(Twinkle.changeTags);
 	pageobj.setCreateOption('recreate');
 	pageobj.save(Twinkle.config.saveSuccess);
 };

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -152,35 +152,6 @@ Twinkle.config.sections = [
 	{
 		title: 'General',
 		preferences: [
-			// TwinkleConfig.summaryAd (string)
-			// Text to be appended to the edit summary of edits made using Twinkle
-			{
-				name: 'summaryAd',
-				label: "\"Ad\" to be appended to Twinkle's edit summaries",
-				helptip: 'The summary ad should start with a space, and be kept short.',
-				type: 'string'
-			},
-
-			// TwinkleConfig.deletionSummaryAd (string)
-			// Text to be appended to the edit summary of deletions made using Twinkle
-			{
-				name: 'deletionSummaryAd',
-				label: 'Summary ad to use for deletion summaries',
-				helptip: 'Normally the same as the edit summary ad above.',
-				adminOnly: true,
-				type: 'string'
-			},
-
-			// TwinkleConfig.protectionSummaryAd (string)
-			// Text to be appended to the edit summary of page protections made using Twinkle
-			{
-				name: 'protectionSummaryAd',
-				label: 'Summary ad to use for page protections',
-				helptip: 'Normally the same as the edit summary ad above.',
-				adminOnly: true,
-				type: 'string'
-			},
-
 			// TwinkleConfig.userTalkPageMode may take arguments:
 			// 'window': open a new window, remember the opened window
 			// 'tab': opens in a new tab, if possible.

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -153,7 +153,8 @@ var callback_commit = function(event) {
 			wikipedia_api.post();
 
 			var page = new Morebits.wiki.page(pageName, 'Deleting article ' + pageName);
-			page.setEditSummary('Expired [[WP:PROD|PROD]], concern was: ' + concerns[pageName] + Twinkle.getPref('deletionSummaryAd'));
+			page.setEditSummary('Expired [[WP:PROD|PROD]], concern was: ' + concerns[pageName]);
+			page.setChangeTags(Twinkle.changeTags);
 			page.suppressProtectWarning();
 			page.deletePage(batchOperation.workerSuccess, batchOperation.workerFailure);
 		});
@@ -168,7 +169,8 @@ var callback_commit = function(event) {
 		}
 
 		var page = new Morebits.wiki.page('Talk:' + apiobj.params.page, 'Deleting talk page of article ' + apiobj.params.page);
-		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"' + Twinkle.getPref('deletionSummaryAd'));
+		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"');
+		page.setChangeTags(Twinkle.changeTags);
 		page.deletePage();
 	},
 	callback_deleteRedirects = function(apiobj) {
@@ -176,7 +178,8 @@ var callback_commit = function(event) {
 		$doc.find('redirects rd').each(function() {
 			var title = $(this).attr('title');
 			var page = new Morebits.wiki.page(title, 'Deleting redirecting page ' + title);
-			page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"' + Twinkle.getPref('deletionSummaryAd'));
+			page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
+			page.setChangeTags(Twinkle.changeTags);
 			page.deletePage();
 		});
 	};

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -422,6 +422,7 @@ Twinkle.fluff.callbacks = {
 			'action': 'edit',
 			'title': mw.config.get('wgPageName'),
 			'summary': summary,
+			'tags': Twinkle.changeTags,
 			'token': csrftoken,
 			'undo': lastrevid,
 			'undoafter': revertToRevID,
@@ -437,7 +438,6 @@ Twinkle.fluff.callbacks = {
 		var wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, apiobj.statelem);
 		wikipedia_api.params = apiobj.params;
 		wikipedia_api.post();
-
 	},
 	main: function(apiobj) {
 		var xmlDoc = apiobj.responseXML;
@@ -625,6 +625,7 @@ Twinkle.fluff.callbacks = {
 			'action': 'edit',
 			'title': params.pagename,
 			'summary': summary,
+			'tags': Twinkle.changeTags,
 			'token': csrftoken,
 			'undo': lastrevid,
 			'undoafter': params.goodid,
@@ -697,7 +698,8 @@ Twinkle.fluff.callbacks = {
 					'action': 'review',
 					'revid': $edit.attr('newrevid'),
 					'token': apiobj.params.csrftoken,
-					'comment': Twinkle.getPref('summaryAd').trim()
+					'comment': 'Automatically reviewing reversion' + Twinkle.summaryAd // until the below
+					// 'tags': Twinkle.changeTags // flaggedrevs tag support: [[phab:T247721]]
 				};
 				var wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);
 				wikipedia_api.post();
@@ -715,7 +717,6 @@ Twinkle.fluff.formatSummary = function(builtInString, userName, customString) {
 	if (customString) {
 		result += ': ' + Morebits.string.toUpperCaseFirstChar(customString);
 	}
-	result += Twinkle.getPref('summaryAd');
 
 	// find number of UTF-8 bytes the resulting string takes up, and possibly add
 	// a contributions or contributions+talk link if it doesn't push the edit summary

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -275,7 +275,8 @@ Twinkle.image.callbacks = {
 		tag += '|help=off}}\n';
 
 		pageobj.setPageText(tag + text);
-		pageobj.setEditSummary('This file is up for deletion, per [[WP:CSD#' + params.normalized + '|CSD ' + params.normalized + ']] (' + params.type + ').' + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary('This file is up for deletion, per [[WP:CSD#' + params.normalized + '|CSD ' + params.normalized + ']] (' + params.type + ').');
+		pageobj.setChangeTags(Twinkle.changeTags);
 		switch (Twinkle.getPref('deliWatchPage')) {
 			case 'yes':
 				pageobj.setWatchlist(true);
@@ -305,7 +306,8 @@ Twinkle.image.callbacks = {
 			}
 			notifytext += '}} ~~~~';
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: tagging for deletion of [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary('Notification: tagging for deletion of [[:' + Morebits.pageNameNorm + ']].');
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			switch (Twinkle.getPref('deliWatchUser')) {
 				case 'yes':

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -210,6 +210,7 @@ Twinkle.prod.callbacks = {
 
 		var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		wikipedia_page.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
+		wikipedia_page.setChangeTags(Twinkle.changeTags);  // Here to apply to triage
 		wikipedia_page.setCallbackParameters(params);
 		wikipedia_page.load(Twinkle.prod.callbacks.main);
 	},
@@ -287,7 +288,8 @@ Twinkle.prod.callbacks = {
 
 					var usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
 					usertalkpage.setAppendText(notifytext);
-					usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+					usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
+					usertalkpage.setChangeTags(Twinkle.changeTags);
 					usertalkpage.setCreateOption('recreate');
 					usertalkpage.setFollowRedirect(true, false);
 					usertalkpage.setCallbackParameters(params);
@@ -329,7 +331,8 @@ Twinkle.prod.callbacks = {
 				var talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
 				var talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
 				talkpage.setPrependText(oldprodfull);
-				talkpage.setEditSummary('Adding {{Old prod}}' + Twinkle.getPref('summaryAd'));
+				talkpage.setEditSummary('Adding {{Old prod}}');
+				talkpage.setChangeTags(Twinkle.changeTags);
 				talkpage.setFollowRedirect(true);  // match behavior for page tagging
 				talkpage.setCreateOption('recreate');
 				talkpage.prepend();
@@ -366,7 +369,7 @@ Twinkle.prod.callbacks = {
 		}
 
 		pageobj.setPageText(text);
-		pageobj.setEditSummary(summaryText + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary(summaryText);
 		pageobj.setWatchlist(Twinkle.getPref('watchProdPages'));
 		pageobj.setCreateOption('nocreate');
 		pageobj.save();
@@ -400,9 +403,9 @@ Twinkle.prod.callbacks = {
 			}
 			summaryText = 'Logging PROD nomination of [[:' + Morebits.pageNameNorm + ']].';
 		}
+		usl.changeTags = Twinkle.changeTags;
 
-		usl.log(logText, summaryText + Twinkle.getPref('summaryAd'));
-
+		usl.log(logText, summaryText);
 	}
 
 };

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1177,6 +1177,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 					statusInited = true;
 				}
 
+				thispage.setChangeTags(Twinkle.changeTags);
 				thispage.protect(next);
 			};
 
@@ -1189,7 +1190,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 				thispage.setFlaggedRevs(input.pclevel, input.pcexpiry);
 
 				if (input.protectReason) {
-					thispage.setEditSummary(input.protectReason);
+					thispage.setEditSummary(input.protectReason + Twinkle.summaryAd); // flaggedrevs tag support: [[phab:T247721]]
 				} else {
 					alert('You must enter a protect reason, which will be inscribed into the protection log.');
 					return;
@@ -1422,7 +1423,7 @@ Twinkle.protect.callbacks = {
 		}
 
 		if (params.tag === 'none') {
-			summary = 'Removing protection template' + Twinkle.getPref('summaryAd');
+			summary = 'Removing protection template';
 		} else {
 			tag = params.tag;
 			if (params.reason) {
@@ -1451,10 +1452,11 @@ Twinkle.protect.callbacks = {
 				var wikipage = new Morebits.wikitext.page(text);
 				text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
 			}
-			summary = 'Adding {{' + params.tag + '}}' + Twinkle.getPref('summaryAd');
+			summary = 'Adding {{' + params.tag + '}}';
 		}
 
 		protectedPage.setEditSummary(summary);
+		protectedPage.setChangeTags(Twinkle.changeTags);
 		protectedPage.setPageText(text);
 		protectedPage.setCreateOption('nocreate');
 		protectedPage.suppressProtectWarning(); // no need to let admins know they are editing through protection
@@ -1555,7 +1557,8 @@ Twinkle.protect.callbacks = {
 		}
 		statusElement.status('Adding new request...');
 		rppPage.setEditSummary('/* ' + Morebits.pageNameNorm + ' */ Requesting ' + params.typename + (params.typename === 'pending changes' ? ' on [[:' : ' of [[:') +
-			Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			Morebits.pageNameNorm + ']].');
+		rppPage.setChangeTags(Twinkle.changeTags);
 		rppPage.setPageText(text);
 		rppPage.setCreateOption('recreate');
 		rppPage.save();

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1282,7 +1282,8 @@ Twinkle.speedy.callbacks = {
 			}
 
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary(editsummary);
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
@@ -1328,7 +1329,8 @@ Twinkle.speedy.callbacks = {
 			}
 
 			var deleteMain = function(callback) {
-				thispage.setEditSummary(reason + Twinkle.getPref('deletionSummaryAd'));
+				thispage.setEditSummary(reason);
+				thispage.setChangeTags(Twinkle.changeTags);
 				thispage.deletePage(function() {
 					thispage.getStatusElement().info('done');
 					typeof callback === 'function' && callback();
@@ -1355,7 +1357,8 @@ Twinkle.speedy.callbacks = {
 					params.normalized !== 'f8' &&
 					document.getElementById('ca-talk').className !== 'new') {
 				var talkpage = new Morebits.wiki.page(mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceNumber') + 1] + ':' + mw.config.get('wgTitle'), 'Deleting talk page');
-				talkpage.setEditSummary('[[WP:CSD#G8|G8]]: Talk page of deleted page "' + Morebits.pageNameNorm + '"' + Twinkle.getPref('deletionSummaryAd'));
+				talkpage.setEditSummary('[[WP:CSD#G8|G8]]: Talk page of deleted page "' + Morebits.pageNameNorm + '"');
+				talkpage.setChangeTags(Twinkle.changeTags);
 				talkpage.deletePage();
 				// this is ugly, but because of the architecture of wiki.api, it is needed
 				// (otherwise success/failure messages for the previous action would be suppressed)
@@ -1446,7 +1449,8 @@ Twinkle.speedy.callbacks = {
 			$snapshot.each(function(key, value) {
 				var title = $(value).attr('title');
 				var page = new Morebits.wiki.page(title, 'Deleting redirect "' + title + '"');
-				page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + Morebits.pageNameNorm + '"' + Twinkle.getPref('deletionSummaryAd'));
+				page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + Morebits.pageNameNorm + '"');
+				page.setChangeTags(Twinkle.changeTags);
 				page.deletePage(onsuccess);
 			});
 		}
@@ -1543,7 +1547,7 @@ Twinkle.speedy.callbacks = {
 
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary(editsummary);
 			pageobj.setWatchlist(params.watch);
 			if (params.scribunto) {
 				pageobj.setCreateOption('recreate'); // Module /doc might not exist
@@ -1683,8 +1687,8 @@ Twinkle.speedy.callbacks = {
 			}
 			appendText += ' ~~~~~\n';
 
-			usl.log(appendText, editsummary + Twinkle.getPref('summaryAd'));
-
+			usl.changeTags = Twinkle.changeTags;
+			usl.log(appendText, editsummary);
 		}
 	}
 };
@@ -2169,6 +2173,7 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	// Modules can't be tagged, follow standard at TfD and place on /doc subpage
 	params.scribunto = mw.config.get('wgPageContentModel') === 'Scribunto';
 	var wikipedia_page = params.scribunto ? new Morebits.wiki.page(mw.config.get('wgPageName') + '/doc', 'Tagging module documentation page') : new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+	wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.speedy.callbacks.user.main);
 };

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -283,7 +283,8 @@ Twinkle.unlink.callbacks = {
 		}
 
 		pageobj.setPageText(text);
-		pageobj.setEditSummary(summaryText + ' "' + Morebits.pageNameNorm + '": ' + params.reason + '.' + Twinkle.getPref('summaryAd'));
+		pageobj.setEditSummary(summaryText + ' "' + Morebits.pageNameNorm + '": ' + params.reason + '.');
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setCreateOption('nocreate');
 		pageobj.save(params.unlinker.workerSuccess, params.unlinker.workerFailure);
 	}

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -199,7 +199,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 // This is all the messages that might be dispatched by the code
 // Each of the individual templates require the following information:
 //   label (required): A short description displayed in the dialog
-//   summary (required): The edit summary used. If an article name is entered, the summary is postfixed with "on [[article]]", and it is always postfixed with ". $summaryAd"
+//   summary (required): The edit summary used. If an article name is entered, the summary is postfixed with "on [[article]]", and it is always postfixed with "."
 //   suppressArticleInSummary (optional): Set to true to suppress showing the article name in the edit summary. Useful if the warning relates to attack pages, or some such.
 Twinkle.warn.messages = {
 	levels: {
@@ -1739,10 +1739,11 @@ Twinkle.warn.callbacks = {
 				}
 			}
 		}
-		summary += '.' + Twinkle.getPref('summaryAd');
+		summary += '.';
 
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summary);
+		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setWatchlist(Twinkle.getPref('watchWarnings'));
 		pageobj.save();
 	}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -888,7 +888,8 @@ Twinkle.xfd.callbacks = {
 			appendText += "\n#* '''Reason''': " + params.reason;
 		}
 
-		usl.log(appendText, editsummary + Twinkle.getPref('summaryAd'));
+		usl.changeTags = Twinkle.changeTags;
+		usl.log(appendText, editsummary);
 	},
 
 	afd: {
@@ -937,6 +938,7 @@ Twinkle.xfd.callbacks = {
 			// Tagging article
 			var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to article');
 			wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the article is moved, we would want to follow the redirect
+			wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 			wikipedia_page.setCallbackParameters(apiobj.params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.taggingArticle);
 		},
@@ -1019,7 +1021,7 @@ Twinkle.xfd.callbacks = {
 			text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('nocreate');
 			pageobj.save();
@@ -1028,7 +1030,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('afd', params));
-			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('createonly');
 			pageobj.save(function() {
@@ -1049,7 +1052,8 @@ Twinkle.xfd.callbacks = {
 				return;
 			}
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Adding [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchList'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save();
@@ -1067,7 +1071,8 @@ Twinkle.xfd.callbacks = {
 			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 			var notifytext = '\n{{subst:Afd notice|1=' + Morebits.pageNameNorm + (params.numbering !== '' ? '|order=&#32;' + params.numbering : '') + '}} ~~~~';
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|nomination]] of [[:' + Morebits.pageNameNorm + ']]  at [[WP:AFD|articles for deletion]].' + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|nomination]] of [[:' + Morebits.pageNameNorm + ']]  at [[WP:AFD|articles for deletion]].');
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
 			usertalkpage.setFollowRedirect(true, false);
@@ -1083,7 +1088,8 @@ Twinkle.xfd.callbacks = {
 			var discussionPage = pageobj.getCallbackParameters().discussionPage;
 			var text = pageobj.getPageText().replace('directly below this line -->', 'directly below this line -->\n{{' + discussionPage + '}}');
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Listing [[:' + discussionPage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Listing [[:' + discussionPage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setCreateOption('nocreate');
 			pageobj.save();
 		}
@@ -1098,7 +1104,8 @@ Twinkle.xfd.callbacks = {
 
 			pageobj.setPageText((params.noinclude ? '<noinclude>' : '') + '{{subst:template for discussion|help=off' +
 				(params.templatetype !== 'standard' ? '|type=' + params.templatetype : '') + (params.noinclude ? '}}</noinclude>' : '}}') + tableNewline + text);
-			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			if (params.scribunto) {
 				pageobj.setCreateOption('recreate'); // Module /doc might not exist
@@ -1113,7 +1120,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText((params.noinclude ? '<noinclude>' : '') + '{{subst:tfm|help=off|' +
 				(params.templatetype !== 'standard' ? 'type=' + params.templatetype + '|' : '') + '1=' + params.otherTemplateName.replace(/^(?:Template|Module):/, '') +
 				(params.noinclude ? '}}</noinclude>' : '}}') + tableNewline + text);
-			pageobj.setEditSummary('Listed for merging with [[:' + params.otherTemplateName + ']]; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Listed for merging with [[:' + params.otherTemplateName + ']]; see [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			if (params.scribunto) {
 				pageobj.setCreateOption('recreate'); // Module /doc might not exist
@@ -1133,7 +1141,8 @@ Twinkle.xfd.callbacks = {
 				return;
 			}
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Adding ' + (params.xfdcat === 'tfd' ? 'deletion nomination' : 'merge listing') + ' of [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding ' + (params.xfdcat === 'tfd' ? 'deletion nomination' : 'merge listing') + ' of [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
@@ -1166,7 +1175,8 @@ Twinkle.xfd.callbacks = {
 			}
 
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + pageobj.getPageName() + ']] at [[WP:TFD|templates for discussion]].' + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + pageobj.getPageName() + ']] at [[WP:TFD|templates for discussion]].');
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
 			usertalkpage.setFollowRedirect(true, false);
@@ -1265,7 +1275,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText((params.noinclude ? '<noinclude>' : '') + '{{' +
 				(params.number === '' ? 'mfd' : 'mfdx|' + params.number) + '|help=off}}\n' +
 				(params.noinclude ? '</noinclude>' : '') + text);
-			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('nocreate');
 			pageobj.save();
@@ -1274,7 +1285,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('mfd', params));
-			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('createonly');
 			pageobj.save(function() {
@@ -1300,7 +1312,8 @@ Twinkle.xfd.callbacks = {
 			}
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Adding [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchList'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save();
@@ -1330,7 +1343,8 @@ Twinkle.xfd.callbacks = {
 			var usertalkpage = new Morebits.wiki.page('User talk:' + userTarget, actionName + ' (' + userTarget + ')');
 			var notifytext = '\n{{subst:Mfd notice|1=' + Morebits.pageNameNorm + (params.numbering !== '' ? '|order=&#32;' + params.numbering : '') + '}} ~~~~';
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|nomination]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:MFD|miscellany for deletion]].' + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|nomination]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:MFD|miscellany for deletion]].');
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
 			usertalkpage.setFollowRedirect(true, false);
@@ -1372,7 +1386,8 @@ Twinkle.xfd.callbacks = {
 					var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 					var notifytext = '\n{{subst:Ffd notice|1=' + mw.config.get('wgTitle') + '}}';
 					usertalkpage.setAppendText(notifytext);
-					usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:FFD|files for discussion]].' + Twinkle.getPref('summaryAd'));
+					usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:FFD|files for discussion]].');
+					usertalkpage.setChangeTags(Twinkle.changeTags);
 					usertalkpage.setCreateOption('recreate');
 					Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
 					usertalkpage.setFollowRedirect(true, false);
@@ -1396,7 +1411,8 @@ Twinkle.xfd.callbacks = {
 			text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, '');
 
 			pageobj.setPageText('{{ffd|log=' + params.date + '|help=off}}\n' + text);
-			pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('recreate');  // it might be possible for a file to exist without a description page
 			pageobj.save();
@@ -1411,7 +1427,8 @@ Twinkle.xfd.callbacks = {
 			}
 
 			pageobj.setPageText(text + '\n\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('ffd', params));
-			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
@@ -1452,7 +1469,8 @@ Twinkle.xfd.callbacks = {
 			editsummary += '; see [[:' + params.discussionpage + ']].';
 
 			pageobj.setPageText(added_data + '\n' + text);
-			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary(editsummary);
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('recreate');  // since categories can be populated without an actual page at that title
 			pageobj.save();
@@ -1472,7 +1490,8 @@ Twinkle.xfd.callbacks = {
 			}
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary(editsummary);
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
@@ -1492,7 +1511,8 @@ Twinkle.xfd.callbacks = {
 			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 			var notifytext = '\n{{subst:Cfd notice|1=' + Morebits.pageNameNorm + '|action=' + params.action + (mw.config.get('wgNamespaceNumber') === 10 ? '|stub=yes' : '') + '}} ~~~~';
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:CFD|categories for discussion]].' + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:CFD|categories for discussion]].');
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
 			usertalkpage.setFollowRedirect(true, false);
@@ -1513,7 +1533,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText('{{subst:cfr-speedy|1=' + params.cfdtarget.replace(/^:?Category:/, '') + '}}\n' + text);
-			pageobj.setEditSummary('Listed for speedy renaming; see [[WP:CFDS|Categories for discussion/Speedy]].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Listed for speedy renaming; see [[WP:CFDS|Categories for discussion/Speedy]].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('recreate');  // since categories can be populated without an actual page at that title
 			pageobj.save(function() {
@@ -1533,7 +1554,8 @@ Twinkle.xfd.callbacks = {
 			}
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
@@ -1623,7 +1645,8 @@ Twinkle.xfd.callbacks = {
 			var text = pageobj.getPageText();
 			var params = pageobj.getCallbackParameters();
 			pageobj.setPageText('{{subst:rfd|' + (mw.config.get('wgNamespaceNumber') === 10 ? 'showontransclusion=1|' : '') + 'content=\n' + text + '\n}}');
-			pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('nocreate');
 			pageobj.save();
@@ -1642,7 +1665,8 @@ Twinkle.xfd.callbacks = {
 			}
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
@@ -1689,7 +1713,8 @@ Twinkle.xfd.callbacks = {
 			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 			var notifytext = '\n{{subst:Rfd notice|1=' + Morebits.pageNameNorm + '}} ~~~~';
 			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:RFD|redirects for discussion]].' + Twinkle.getPref('summaryAd'));
+			usertalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:RFD|redirects for discussion]].');
+			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
 			usertalkpage.setFollowRedirect(true, false);
@@ -1705,7 +1730,8 @@ Twinkle.xfd.callbacks = {
 			var targettalkpage = new Morebits.wiki.page(targetTalk, 'Notifying redirect target of the discussion');
 			var notifytext = '\n{{subst:Rfd notice|1=' + Morebits.pageNameNorm + '}} ~~~~';
 			targettalkpage.setAppendText(notifytext);
-			targettalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:RFD|redirects for discussion]].' + Twinkle.getPref('summaryAd'));
+			targettalkpage.setEditSummary('Notification: [[' + params.discussionpage + '|listing]] of [[:' + Morebits.pageNameNorm + ']] at [[WP:RFD|redirects for discussion]].');
+			targettalkpage.setChangeTags(Twinkle.changeTags);
 			targettalkpage.setCreateOption('recreate');
 			Twinkle.xfd.setWatchPref(targettalkpage, Twinkle.getPref('xfdWatchRelated'));
 			targettalkpage.setFollowRedirect(true);
@@ -1724,7 +1750,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 
 			pageobj.setAppendText('\n\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
-			pageobj.setEditSummary('Proposing move' + (params.newname ? ' to [[:' + params.newname + ']]' : '') + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Proposing move' + (params.newname ? ' to [[:' + params.newname + ']]' : ''));
+			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setCreateOption('recreate'); // since the talk page need not exist
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.append(function() {
@@ -1746,7 +1773,8 @@ Twinkle.xfd.callbacks = {
 				return;
 			}
 			pageobj.setPageText(newtext);
-			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].' + Twinkle.getPref('summaryAd'));
+			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 				// add this nomination to the user's userspace log

--- a/twinkle.js
+++ b/twinkle.js
@@ -31,8 +31,13 @@ window.Twinkle = Twinkle;  // allow global access
  * Twinkle-specific data shared by multiple modules
  * Likely customized per installation
  */
-// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
-// ensure MOS:ORDER
+// Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
+Twinkle.changeTags = 'twinkle';
+// Available for actions that don't (yet) support tags
+// currently: FlaggedRevs and PageTriage
+Twinkle.summaryAd = ' ([[WP:TW|TW]])';
+
+// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to ensure [[w:en:MOS:ORDER]]
 Twinkle.hatnoteRegex = 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)';
 
 
@@ -58,9 +63,6 @@ Twinkle.defaultConfig = {};
  */
 Twinkle.defaultConfig = {
 	// General
-	summaryAd: ' ([[WP:TW|TW]])',
-	deletionSummaryAd: ' ([[WP:TW|TW]])',
-	protectionSummaryAd: ' ([[WP:TW|TW]])',
 	userTalkPageMode: 'tab',
 	dialogLargeFont: false,
 	disabledModules: [],
@@ -143,8 +145,12 @@ Twinkle.defaultConfig = {
 	batchMax: 5000,
 	batchChunks: 50,
 
-	// Formerly defaultConfig.friendly:
+	// Deprecated options, as a fallback for add-on scripts/modules
+	summaryAd: ' ([[WP:TW|TW]])',
+	deletionSummaryAd: ' ([[WP:TW|TW]])',
+	protectionSummaryAd: ' ([[WP:TW|TW]])',
 
+	// Formerly defaultConfig.friendly:
 	// Tag
 	groupByDefault: true,
 	watchTaggedPages: true,


### PR DESCRIPTION
See individual commits for details, but basically:

- Defines `Twinkle.changeTags = 'twinkle'` in twinkle.js and applies that across the board
    - Applied to `Morebits.wiki.page` via `setChangesTags()`, and manually to `Morebits.wiki.api` via `tags`
- Excludes PageTriage ([T252980](https://phabricator.wikimedia.org/T252980)) and FlaggedRevs ([T247721](https://phabricator.wikimedia.org/T247721)) (and other 
- Remove customization of `summaryAd` preferences (they options remain hidden as backups, including for use in the above)

There's some precedence for at least being polite and asking before creating a tag like this; I'll post at VPT at some point.  cc @MusikAnimal since this would be a notable change.  Closes #265 