### PR TITLE
Remove useragent 2.0 specification

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1836,14 +1836,14 @@ Morebits.wiki.api.prototype = {
 
 // Custom user agent header, used by WMF for server-side logging
 // See https://lists.wikimedia.org/pipermail/mediawiki-api-announce/2014-November/000075.html
-var morebitsWikiApiUserAgent = 'morebits.js/2.0 ([[w:WT:TW]])';
+var morebitsWikiApiUserAgent = 'morebits.js ([[w:WT:TW]])';
 
 /**
  * Sets the custom user agent header
  * @param {string} ua   User agent
  */
 Morebits.wiki.api.setApiUserAgent = function(ua) {
-	morebitsWikiApiUserAgent = (ua ? ua + ' ' : '') + 'morebits.js/2.0 ([[w:WT:TW]])';
+	morebitsWikiApiUserAgent = (ua ? ua + ' ' : '') + 'morebits.js ([[w:WT:TW]])';
 };
 
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -443,7 +443,7 @@ Twinkle.load = function () {
 	}
 
 	// Set custom Api-User-Agent header, for server-side logging purposes
-	Morebits.wiki.api.setApiUserAgent('Twinkle/2.0 (' + mw.config.get('wgDBname') + ')');
+	Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
 
 	// Load all the modules in the order that the tabs should appear
 	var twinkleModules = [


### PR DESCRIPTION
First added in c236127 but the 2.0 specification hasn't been updated or considered in nearly a decade and its not something we're using.  These are used for logging purposes, all that really matters is that there's a unique and identifiable string, for which the tool and project suffice.

Also move to `wgWikiID` rather than `wgDBname` per https://phabricator.wikimedia.org/rMWd45baf7f0734a2506c77925064f42bc13e1bff5e