### PR TITLE
Merge individual chunk prefs into one: batchChunks

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -319,7 +319,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		}).get();
 
 		var subpageLister = new Morebits.batchOperation();
-		subpageLister.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
+		subpageLister.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		subpageLister.setPageList(pages);
 		subpageLister.run(function worker (pageName) {
 			var pageTitle = mw.Title.newFromText(pageName);
@@ -459,7 +459,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 	}
 
 	var pageDeleter = new Morebits.batchOperation(input.delete_page ? 'Deleting pages' : 'Initiating requested tasks');
-	pageDeleter.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
+	pageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	// we only need the initial status lines if we're deleting the pages in the pages array
 	pageDeleter.setOption('preserveIndividualStatusLines', input.delete_page);
 	pageDeleter.setPageList(input.pages);
@@ -487,7 +487,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 	}, function postFinish() {
 		if (input.delete_subpages) {
 			var subpageDeleter = new Morebits.batchOperation('Deleting subpages');
-			subpageDeleter.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
+			subpageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 			subpageDeleter.setOption('preserveIndividualStatusLines', true);
 			subpageDeleter.setPageList(input.subpages);
 			subpageDeleter.run(function(pageName) {
@@ -589,7 +589,7 @@ Twinkle.batchdelete.callbacks = {
 		}
 
 		var redirectDeleter = new Morebits.batchOperation('Deleting redirects to ' + apiobj.params.page);
-		redirectDeleter.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
+		redirectDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		redirectDeleter.setPageList(pages);
 		redirectDeleter.run(function(pageName) {
 			var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
@@ -620,7 +620,7 @@ Twinkle.batchdelete.callbacks = {
 		}
 
 		var unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
-		unlinker.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
+		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run(function(pageName) {
 			var wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking on ' + pageName);
@@ -672,7 +672,7 @@ Twinkle.batchdelete.callbacks = {
 		}
 
 		var unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
-		unlinker.setOption('chunkSize', Twinkle.getPref('batchdeleteChunks'));
+		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run(function(pageName) {
 			var wikipedia_page = new Morebits.wiki.page(pageName, 'Removing file usages on ' + pageName);

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -388,7 +388,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 	}
 
 	var batchOperation = new Morebits.batchOperation('Applying protection settings');
-	batchOperation.setOption('chunkSize', Twinkle.getPref('batchProtectChunks'));
+	batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	batchOperation.setOption('preserveIndividualStatusLines', true);
 	batchOperation.setPageList(input.pages);
 	batchOperation.run(function(pageName) {

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -136,7 +136,7 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 	}
 
 	var pageUndeleter = new Morebits.batchOperation('Undeleting pages');
-	pageUndeleter.setOption('chunkSize', Twinkle.getPref('batchUndeleteChunks'));
+	pageUndeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	pageUndeleter.setOption('preserveIndividualStatusLines', true);
 	pageUndeleter.setPageList(input.pages);
 	pageUndeleter.run(function(pageName) {

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -915,33 +915,15 @@ Twinkle.config.sections = [
 				name: 'autolevelStaleDays',
 				type: 'integer'
 			},
-			// twinklebatchdelete.js: How many pages should be processed maximum
+			// How many pages should be queried by deprod and batchdelete/protect/undelete
 			{
 				name: 'batchMax',
 				type: 'integer',
 				adminOnly: true
 			},
-			// twinklebatchdelete.js: How many pages should be processed at a time
+			// How many pages should be processed at a time by deprod and batchdelete/protect/undelete
 			{
-				name: 'batchdeleteChunks',
-				type: 'integer',
-				adminOnly: true
-			},
-			// twinklebatchprotect.js: How many pages should be processed at a time
-			{
-				name: 'batchProtectChunks',
-				type: 'integer',
-				adminOnly: true
-			},
-			// twinklebatchundelete.js: How many pages should be processed at a time
-			{
-				name: 'batchundeleteChunks',
-				type: 'integer',
-				adminOnly: true
-			},
-			// twinkledeprod.js: How many pages should be processed at a time
-			{
-				name: 'proddeleteChunks',
+				name: 'batchChunks',
 				type: 'integer',
 				adminOnly: true
 			}

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -44,7 +44,7 @@ Twinkle.deprod.callback = function() {
 		'action': 'query',
 		'generator': 'categorymembers',
 		'gcmtitle': mw.config.get('wgPageName'),
-		'gcmlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
+		'gcmlimit': Twinkle.getPref('batchMax'),
 		'gcmnamespace': '0|6|108|2', // mostly to ignore categories
 		'prop': [ 'info', 'revisions' ],
 		'rvprop': [ 'content' ],
@@ -127,7 +127,7 @@ var callback_commit = function(event) {
 		Morebits.status.init(event.target);
 
 		var batchOperation = new Morebits.batchOperation('Deleting pages');
-		batchOperation.setOption('chunkSize', Twinkle.getPref('proddeleteChunks'));
+		batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		batchOperation.setOption('preserveIndividualStatusLines', true);
 		batchOperation.setPageList(pages);
 		batchOperation.run(function(pageName) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -127,10 +127,7 @@ Twinkle.defaultConfig = {
 	revertMaxRevisions: 50,
 	autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
 	batchMax: 5000,
-	batchdeleteChunks: 50,
-	batchProtectChunks: 50,
-	batchundeleteChunks: 50,
-	proddeleteChunks: 50,
+	batchChunks: 50,
 
 	// Formerly defaultConfig.friendly:
 


### PR DESCRIPTION
`batchdeleteChunks`, `batchProtectChunks`, `batchundeleteChunks`, and `proddeleteChunks` have been around since the inception of these modules, and have been kept as hidden prefs, but there's no real need for four separate preferences.  Nobody is using them (oddly, there are three uses of `proddeleteChunks` by inactive users with negligible edits) and there's no real need for such granularity in hidden prefs, especially given that they've been unchanged for over a decade.  This replaces them all with one unified hidden pref, `batchChunks`.

Also makes use of `batchMax` in `deprod`.