### PR TITLE
xfd: Fix xfd log numbering

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -814,7 +814,7 @@ Twinkle.xfd.callbacks = {
 		}
 		appendText += ' ~~~~~';
 		if (params.reason) {
-			appendText += "\n#* '''Reason''': " + params.reason + '\n';
+			appendText += "\n#* '''Reason''': " + params.reason;
 		}
 
 		usl.log(appendText, editsummary + Twinkle.getPref('summaryAd'));

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -745,7 +745,7 @@ Twinkle.xfd.callbacks = {
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
 		var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
 
-		var appendText = '\n# [[:' + Morebits.pageNameNorm + ']]' + fileLogLink + ' nominated at [[WP:' + params.venue.toUpperCase() + '|' + toTLACase(params.venue) + ']]';
+		var appendText = '# [[:' + Morebits.pageNameNorm + ']]' + fileLogLink + ' nominated at [[WP:' + params.venue.toUpperCase() + '|' + toTLACase(params.venue) + ']]';
 		var extraInfo = '';
 
 		switch (params.venue) {


### PR DESCRIPTION
Issue: The log numbering at, e.g., [User:Mdaniels5757/XfD log at 963070422](https://en.wikipedia.org/wiki/Special:Permalink/963070422) is wrong (repeating 1s) because there is an extra newline when a reason is provided.

Solution: Removed that newline (line 817, twinklexfd.js).

Cheers,
Michael (User:Mdaniels5757)