### PR TITLE
tag: Fix issue in whitespace matching preexisting rcats

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1822,6 +1822,10 @@ Twinkle.tag.callbacks = {
 			summaryText += ' {{[[:' + (tagName.indexOf(':') !== -1 ? tagName : 'Template:' + tagName + '|' + tagName) + ']]}}';
 		};
 
+		if (!tags.length) {
+			Morebits.status.warn('Info', 'No tags remaining to apply');
+		}
+
 		tags.sort();
 		$.each(tags, addTag);
 
@@ -1832,19 +1836,20 @@ Twinkle.tag.callbacks = {
 			pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
 		} else {
 			// Fold any pre-existing Rcats into taglist and under Rcatshell
-			var pageTags = pageText.match(/\n{{R(?:edirect)? .*?}}/img);
+			var pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
 			var oldPageTags = '';
 			if (pageTags) {
 				pageTags.forEach(function(pageTag) {
 					var pageRe = new RegExp(pageTag, 'img');
 					pageText = pageText.replace(pageRe, '');
-					oldPageTags += pageTag;
+					pageTag = pageTag.trim();
+					oldPageTags += '\n' + pageTag;
 				});
 			}
 			pageText += '\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
 		}
 
-		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : '') : '') + ' to redirect';
+		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : 'rcat shell') + ' to redirect';
 
 		// avoid truncated summaries
 		if (summaryText.length > (499 - Twinkle.getPref('summaryAd').length)) {


### PR DESCRIPTION
The overly-strict requirement of `\n` meant any tags existing on the same line as the redirect would be missed.  This would lead to some unexpected behavior when an existing tag wasn't in an rcat shell, and thus an empty shell was added.  Reported at https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=963773656#Special:Diff/963757536, see https://en.wikipedia.org/w/index.php?diff=963757536.  This has the added benefit of being slightly more tidy around whitespace.

Also fixed the edit summary in cases when no tags are added.