### PR TITLE
[ARV] Cleanup: Don't save single-use api variables

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -329,8 +329,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 						var $field = $(root).find('[name=' + field + ']');
 						$field.find('.entry').remove();
 
-						var api = new mw.Api();
-						api.get({
+						new mw.Api().get({
 							action: 'query',
 							prop: 'revisions',
 							format: 'json',
@@ -750,8 +749,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					}
 				}
 
-				var api = new mw.Api();
-				api.get(query).done(function(data) {
+				new mw.Api().get(query).done(function(data) {
 					var page;
 					if (data.compare && data.compare.fromtitle === data.compare.totitle) {
 						page = data;
@@ -859,8 +857,7 @@ Twinkle.arv.processAN3 = function(params) {
 		}
 	}
 
-	var api = new mw.Api();
-	api.get({
+	new mw.Api().get({
 		action: 'query',
 		prop: 'revisions',
 		format: 'json',


### PR DESCRIPTION
If an api object is only used once, no need to store it in a variable