### PR TITLE
tag: Disallow conflicting file tags and use functions to validate

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -2028,6 +2028,71 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			break;
 
 		case 'file':
+			if (((params.tags.indexOf('Bad GIF') !== -1) + (params.tags.indexOf('Bad JPEG') !== -1) +
+				(params.tags.indexOf('Bad SVG') !== -1) + (params.tags.indexOf('Bad format') !== -1)) > 1) {
+				alert('Please select only one of {{Bad GIF}}, {{Bad JPEG}}, {{Bad SVG}}, and {{bad format}}.');
+				return;
+			}
+			if (((params.tags.indexOf('Should be PNG') !== -1) + (params.tags.indexOf('Should be SVG') !== -1) +
+				(params.tags.indexOf('Should be text') !== -1)) > 1) {
+				alert('Please select only one of {{Should be PNG}}, {{Should be SVG}}, and {{Should be text}}.');
+				return;
+			}
+			if ((params.tags.indexOf('Bad SVG') !== -1) && (params.tags.indexOf('Vector version available') !== -1)) {
+				alert('Please select only one of {{Bad SVG}} and {{Vector version available}}.');
+				return;
+			}
+			if ((params.tags.indexOf('Bad JPEG') !== -1) && (params.tags.indexOf('Overcompressed JPEG') !== -1)) {
+				alert('Please select only one of {{Bad JPEG}} and {{Overcompressed JPEG}}.');
+				return;
+			}
+			if ((params.tags.indexOf('PNG version available') !== -1) && (params.tags.indexOf('Vector version available') !== -1)) {
+				alert('Please select only one of {{PNG version available}} and {{Vector version available}}.');
+				return;
+			}
+
+			var extension;
+			if ((extension = Morebits.pageNameNorm.match(/\.(\w+)$/)) !== null) {
+				extension = extension[1];
+				var extensionUpper = extension.toUpperCase();
+
+				// What self-respecting file format has *two* extensions?!
+				if (extensionUpper === 'JPG') {
+					extension = 'JPEG';
+				}
+
+				// We've already ensured above that there can be only one of {{Bad *}} and {{Should be *}},
+				// so these check that it actually matches the file's actual extension.  We need to check
+				// if any tags start with a string, which means using string's indexOf, since can't
+				// use ES6y things like find or findIndex.
+
+				// Bad GIF|JPEG|SVG
+				if ((params.tags.toString().indexOf('Bad ') !== -1) && (params.tags.indexOf('Bad ' + extensionUpper) === -1)) {
+					alert('This appears to be a ' + extension + ' file, please use {{Bad ' + extensionUpper + '}} instead.');
+					return;
+				}
+				// Should be PNG|SVG
+				if ((params.tags.toString().indexOf('Should be ') !== -1) && (params.tags.indexOf('Should be ' + extensionUpper) === -1)) {
+					alert('This appears to be a ' + extension + ' file, please use {{Should be ' + extensionUpper + '}} instead.');
+					return;
+				}
+
+				// Overcompressed JPEG
+				if (params.tags.indexOf('Overcompressed JPEG') !== -1 && extensionUpper !== 'JPEG') {
+					alert('This appears to be a ' + extension + ' file, so {{Overcompressed JPEG}} probably doesn\'t apply.');
+					return;
+				}
+				// Bad trace and Bad font
+				if (extensionUpper !== 'SVG') {
+					if (params.tags.indexOf('Bad trace') !== -1) {
+						alert('This appears to be a ' + extension + ' file, so {{Bad trace}} probably doesn\'t apply.');
+						return;
+					} else if (params.tags.indexOf('Bad font') !== -1) {
+						alert('This appears to be a ' + extension + ' file, so {{Bad font}} probably doesn\'t apply.');
+						return;
+					}
+				}
+			}
 
 			if (params.tags.indexOf('Cleanup image') !== -1 && params.cleanupimageReason === '') {
 				alert('You must specify a reason for the cleanup tag.');


### PR DESCRIPTION
1st commit disallows some conflicting file tags, as requested at [WT:TW](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_42#Mutually_exclusive_tags).  There are probably more we could do, this covers:
- Only one of {{Bad GIF}}, {{Bad JPEG}}, {{Bad SVG}}, and {{Bad format}} is used
- Only one of {{Should be PNG}}, {{Should be SVG}}, and {{Should be text}} is used
- Only one of {{Bad SVG}} and {{Vector version available}} is used
- Only one of {{Bad JPEG}} and {{Overcompressed JPEG}} is used
- Only one of {{PNG version available}} and {{Vector version available}} is used
- The correct extension is used for Bad GIF/JPEG/SVG and Should be PNG/SVG
- Only allows JPEGs to be tagged with {{Overcompressed JPEG}}
- Only allows SVGs to be tagged with {{Bad trace}} and {{Bad font}}

2nd commit uses `checkIncompatible` and `checkParameter` to make the repetitive validation measures more straightforward.