### PR TITLE
tag: rename 'Quick filter' label to 'Filter tag list'

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -45,7 +45,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 	form.append({
 		type: 'input',
-		label: 'Quick filter: ',
+		label: 'Filter tag list: ',
 		name: 'quickfilter',
 		size: '30px',
 		event: function twinkletagquickfilter() {


### PR DESCRIPTION
Semantically more clear