### PR TITLE
morebits: fix ability to query in JSON

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1743,7 +1743,7 @@ Morebits.wiki.api.prototype = {
 			type: 'POST',
 			url: mw.util.wikiScript('api'),
 			data: queryString,
-			dataType: 'xml',
+			dataType: this.query.format,
 			headers: {
 				'Api-User-Agent': morebitsWikiApiUserAgent
 			}


### PR DESCRIPTION
Lost in between adding JSON support (19435c4/#493) and removing `queryString` (37d6b67/#725)