### PR TITLE
lint: mark globals as writeable/readonly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
 		"jquery": true
 	},
 	"globals": {
-		"mw": true
+		"mw": "readonly"
 	},
 	"ignorePatterns": "select2*",
 	"rules": {

--- a/modules/.eslintrc.json
+++ b/modules/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"globals": {
-		"Twinkle": true,
-		"Morebits": true
+		"Morebits": "readonly",
+		"Twinkle": "writable"
 	}
 }


### PR DESCRIPTION
The values false and true are deprecated, they are equivalent to "readonly" and "writable", respectively.

See https://eslint.org/docs/user-guide/configuring#specifying-globals