### PR TITLE
block: fix IE bug

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1298,7 +1298,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 		data.autoblock = false;
 	}
 
-	$(form.field_block_options).find(':checkbox').each(function(i, el) {
+	$(form).find('[name=field_block_options]').find(':checkbox').each(function(i, el) {
 		// don't override original options if useInitialOptions is set
 		if (data.useInitialOptions && data[el.name] === undefined) {
 			return;


### PR DESCRIPTION
In IE, fieldset elements are not available as properties on the HTMLFormElement object. The loop was silently being skipped as `$(undefined).find(...).each(...)` doesn't throw. This bug has been here since the block module was added in 465eb53.
