### PR TITLE
tag: Fix bug in processing existing tags

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1963,7 +1963,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 	switch (Twinkle.tag.mode) {
 		case 'article':
 			params.tagsToRemove = form.getUnchecked('existingTags'); // not in `input`
-			params.tagsToRemain = params.existingTags;
+			params.tagsToRemain = params.existingTags || []; // container not created if none present
 
 			// Validation
 			if ((params.tags.indexOf('Merge') !== -1) || (params.tags.indexOf('Merge from') !== -1) ||


### PR DESCRIPTION
`[name=existingTags]` isn't added unless there are existing tags, so this stalls out when there are none.  `form.getChecked('existingTags')` would presumably work as well, thanks to 83c5955.