### PR TITLE
morebits: Fix bug defaulting followCrossNsRedirect to false

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2446,7 +2446,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			return;
 		}
 		ctx.followRedirect = followRedirect;
-		ctx.followCrossNsRedirect = followCrossNsRedirect;
+		ctx.followCrossNsRedirect = typeof followCrossNsRedirect !== 'undefined' ? followCrossNsRedirect : ctx.followCrossNsRedirect;
 	};
 
 	// lookup-creation setter function


### PR DESCRIPTION
Introduced in #915, but if the second parameter to `setFollowRedirect` (aka `followCrossNsRedirect`) isn't provided, it is passed as `undefined` aka falsey.  That breaks anything that is was using `setFollowRedirect` without explicitly passing a second parameter (aka everything), given that the default value is `true`.

As elsewhere, this `typeof` style is because IE11 doesn't support default parameters.