### PR TITLE
tag: Don't follow cross-namespace redirect when posting to user talk page

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1413,7 +1413,7 @@ Twinkle.tag.callbacks = {
 						userTalkPage.setEditSummary('Notice: Please use English when contributing to the English Wikipedia.' +
 							Twinkle.getPref('summaryAd'));
 						userTalkPage.setCreateOption('recreate');
-						userTalkPage.setFollowRedirect(true);
+						userTalkPage.setFollowRedirect(true, false);
 						userTalkPage.append();
 					});
 				}


### PR DESCRIPTION
Missed this with the others, but I guess we don't want to do it here either?