### PR TITLE
tag: Fix regex for renamed {{other hurricanes}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1639,7 +1639,7 @@ Twinkle.tag.callbacks = {
 					// PROD
 					'(?:proposed deletion|prod blp)\\/dated(?:\\s*\\|(?:concern|user|timestamp|help).*)+|' +
 					// various hatnote templates
-					'about|correct title|dablink|distinguish|for|other\\s?(?:hurricaneuses|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|short description|the' +
+					'about|correct title|dablink|distinguish|for|other\\s?(?:hurricane(?: use)?s|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|short description|the' +
 					// not a hatnote, but sometimes under a CSD or AfD
 					'|salt|proposed deletion endorsed' +
 					// end main template name, optionally with a number (such as redirect2)


### PR DESCRIPTION
Renamed from {{Other hurricaneuses}} to {{Other hurricane uses}} in 2010, and then again to {{Other hurricanes}} in 2011.  The intermediate form has about 200 instances, so the regex allows for it.