### PR TITLE
Add `insertAfterTemplates` to Morebits.wikitext.page, respect MOS:ORDER when tagging, update hatnotes

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1516,40 +1516,22 @@ Twinkle.tag.callbacks = {
 		var addUngroupedTags = function() {
 			$.each(tags, addTag);
 
-			// Smartly insert the new tags after any hatnotes or
-			// afd, csd, or prod templates or hatnotes. Regex is
-			// extra complicated to allow for templates with
-			// parameters and to handle whitespace properly.
-			pageText = pageText.replace(
-				new RegExp(
-					// leading whitespace
-					'^\\s*' +
-					// capture template(s)
-					'(?:((?:\\s*' +
-					// AfD is special, as the tag includes html comments before and after the actual template
-					'(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?|' + // trailing whitespace/newline needed since this subst's a newline
-					// begin template format
-					'\\{\\{\\s*(?:' +
-					// CSD
-					'db|delete|db-.*?|speedy deletion-.*?|' +
-					// PROD
-					'(?:proposed deletion|prod blp)\\/dated(?:\\s*\\|(?:concern|user|timestamp|help).*)+|' +
-					// various hatnote templates
-					'about|correct title|dablink|distinguish|for|other\\s?(?:hurricane(?: use)?s|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|short description|the' +
-					// not a hatnote, but sometimes under a CSD or AfD
-					'|salt|proposed deletion endorsed' +
-					// end main template name, optionally with a number (such as redirect2)
-					')\\d*\\s*' +
-					// template parameters
-					'(\\|(?:\\{\\{[^{}]*\\}\\}|[^{}])*)?' +
-					// end template format
-					'\\}\\})+' +
-					// end capture
-					'(?:\\s*\\n)?)' +
-					// trailing whitespace
-					'\\s*)?',
-					'i'), '$1' + tagText
-			);
+			// Insert tag after short description or any hatnotes,
+			// as well as deletion/protection-related templates
+			var wikipage = new Morebits.wikitext.page(pageText);
+			var templatesAfter = Twinkle.hatnoteRegex +
+				// Protection templates
+				'pp|pp-.*?|' +
+				// CSD
+				'db|delete|db-.*?|speedy deletion-.*?|' +
+				// PROD
+				'(?:proposed deletion|prod blp)\\/dated(?:\\s*\\|(?:concern|user|timestamp|help).*)+|' +
+				// not a hatnote, but sometimes under a CSD or AfD
+				'salt|proposed deletion endorsed';
+			// AfD is special, as the tag includes html comments before and after the actual template
+			// trailing whitespace/newline needed since this subst's a newline
+			var afdRegex = '(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?';
+			pageText = wikipage.insertAfterTemplates(tagText, templatesAfter, null, afdRegex).getText();
 
 			removeTags();
 		};

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -648,9 +648,8 @@ Twinkle.batchdelete.callbacks = {
 		}
 		var old_text = text;
 		var wikiPage = new Morebits.wikitext.page(text);
-		wikiPage.removeLink(params.page);
+		text = wikiPage.removeLink(params.page).getText();
 
-		text = wikiPage.getText();
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
 		if (text === old_text) {
 			// Nothing to do, return
@@ -701,9 +700,8 @@ Twinkle.batchdelete.callbacks = {
 		}
 		var old_text = text;
 		var wikiPage = new Morebits.wikitext.page(text);
-		wikiPage.commentOutImage(image, 'Commented out because image was deleted');
+		text = wikiPage.commentOutImage(image, 'Commented out because image was deleted').getText();
 
-		text = wikiPage.getText();
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
 		if (text === old_text) {
 			pageobj.getStatusElement().error('failed to unlink image ' + image + ' from ' + pageobj.getPageName());

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -308,16 +308,21 @@ Twinkle.prod.callbacks = {
 			} else if (Twinkle.getPref('logProdPages')) { // If not notifying, log this PROD
 				Twinkle.prod.callbacks.addToLog(params);
 			}
+			var tag;
 			if (params.blp) {
 				summaryText = 'Proposing article for deletion per [[WP:BLPPROD]].';
-				text = '{{subst:prod blp' + (params.usertalk ? '|help=off' : '') + '}}\n' + text;
+				tag = '{{subst:prod blp' + (params.usertalk ? '|help=off' : '') + '}}';
 			} else if (params.book) {
 				summaryText = 'Proposing book for deletion per [[WP:BOOKPROD]].';
-				text = '{{subst:book-prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}\n' + text;
+				tag = '{{subst:book-prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}';
 			} else {
 				summaryText = 'Proposing ' + namespace + ' for deletion per [[WP:PROD]].';
-				text = '{{subst:prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}\n' + text;
+				tag = '{{subst:prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}';
 			}
+
+			// Insert tag after short description or any hatnotes
+			var wikipage = new Morebits.wikitext.page(text);
+			text = wikipage.insertAfterTemplates(tag + '\n', Twinkle.hatnoteRegex).getText();
 
 			// Add {{Old prod}} to the talk page
 			if (!params.oldProdPresent) {

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1438,10 +1438,16 @@ Twinkle.protect.callbacks = {
 					Morebits.status.info('Redirect category shell present', 'nothing to do');
 					return;
 				}
-			} else if (params.noinclude) {
-				text = '<noinclude>{{' + tag + '}}</noinclude>' + text;
 			} else {
-				text = '{{' + tag + '}}\n' + text;
+				if (params.noinclude) {
+					tag = '<noinclude>{{' + tag + '}}</noinclude>';
+				} else {
+					tag = '{{' + tag + '}}\n';
+				}
+
+				// Insert tag after short description or any hatnotes
+				var wikipage = new Morebits.wikitext.page(text);
+				text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
 			}
 			summary = 'Adding {{' + params.tag + '}}' + Twinkle.getPref('summaryAd');
 		}

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1545,7 +1545,18 @@ Twinkle.speedy.callbacks = {
 				code = code.replace('$TIMESTAMP', pageobj.getLastEditTime());
 			}
 
-			pageobj.setPageText(code + (params.normalizeds.indexOf('g10') !== -1 ? '' : '\n' + text)); // cause attack pages to be blanked
+
+			// Blank attack pages
+			if (params.normalizeds.indexOf('g10') !== -1) {
+				text = code;
+			} else {
+				// Insert tag after short description or any hatnotes
+				var wikipage = new Morebits.wikitext.page(text);
+				text = wikipage.insertAfterTemplates(code + '\n', Twinkle.hatnoteRegex).getText();
+			}
+
+
+			pageobj.setPageText(text);
 			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 			pageobj.setWatchlist(params.watch);
 			if (params.scribunto) {

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -255,8 +255,7 @@ Twinkle.unlink.callbacks = {
 
 		// remove image usages
 		if (params.doImageusage) {
-			wikiPage.commentOutImage(mw.config.get('wgTitle'), 'Commented out');
-			text = wikiPage.getText();
+			text = wikiPage.commentOutImage(mw.config.get('wgTitle'), 'Commented out').getText();
 			// did we actually make any changes?
 			if (text === oldtext) {
 				warningString = 'file usages';
@@ -268,8 +267,7 @@ Twinkle.unlink.callbacks = {
 
 		// remove backlinks
 		if (params.doBacklinks) {
-			wikiPage.removeLink(Morebits.pageNameNorm);
-			text = wikiPage.getText();
+			text = wikiPage.removeLink(Morebits.pageNameNorm).getText();
 			// did we actually make any changes?
 			if (text === oldtext) {
 				warningString = warningString ? 'backlinks or file usages' : 'backlinks';

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -925,8 +925,14 @@ Twinkle.xfd.callbacks = {
 				text = textNoSd;
 			}
 
-			pageobj.setPageText((params.noinclude ? '<noinclude>{{' : '{{') + (params.number === '' ? 'subst:afd|help=off' : 'subst:afdx|' +
-				params.number + '|help=off') + (params.noinclude ? '}}</noinclude>\n' : '}}\n') + text);
+			var tag = (params.noinclude ? '<noinclude>{{' : '{{') + (params.number === '' ? 'subst:afd|help=off' : 'subst:afdx|' +
+					params.number + '|help=off') + (params.noinclude ? '}}</noinclude>\n' : '}}\n');
+
+			// Insert tag after short description or any hatnotes
+			var wikipage = new Morebits.wikitext.page(text);
+			text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
+
+			pageobj.setPageText(text);
 			pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].' + Twinkle.getPref('summaryAd'));
 			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
 			pageobj.setCreateOption('nocreate');

--- a/morebits.js
+++ b/morebits.js
@@ -3894,6 +3894,8 @@ Morebits.wikitext.page.prototype = {
 	/**
 	 * Removes links to `link_target` from the page text.
 	 * @param {string} link_target
+	 *
+	 * @returns {Morebits.wikitext.page}
 	 */
 	removeLink: function(link_target) {
 		var first_char = link_target.substr(0, 1);
@@ -3907,6 +3909,7 @@ Morebits.wikitext.page.prototype = {
 		var link_simple_re = new RegExp('\\[\\[' + colon + '(' + link_re_string + ')\\]\\]', 'g');
 		var link_named_re = new RegExp('\\[\\[' + colon + link_re_string + '\\|(.+?)\\]\\]', 'g');
 		this.text = this.text.replace(link_simple_re, '$1').replace(link_named_re, '$1');
+		return this;
 	},
 
 	/**
@@ -3914,6 +3917,8 @@ Morebits.wikitext.page.prototype = {
 	 * If used as a template argument (not necessarily with File: prefix), the template parameter is commented out.
 	 * @param {string} image - Image name without File: prefix
 	 * @param {string} reason - Reason to be included in comment, alongside the commented-out image
+	 *
+	 * @returns {Morebits.wikitext.page}
 	 */
 	commentOutImage: function(image, reason) {
 		var unbinder = new Morebits.unbinder(this.text);
@@ -3951,12 +3956,15 @@ Morebits.wikitext.page.prototype = {
 		unbinder.content = unbinder.content.replace(free_image_re, '<!-- ' + reason + '$1 -->');
 		// Rebind the content now, we are done!
 		this.text = unbinder.rebind();
+		return this;
 	},
 
 	/**
 	 * Converts first usage of [[File:`image`]] to [[File:`image`|`data`]]
 	 * @param {string} image - Image name without File: prefix
 	 * @param {string} data
+	 *
+	 * @returns {Morebits.wikitext.page}
 	 */
 	addToImageComment: function(image, data) {
 		var first_char = image.substr(0, 1);
@@ -3978,12 +3986,15 @@ Morebits.wikitext.page.prototype = {
 		var gallery_re = new RegExp('^(\\s*' + image_re_string + '.*?)\\|?(.*?)$', 'mg');
 		var newtext = '$1|$2 ' + data;
 		this.text = this.text.replace(gallery_re, newtext);
+		return this;
 	},
 
 	/**
 	 * Removes transclusions of template from page text
 	 * @param {string} template - Page name whose transclusions are to be removed,
 	 * include namespace prefix only if not in template namespace
+	 *
+	 * @returns {Morebits.wikitext.page}
 	 */
 	removeTemplate: function(template) {
 		var first_char = template.substr(0, 1);
@@ -3995,6 +4006,7 @@ Morebits.wikitext.page.prototype = {
 				this.text = this.text.replace(allTemplates[i], '', 'g');
 			}
 		}
+		return this;
 	},
 
 	/** @returns {string} */

--- a/twinkle.js
+++ b/twinkle.js
@@ -33,7 +33,7 @@ window.Twinkle = Twinkle;  // allow global access
  */
 // Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
 // ensure MOS:ORDER
-Twinkle.hatnoteRegex = 'about|correct title|dablink|distinguish|for|other\\s?(?:hurricane(?: use)?s|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|short description|the';
+Twinkle.hatnoteRegex = 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)';
 
 
 Twinkle.initCallbacks = [];

--- a/twinkle.js
+++ b/twinkle.js
@@ -27,8 +27,16 @@ if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirm
 var Twinkle = {};
 window.Twinkle = Twinkle;  // allow global access
 
-Twinkle.initCallbacks = [];
+/**
+ * Twinkle-specific data shared by multiple modules
+ * Likely customized per installation
+ */
+// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
+// ensure MOS:ORDER
+Twinkle.hatnoteRegex = 'about|correct title|dablink|distinguish|for|other\\s?(?:hurricane(?: use)?s|people|persons|places|uses(?:of)?)|redirect(?:-acronym)?|see\\s?(?:also|wiktionary)|selfref|short description|the';
 
+
+Twinkle.initCallbacks = [];
 /**
  * Adds a callback to execute when Twinkle has loaded.
  * @param {function} func


### PR DESCRIPTION
As noted [on WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=964243708#Twinkle_violating_MOS:ORDER_-_needs_correction), Twinkle isn't great about [MOS:ORDER](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Layout#Order_of_article_elements) when tagging things.  Accordingly, this:

- 1st commit adds a function to Morebits.wikitext.page to insert a string after a provided template regex.  This is basically copied from the handling in `tag`.  Takes either a string or an array and allows for custom flags.
- 2nd commit uses that in xfd/protect/prod/csd/tag, with tag getting the extra benefit of finally learning about protection tags (`{{pp}}`, `{{pp-move}}`, etc.).  A new hidden preference, `hatnoteRegex`, is added to store the "various hatnotes templates` regex in a unified location.
- 3rd commit expands thats regex with most hatnotes from [Template:Hatnote templates](https://en.wikipedia.org/w/index.php?title=Template:Hatnote_templates) with more than a hundred or so transclusions.

There are some more notes in the individual commits.  The main annoyance is that AfD has a comment *before* the actual template, so having to support that as well is a drag.  Maybe the option to specify a flag for the regex for `insertAfterTemplates` is unnecessary?