### PR TITLE
xfd: undisable all options, use warning texts instead

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -56,7 +56,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 		type: 'select',
 		name: 'category',
 		label: 'Deletion discussion venue:',
-		tooltip: 'When activated, a default choice is made, based on what namespace you are in. This default should be the most appropriate; some inappropriate options may be disabled.',
+		tooltip: 'When activated, a default choice is made, based on what namespace you are in. This default should be the most appropriate.',
 		event: Twinkle.xfd.callback.change_category
 	});
 	var namespace = mw.config.get('wgNamespaceNumber');
@@ -71,28 +71,24 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 		type: 'option',
 		label: 'TfD (Templates for discussion)',
 		selected: [ 10, 828 ].indexOf(namespace) !== -1,  // Template and module namespaces
-		value: 'tfd',
-		disabled: namespace === 10 && /-stub$/.test(Morebits.pageNameNorm) // Stub templates at CfD
+		value: 'tfd'
 	});
 	categories.append({
 		type: 'option',
 		label: 'FfD (Files for discussion)',
 		selected: namespace === 6,  // File namespace
-		value: 'ffd',
-		disabled: namespace !== 6
+		value: 'ffd'
 	});
 	categories.append({
 		type: 'option',
 		label: 'CfD (Categories for discussion)',
 		selected: namespace === 14 || (namespace === 10 && /-stub$/.test(Morebits.pageNameNorm)),  // Category namespace and stub templates
-		value: 'cfd',
-		disabled: [ 10, 14 ].indexOf(namespace) === -1 // Disabled outside category and templatespace
+		value: 'cfd'
 	});
 	categories.append({
 		type: 'option',
 		label: 'CfD/S (Categories for speedy renaming)',
-		value: 'cfds',
-		disabled: namespace !== 14
+		value: 'cfds'
 	});
 	categories.append({
 		type: 'option',
@@ -111,8 +107,13 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 		type: 'option',
 		label: 'RM (Requested moves)',
 		selected: false,
-		value: 'rm',
-		disabled: namespace === 14
+		value: 'rm'
+	});
+
+	form.append({
+		type: 'div',
+		id: 'wrong-venue-warn',
+		style: 'color: red; font-style: italic'
 	});
 
 	form.append({
@@ -155,6 +156,54 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	result.category.dispatchEvent(evt);
 };
 
+Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(venue) {
+	var text = '';
+	var namespace = mw.config.get('wgNamespaceNumber');
+
+	switch (venue) {
+		case 'afd':
+			if (namespace !== 0) {
+				text = 'AfD is generally appropriate only for articles.';
+			} else if (mw.config.get('wgIsRedirect')) {
+				text = 'Please use RfD for redirects.';
+			}
+			break;
+		case 'tfd':
+			if (namespace === 10 && /-stub$/.test(Morebits.pageNameNorm)) {
+				text = 'Use CfD for stub templates.';
+			} else if (Morebits.pageNameNorm.indexOf('Template:User ') === 0) {
+				text = 'Please use MfD for userboxes';
+			}
+			break;
+		case 'cfd':
+			if ([ 10, 14 ].indexOf(namespace) === -1) {
+				text = 'CfD is only for categories and stub templates.';
+			}
+			break;
+		case 'cfds':
+			if (namespace !== 14) {
+				text = 'CfDS is only for categories.';
+			}
+			break;
+		case 'ffd':
+			if (namespace !== 6) {
+				text = 'FFD is selected but this page doesn\'t look like a file!';
+			}
+			break;
+		case 'rm':
+			if (namespace === 14) { // category
+				text = 'Please use CfD or CfDS for category renames.';
+			}
+			break;
+
+		default: // mfd or rfd
+			break;
+	}
+
+	$('#wrong-venue-warn').text(text);
+
+};
+
 Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory(e) {
 	var value = e.target.value;
 	var form = e.target.form;
@@ -173,6 +222,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			tooltip: 'You can use wikimarkup in your reason. Twinkle will automatically sign your post.'
 		});
 	};
+
+	Twinkle.xfd.callback.wrongVenueWarning(value);
 
 	form.previewer.closePreview();
 
@@ -304,10 +355,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Templates for discussion',
 				name: 'work_area'
 			});
-			work_area.append({
-				type: 'div',
-				label: 'Userboxes are not eligible for TfD; they go to MfD.'
-			});
+
 			var templateOrModule = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'module' : 'template';
 			var tfd_category = work_area.append({
 				type: 'select',


### PR DESCRIPTION
In my opinion, the new system of having some of the invalid options disabled but not the others is just ugly and plain unprofessional. It isn't feasible to disable all invalid options, so I think the better solution is to allow anything to be selected, but use warning texts to tell the user in the interface that the option may not be appropriate.

At the same time, with the warning showed on selecting AfD on redirects takes care of a [recent WT:TW request](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#AfDing_non-Article_page) and alleviates the issue #379. 

Closes #753.