### PR TITLE
Bump font size to 12px

### DIFF
--- a/morebits.css
+++ b/morebits.css
@@ -40,6 +40,7 @@ form.quickform
 form.quickform *
 {
 	font-family: sans-serif;
+	font-size: 12px;
 }
 
 form.quickform fieldset
@@ -186,10 +187,6 @@ div.morebits-previewbox .mw-editsection
 	background-image: none;
 }
 
-body.skin-monobook .morebits-dialog {
-	font-size: 125%;
-}
-
 body .ui-dialog.morebits-dialog .ui-dialog-titlebar {
 	height: 1em;
 	background-color: #BCCADF !important;
@@ -221,7 +218,6 @@ body.skin-monobook .morebits-dialog .ui-dialog-titlebar {
 }
 
 .ui-dialog.morebits-dialog .morebits-dialog-content {
-	font-size: 88%;  /* this just seems to be traditional - I don't quite see the point, in this day and age of huge monitors, etc. */
 	padding: 0;
 }
 


### PR DESCRIPTION
Twinkle has been using a font-size of 11.44px (11px on monobook) on all UI dialog texts all these years. I think this is way too small that it causes accessibility issues for at least some users and is generally hard to read. 

I propose bumping the morebits font-size to 12px. This change is subtle enough that it doesn't disturb the relative positioning of any UI elements, and would likely go unnoticed, but at the same time it does make things easier to read. 