### PR TITLE
morebits: add Morebits.taskManager

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
 		"jquery": true
 	},
 	"globals": {
-		"mw": "readonly"
+		"mw": "readonly",
+		"Map": "readonly"
 	},
 	"ignorePatterns": ["dev/", "lib/"],
 	"rules": {

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -180,208 +180,234 @@ Twinkle.prod.callback.prodtypechanged = function(event) {
 	event.target.form.replaceChild(field.render(), $(event.target.form).find('fieldset[name="parameters"]')[0]);
 };
 
+// global params object, initially set in evaluate(), and
+// modified in various callback functions
+var params = {};
+
 Twinkle.prod.callbacks = {
-	checkpriors: function(apiobj) {
-		var xmlDoc = apiobj.responseXML;
-		var statelem = apiobj.statelem;
-		var params = apiobj.params;
+	checkpriors: function twinkleprodCheckpriors() {
 
-		// Check talk page for templates indicating prior XfD or PROD
-		var numTemplates = $(xmlDoc).find('templates tl').length;
-		if (numTemplates) {
-			var template = $(xmlDoc).find('templates tl')[0].getAttribute('title');
-			if (numTemplates === 1 && template === 'Template:Old prod') {
-				params.oldProdPresent = true; // Mark for reference later, when deciding if to endorse
-			// if there are multiple templates, at least one of them would be a prior xfd template
-			} else {
-				statelem.warn('Previous XfD template found on talk page, aborting procedure');
-				return;
+		var talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+		// Talk page templates for PROD-able discussions
+		var blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
+			'Template:Oldpuffull|' + // Legacy prior XfD template
+			'Template:Olddelrev|' + // Prior DRV template
+			'Template:Old prod';
+		var query = {
+			'action': 'query',
+			'titles': talk_title,
+			'prop': 'templates',
+			'tltemplates': blocking_templates
+		};
+
+		var wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
+		return wikipedia_api.post().then(function(apiobj) {
+			var xmlDoc = apiobj.responseXML;
+			var statelem = apiobj.statelem;
+
+			// Check talk page for templates indicating prior XfD or PROD
+			var numTemplates = $(xmlDoc).find('templates tl').length;
+			if (numTemplates) {
+				var template = $(xmlDoc).find('templates tl')[0].getAttribute('title');
+				if (numTemplates === 1 && template === 'Template:Old prod') {
+					params.oldProdPresent = true; // Mark for reference later, when deciding if to endorse
+				// if there are multiple templates, at least one of them would be a prior xfd template
+				} else {
+					statelem.warn('Previous XfD template found on talk page, aborting procedure');
+					return $.Deferred().reject();
+				}
 			}
-		}
-
-		var ts = new Morebits.wiki.page(mw.config.get('wgPageName'));
-		ts.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
-		ts.setCallbackParameters(params);
-		ts.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
-		ts.lookupCreation(Twinkle.prod.callbacks.creationInfo);
+		});
 	},
 
-	creationInfo: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
-		params.initialContrib = pageobj.getCreator();
-		params.creation = pageobj.getCreationTimestamp();
+	fetchCreationInfo: function twinkleprodFetchCreationInfo() {
+		var def = $.Deferred();
+		var ts = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Looking up page creator');
+		ts.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
+		ts.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
+		ts.lookupCreation(function(pageobj) {
+			params.initialContrib = pageobj.getCreator();
+			params.creation = pageobj.getCreationTimestamp();
+			pageobj.getStatusElement().info('Done, found ' + params.initialContrib);
+			def.resolve();
+		}, def.reject);
+		return def;
+	},
 
-		Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
-		Morebits.wiki.actionCompleted.notice = 'Tagging complete';
+	taggingPage: function twinkleprodTaggingPage() {
+		var def = $.Deferred();
 
 		var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		wikipedia_page.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
-		wikipedia_page.setChangeTags(Twinkle.changeTags);  // Here to apply to triage
-		wikipedia_page.setCallbackParameters(params);
-		wikipedia_page.load(Twinkle.prod.callbacks.main);
-	},
+		wikipedia_page.load(function(pageobj) {
+			var statelem = pageobj.getStatusElement();
 
-	main: function(pageobj) {
-		var statelem = pageobj.getStatusElement();
-
-		if (!pageobj.exists()) {
-			statelem.error("It seems that the page doesn't exist. Perhaps it has already been deleted.");
-			return;
-		}
-
-		var text = pageobj.getPageText();
-		var params = pageobj.getCallbackParameters();
-
-		// Check for already existing deletion tags
-		var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
-		if (tag_re.test(text)) {
-			statelem.warn('Page already tagged with a deletion template, aborting procedure');
-			return;
-		}
-
-
-		// Remove tags that become superfluous with this action
-		text = text.replace(/{{\s*(userspace draft|mtc|(copy|move) to wikimedia commons|(copy |move )?to ?commons)\s*(\|(?:{{[^{}]*}}|[^{}])*)?}}\s*/gi, '');
-		var prod_re = /{{\s*(?:Prod blp|Proposed deletion|book-prod)\/dated(?: files)?\s*\|(?:{{[^{}]*}}|[^{}])*}}/i;
-		var summaryText;
-
-		if (!prod_re.test(text)) {
-
-			// Page previously PROD-ed
-			if (params.oldProdPresent) {
-				if (params.blp) {
-					if (!confirm('Previous PROD nomination found on talk page. Do you still want to continue applying BLPPROD? ')) {
-						statelem.warn('Previous PROD found on talk page, aborted by user');
-						return;
-					}
-					statelem.info('Previous PROD found on talk page, continuing');
-				} else {
-					statelem.warn('Previous PROD found on talk page, aborting procedure');
-					return;
-				}
+			if (!pageobj.exists()) {
+				statelem.error("It seems that the page doesn't exist. Perhaps it has already been deleted.");
+				// reject, so that all dependent actions like notifyAuthor() and
+				// addToLog() are cancelled
+				return def.reject();
 			}
 
-			// Alert if article is at least three days old, not in Category:Living people, and BLPPROD is selected
-			if (params.blp) {
-				var isMoreThan3DaysOld = new Morebits.date(params.creation).add(3, 'days').isAfter(new Date(pageobj.getLoadTime()));
-				var blpcheck_re = /\[\[Category:Living people\]\]/i;
-				if (!blpcheck_re.test(text) && isMoreThan3DaysOld) {
-					if (!confirm('Please note that the article is not in Category:Living people and hence may be ineligible for BLPPROD. Are you sure you want to continue? \n\nYou may wish to add the category if you proceed, unless the article is about a recently deceased person.')) {
-						return;
-					}
-				}
+			var text = pageobj.getPageText();
+
+			// Check for already existing deletion tags
+			var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
+			if (tag_re.test(text)) {
+				statelem.warn('Page already tagged with a deletion template, aborting procedure');
+				return def.reject();
 			}
 
-			// Notification to first contributor
-			if (params.usertalk) {
-				// Disallow warning yourself
-				if (params.initialContrib === mw.config.get('wgUserName')) {
-					statelem.warn('You (' + params.initialContrib + ') created this page; skipping user notification');
-					if (Twinkle.getPref('logProdPages')) {
-						Twinkle.prod.callbacks.addToLog(params);
-					}
-				} else {
-					// [[Template:Proposed deletion notify]] supports File namespace
-					var notifyTemplate;
+
+			// Remove tags that become superfluous with this action
+			text = text.replace(/{{\s*(userspace draft|mtc|(copy|move) to wikimedia commons|(copy |move )?to ?commons)\s*(\|(?:{{[^{}]*}}|[^{}])*)?}}\s*/gi, '');
+			var prod_re = /{{\s*(?:Prod blp|Proposed deletion|book-prod)\/dated(?: files)?\s*\|(?:{{[^{}]*}}|[^{}])*}}/i;
+			var summaryText;
+
+			if (!prod_re.test(text)) {
+
+				// Page previously PROD-ed
+				if (params.oldProdPresent) {
 					if (params.blp) {
-						notifyTemplate = 'prodwarningBLP';
-					} else if (params.book) {
-						notifyTemplate = 'bprodwarning';
+						if (!confirm('Previous PROD nomination found on talk page. Do you still want to continue applying BLPPROD? ')) {
+							statelem.warn('Previous PROD found on talk page, aborted by user');
+							return def.reject();
+						}
+						statelem.info('Previous PROD found on talk page, continuing');
 					} else {
-						notifyTemplate = 'proposed deletion notify';
+						statelem.warn('Previous PROD found on talk page, aborting procedure');
+						return def.reject();
 					}
-					var notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
-
-					var usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
-					usertalkpage.setAppendText(notifytext);
-					usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
-					usertalkpage.setChangeTags(Twinkle.changeTags);
-					usertalkpage.setCreateOption('recreate');
-					usertalkpage.setFollowRedirect(true, false);
-					usertalkpage.setCallbackParameters(params);
-					usertalkpage.append(function onNotifySuccess() {
-						// add nomination to the userspace log, if the user has enabled it
-						if (Twinkle.getPref('logProdPages')) {
-							params.logInitialContrib = params.initialContrib;
-							Twinkle.prod.callbacks.addToLog(params);
-						}
-					}, function onNotifyError() {
-						// if user could not be notified, log nomination without mentioning that notification was sent
-						if (Twinkle.getPref('logProdPages')) {
-							Twinkle.prod.callbacks.addToLog(params);
-						}
-					});
 				}
-			} else if (Twinkle.getPref('logProdPages')) { // If not notifying, log this PROD
-				Twinkle.prod.callbacks.addToLog(params);
-			}
-			var tag;
-			if (params.blp) {
-				summaryText = 'Proposing article for deletion per [[WP:BLPPROD]].';
-				tag = '{{subst:prod blp' + (params.usertalk ? '|help=off' : '') + '}}';
-			} else if (params.book) {
-				summaryText = 'Proposing book for deletion per [[WP:BOOKPROD]].';
-				tag = '{{subst:book-prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}';
-			} else {
-				summaryText = 'Proposing ' + namespace + ' for deletion per [[WP:PROD]].';
-				tag = '{{subst:prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}';
-			}
 
-			// Insert tag after short description or any hatnotes
-			var wikipage = new Morebits.wikitext.page(text);
-			text = wikipage.insertAfterTemplates(tag + '\n', Twinkle.hatnoteRegex).getText();
+				// Alert if article is at least three days old, not in Category:Living people, and BLPPROD is selected
+				if (params.blp) {
+					var isMoreThan3DaysOld = new Morebits.date(params.creation).add(3, 'days').isAfter(new Date(pageobj.getLoadTime()));
+					var blpcheck_re = /\[\[Category:Living people\]\]/i;
+					if (!blpcheck_re.test(text) && isMoreThan3DaysOld) {
+						if (!confirm('Please note that the article is not in Category:Living people and hence may be ineligible for BLPPROD. Are you sure you want to continue? \n\nYou may wish to add the category if you proceed, unless the article is about a recently deceased person.')) {
+							return def.reject();
+						}
+					}
+				}
 
-			// Add {{Old prod}} to the talk page
-			if (!params.oldProdPresent) {
-				var oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
-				var talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
-				var talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
-				talkpage.setPrependText(oldprodfull);
-				talkpage.setEditSummary('Adding {{Old prod}}');
-				talkpage.setChangeTags(Twinkle.changeTags);
-				talkpage.setFollowRedirect(true);  // match behavior for page tagging
-				talkpage.setCreateOption('recreate');
-				talkpage.prepend();
-			}
-		} else {  // already tagged for PROD, so try endorsing it
-			var prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/i;
-			if (prod2_re.test(text)) {
-				statelem.warn('Page already tagged with {{proposed deletion}} and {{proposed deletion endorsed}} templates, aborting procedure');
-				return;
-			}
-			var confirmtext = 'A {{proposed deletion}} tag was already found on this page. \nWould you like to add a {{proposed deletion endorsed}} tag with your explanation?';
-			if (params.blp && !/{{\s*Prod blp\/dated/.test(text)) {
-				confirmtext = 'A non-BLP {{proposed deletion}} tag was found on this article.\nWould you like to add a {{proposed deletion endorsed}} tag with explanation "article is a biography of a living person with no sources"?';
-			}
-			if (!confirm(confirmtext)) {
-				statelem.warn('Aborted per user request');
-				return;
-			}
+				var tag;
+				if (params.blp) {
+					summaryText = 'Proposing article for deletion per [[WP:BLPPROD]].';
+					tag = '{{subst:prod blp' + (params.usertalk ? '|help=off' : '') + '}}';
+				} else if (params.book) {
+					summaryText = 'Proposing book for deletion per [[WP:BOOKPROD]].';
+					tag = '{{subst:book-prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}';
+				} else {
+					summaryText = 'Proposing ' + namespace + ' for deletion per [[WP:PROD]].';
+					tag = '{{subst:prod|1=' + Morebits.string.formatReasonText(params.reason) + (params.usertalk ? '|help=off' : '') + '}}';
+				}
 
-			summaryText = 'Endorsing proposed deletion per [[WP:' + (params.blp ? 'BLP' : params.book ? 'BOOK' : '') + 'PROD]].';
-			text = text.replace(prod_re, text.match(prod_re) + '\n{{Proposed deletion endorsed|1=' + (params.blp ?
-				'article is a [[WP:BLPPROD|biography of a living person with no sources]]' :
-				Morebits.string.formatReasonText(params.reason)) + '}}\n');
+				// Insert tag after short description or any hatnotes
+				var wikipage = new Morebits.wikitext.page(text);
+				text = wikipage.insertAfterTemplates(tag + '\n', Twinkle.hatnoteRegex).getText();
 
-			if (Twinkle.getPref('logProdPages')) {
+			} else {  // already tagged for PROD, so try endorsing it
+				var prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/i;
+				if (prod2_re.test(text)) {
+					statelem.warn('Page already tagged with {{proposed deletion}} and {{proposed deletion endorsed}} templates, aborting procedure');
+					return def.reject();
+				}
+				var confirmtext = 'A {{proposed deletion}} tag was already found on this page. \nWould you like to add a {{proposed deletion endorsed}} tag with your explanation?';
+				if (params.blp && !/{{\s*Prod blp\/dated/.test(text)) {
+					confirmtext = 'A non-BLP {{proposed deletion}} tag was found on this article.\nWould you like to add a {{proposed deletion endorsed}} tag with explanation "article is a biography of a living person with no sources"?';
+				}
+				if (!confirm(confirmtext)) {
+					statelem.warn('Aborted per user request');
+					return def.reject();
+				}
+
+				summaryText = 'Endorsing proposed deletion per [[WP:' + (params.blp ? 'BLP' : params.book ? 'BOOK' : '') + 'PROD]].';
+				text = text.replace(prod_re, text.match(prod_re) + '\n{{Proposed deletion endorsed|1=' + (params.blp ?
+					'article is a [[WP:BLPPROD|biography of a living person with no sources]]' :
+					Morebits.string.formatReasonText(params.reason)) + '}}\n');
+
 				params.logEndorsing = true;
-				Twinkle.prod.callbacks.addToLog(params);
 			}
-		}
 
-		// curate/patrol the page
-		if (Twinkle.getPref('markProdPagesAsPatrolled')) {
-			pageobj.triage();
-		}
+			// curate/patrol the page
+			if (Twinkle.getPref('markProdPagesAsPatrolled')) {
+				pageobj.triage();
+			}
 
-		pageobj.setPageText(text);
-		pageobj.setEditSummary(summaryText);
-		pageobj.setWatchlist(Twinkle.getPref('watchProdPages'));
-		pageobj.setCreateOption('nocreate');
-		pageobj.save();
+			pageobj.setPageText(text);
+			pageobj.setEditSummary(summaryText);
+			pageobj.setChangeTags(Twinkle.changeTags);
+			pageobj.setWatchlist(Twinkle.getPref('watchProdPages'));
+			pageobj.setCreateOption('nocreate');
+			pageobj.save(def.resolve, def.reject);
+
+		}, def.reject);
+		return def;
 	},
 
-	addToLog: function(params) {
+	addOldProd: function twinkleprodAddOldProd() {
+		var def = $.Deferred();
+
+		if (params.oldProdPresent) {
+			return def.resolve();
+		}
+
+		// Add {{Old prod}} to the talk page
+		var oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
+		var talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+		var talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
+		talkpage.setPrependText(oldprodfull);
+		talkpage.setEditSummary('Adding {{Old prod}}');
+		talkpage.setChangeTags(Twinkle.changeTags);
+		talkpage.setFollowRedirect(true);  // match behavior for page tagging
+		talkpage.setCreateOption('recreate');
+		talkpage.prepend(def.resolve, def.reject);
+		return def;
+	},
+
+	notifyAuthor: function twinkleprodNotifyAuthor() {
+		var def = $.Deferred();
+
+		if (!params.blp && !params.usertalk) {
+			return def.resolve();
+		}
+
+		// Disallow warning yourself
+		if (params.initialContrib === mw.config.get('wgUserName')) {
+			Morebits.status.info('Notifying creator', 'You (' + params.initialContrib + ') created this page; skipping user notification');
+			return def.resolve();
+		}
+		// [[Template:Proposed deletion notify]] supports File namespace
+		var notifyTemplate;
+		if (params.blp) {
+			notifyTemplate = 'prodwarningBLP';
+		} else if (params.book) {
+			notifyTemplate = 'bprodwarning';
+		} else {
+			notifyTemplate = 'proposed deletion notify';
+		}
+		var notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
+
+		var usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
+		usertalkpage.setAppendText(notifytext);
+		usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
+		usertalkpage.setChangeTags(Twinkle.changeTags);
+		usertalkpage.setCreateOption('recreate');
+		usertalkpage.setFollowRedirect(true, false);
+		usertalkpage.append(function onNotifySuccess() {
+			// add nomination to the userspace log, if the user has enabled it
+			params.logInitialContrib = params.initialContrib;
+			def.resolve();
+		}, def.resolve); // resolves even if notification was unsuccessful
+
+		return def;
+	},
+
+	addToLog: function twinkleprodAddToLog() {
+		if (!Twinkle.getPref('logProdPages')) {
+			return $.Deferred().resolve();
+		}
 		var usl = new Morebits.userspaceLogger(Twinkle.getPref('prodLogPageName'));
 		usl.initialText =
 			"This is a log of all [[WP:PROD|proposed deletion]] tags applied or endorsed by this user using [[WP:TW|Twinkle]]'s PROD module.\n\n" +
@@ -412,6 +438,10 @@ Twinkle.prod.callbacks = {
 		usl.changeTags = Twinkle.changeTags;
 
 		usl.log(logText, summaryText);
+		return $.Deferred().resolve(); // KLUDGE: this should actually return resolved/
+		// rejected after the logging succeeded/failed, but Morebits.userspaceLogger#log
+		// doesn't support callbacks, and it seems wasteful to add them just for this.
+		// This isn't a real issue since no other task depend on this one.
 	}
 
 };
@@ -420,7 +450,7 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	var form = e.target;
 	var input = Morebits.quickForm.getInputData(form);
 
-	var params = {
+	params = {
 		usertalk: input.notify || input.prodtype === 'prodblp',
 		blp: input.prodtype === 'prodblp',
 		book: namespace === 'book',
@@ -436,22 +466,31 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	var talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
-	// Talk page templates for PROD-able discussions
-	var blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
-		'Template:Oldpuffull|' + // Legacy prior XfD template
-		'Template:Olddelrev|' + // Prior DRV template
-		'Template:Old prod';
-	var query = {
-		'action': 'query',
-		'titles': talk_title,
-		'prop': 'templates',
-		'tltemplates': blocking_templates
-	};
+	Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 
-	var wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query, Twinkle.prod.callbacks.checkpriors);
-	wikipedia_api.params = params;
-	wikipedia_api.post();
+	var tm = new Morebits.taskManager();
+	var cbs = Twinkle.prod.callbacks; // shortcut reference
+
+	// checkpriors() and fetchCreationInfo() have no dependencies, they'll run first
+	tm.add(cbs.checkpriors, []);
+	tm.add(cbs.fetchCreationInfo, []);
+	// tag the page once we're clear of the pre-requisites
+	tm.add(cbs.taggingPage, [ cbs.checkpriors ]);
+	// notify the author once we know who's the author, and also wait for the
+	// taggingPage() as we don't need to notify if tagging was not done, such as
+	// there was already a tag and the user chose not to endorse.
+	tm.add(cbs.notifyAuthor, [ cbs.fetchCreationInfo, cbs.taggingPage ]);
+	// oldProd needs to be added only if there wasn't one before, so need to wait
+	// for checkpriors() to finish
+	tm.add(cbs.addOldProd, [ cbs.checkpriors ]);
+	// add to log only after notifying author so that the logging can be adjusted if
+	// notification wasn't successful. Also, don't run if tagging was not done.
+	tm.add(cbs.addToLog, [ cbs.notifyAuthor, cbs.taggingPage ]);
+	// All set, go!
+	tm.execute().then(function() {
+		Morebits.status.actionCompleted('Tagging complete');
+	});
+
 };
 
 Twinkle.addInitCallback(Twinkle.prod, 'prod');


### PR DESCRIPTION
New task manager class (first mentioned in https://github.com/azatoth/twinkle/pull/839#issuecomment-582514117) to automatically determine the execution sequence of asynchronous functions and run them, given the list of tasks (functions returning promises) and their dependencies. 

I'll try to incorporate this into the xfd module at the first opportunity. But how to proceed is a bit unclear at the moment due to conflicts posed by #911 and #1030 (#911 isn't necessary to promisify the code in xfd module, it can also be done just putting `var def = $.Deferred()` at the top of each function and returning it). 