### PR TITLE
morebits: integrate checkboxShiftClickSupport into quickForm

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -225,6 +225,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			type: 'checkbox',
 			name: 'pages',
 			id: 'tw-dbatch-pages',
+			shiftClickSupport: true,
 			list: $.map(Twinkle.batchdelete.pages, function (e) {
 				return e;
 			})
@@ -234,9 +235,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		var result = form.render();
 		apiobj.params.Window.setContent(result);
 
-		var pageCheckboxes = Morebits.quickForm.getElements(result, 'pages');
-		pageCheckboxes.forEach(generateArrowLinks);
-		Morebits.checkboxShiftClickSupport(pageCheckboxes);
+		Morebits.quickForm.getElements(result, 'pages').forEach(generateArrowLinks);
 
 	}, statelem);
 
@@ -268,6 +267,7 @@ Twinkle.batchdelete.generateNewPageList = function(form) {
 		type: 'checkbox',
 		name: 'pages',
 		id: 'tw-dbatch-pages',
+		shiftClickSupport: true,
 		list: $.map(Twinkle.batchdelete.pages, function (e) {
 			return e;
 		})
@@ -277,7 +277,7 @@ Twinkle.batchdelete.generateNewPageList = function(form) {
 Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e) {
 
 	var form = e.target.form;
-	var newPageList, pageCheckboxes, subpageCheckboxes;
+	var newPageList;
 
 	if (e.target.checked) {
 
@@ -299,13 +299,8 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
 			$('#tw-dbatch-pages').replaceWith(newPageList);
 
-			pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages');
-			pageCheckboxes.forEach(generateArrowLinks);
-			Morebits.checkboxShiftClickSupport(pageCheckboxes);
-
-			subpageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages.subpages');
-			subpageCheckboxes.forEach(generateArrowLinks);
-			Morebits.checkboxShiftClickSupport(subpageCheckboxes);
+			Morebits.quickForm.getElements(newPageList, 'pages').forEach(generateArrowLinks);
+			Morebits.quickForm.getElements(newPageList, 'pages.subpages').forEach(generateArrowLinks);
 
 			return;
 		}
@@ -381,6 +376,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 						type: 'checkbox',
 						name: 'subpages',
 						className: 'dbatch-subpages',
+						shiftClickSupport: true,
 						list: subpageList
 					};
 				}
@@ -396,13 +392,8 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
 			$('#tw-dbatch-pages').replaceWith(newPageList);
 
-			pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages');
-			pageCheckboxes.forEach(generateArrowLinks);
-			Morebits.checkboxShiftClickSupport(pageCheckboxes);
-
-			subpageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages.subpages');
-			subpageCheckboxes.forEach(generateArrowLinks);
-			Morebits.checkboxShiftClickSupport(subpageCheckboxes);
+			Morebits.quickForm.getElements(newPageList, 'pages').forEach(generateArrowLinks);
+			Morebits.quickForm.getElements(newPageList, 'pages.subpages').forEach(generateArrowLinks);
 
 			subpagesLoaded = true;
 
@@ -426,10 +417,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		newPageList = Twinkle.batchdelete.generateNewPageList(form);
 		$('#tw-dbatch-pages').replaceWith(newPageList);
 
-		pageCheckboxes = Morebits.quickForm.getElements(newPageList, 'pages');
-		pageCheckboxes.forEach(generateArrowLinks);
-		Morebits.checkboxShiftClickSupport(pageCheckboxes);
-
+		Morebits.quickForm.getElements(newPageList, 'pages').forEach(generateArrowLinks);
 	}
 };
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -345,6 +345,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		form.append({
 			type: 'checkbox',
 			name: 'pages',
+			shiftClickSupport: true,
 			list: list
 		});
 		form.append({ type: 'submit' });
@@ -352,7 +353,6 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		var result = form.render();
 		Window.setContent(result);
 
-		Morebits.checkboxShiftClickSupport(Morebits.quickForm.getElements(result, 'pages'));
 	}, statelem);
 
 	wikipedia_api.post();

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -98,6 +98,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		apiobj.params.form.append({
 			type: 'checkbox',
 			name: 'pages',
+			shiftClickSupport: true,
 			list: list
 		});
 		apiobj.params.form.append({ type: 'submit' });
@@ -105,7 +106,6 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		var result = apiobj.params.form.render();
 		apiobj.params.Window.setContent(result);
 
-		Morebits.checkboxShiftClickSupport(Morebits.quickForm.getElements(result, 'pages'));
 	}, statelem);
 	wikipedia_api.params = { form: form, Window: Window };
 	wikipedia_api.post();

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -174,6 +174,7 @@ Twinkle.unlink.callbacks = {
 					apiobj.params.form.append({
 						type: 'checkbox',
 						name: 'imageusage',
+						shiftClickSupport: true,
 						list: list
 					});
 					havecontent = true;
@@ -220,6 +221,7 @@ Twinkle.unlink.callbacks = {
 				apiobj.params.form.append({
 					type: 'checkbox',
 					name: 'backlinks',
+					shiftClickSupport: true,
 					list: list
 				});
 				havecontent = true;
@@ -233,9 +235,6 @@ Twinkle.unlink.callbacks = {
 
 			var result = apiobj.params.form.render();
 			apiobj.params.Window.setContent(result);
-
-			Morebits.checkboxShiftClickSupport($("input[name='imageusage']", result));
-			Morebits.checkboxShiftClickSupport($("input[name='backlinks']", result));
 
 		}
 	},

--- a/morebits.js
+++ b/morebits.js
@@ -445,6 +445,9 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 					}
 				}
 			}
+			if (data.shiftClickSupport && data.type === 'checkbox') {
+				Morebits.checkboxShiftClickSupport(Morebits.quickForm.getElements(node, data.name));
+			}
 			break;
 		case 'input':
 			node = document.createElement('div');


### PR DESCRIPTION
Integrate checkboxShiftClickSupport into quickForm by providing a new `shiftClickSupport` option for checkbox elements.

Was developing an unrelated script, and what, I have to [write one whole extra line](https://en.wikipedia.org/w/index.php?title=User:SD0001/massMoveRevert.js&diff=prev&oldid=967476421) to get shift click support?? NO way, I am gonna tweak the library instead. 