### PR TITLE
Fix testing, move addInitCallback below callback definitions

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -20,7 +20,6 @@ Twinkle.shared = function friendlyshared() {
 		}, 'Shared IP', 'friendly-shared', 'Shared IP tagging');
 	}
 };
-Twinkle.addInitCallback(Twinkle.shared, 'shared');
 
 Twinkle.shared.callback = function friendlysharedCallback() {
 	var Window = new Morebits.simpleWindow(600, 420);
@@ -186,6 +185,8 @@ Twinkle.shared.callback.evaluate = function friendlysharedCallbackEvaluate(e) {
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.shared.callbacks.main);
 };
+
+Twinkle.addInitCallback(Twinkle.shared, 'shared');
 })(jQuery);
 
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -32,7 +32,6 @@ Twinkle.tag = function friendlytag() {
 		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add or remove article maintenance tags');
 	}
 };
-Twinkle.addInitCallback(Twinkle.tag, 'tag');
 
 Twinkle.tag.checkedTags = [];
 
@@ -2016,5 +2015,6 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 
 };
 
+Twinkle.addInitCallback(Twinkle.tag, 'tag');
 })(jQuery);
 // </nowiki>

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -21,7 +21,6 @@ Twinkle.talkback = function() {
 
 	Twinkle.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
 };
-Twinkle.addInitCallback(Twinkle.talkback, 'talkback');
 
 Twinkle.talkback.callback = function() {
 	if (mw.config.get('wgRelevantUserName') === mw.config.get('wgUserName') && !confirm("Is it really so bad that you're talking back to yourself?")) {
@@ -437,6 +436,7 @@ Twinkle.talkback.getNoticeWikitext = function(input) {
 	return text;
 };
 
+Twinkle.addInitCallback(Twinkle.talkback, 'talkback');
 })(jQuery);
 
 

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -24,7 +24,6 @@ Twinkle.welcome = function friendlywelcome() {
 		Twinkle.welcome.normal();
 	}
 };
-Twinkle.addInitCallback(Twinkle.welcome, 'welcome');
 
 Twinkle.welcome.auto = function() {
 	if (mw.util.getParamValue('action') !== 'edit') {
@@ -660,6 +659,8 @@ Twinkle.welcome.callback.evaluate = function friendlywelcomeCallbackEvaluate(e) 
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.welcome.callbacks.main);
 };
+
+Twinkle.addInitCallback(Twinkle.welcome, 'welcome');
 })(jQuery);
 
 

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -24,7 +24,6 @@ Twinkle.arv = function twinklearv() {
 		Twinkle.arv.callback(username);
 	}, 'ARV', 'tw-arv', title);
 };
-Twinkle.addInitCallback(Twinkle.arv, 'arv');
 
 Twinkle.arv.callback = function (uid) {
 	var Window = new Morebits.simpleWindow(600, 500);
@@ -987,6 +986,8 @@ Twinkle.arv.processAN3 = function(params) {
 		console.log('API failed :(', data); // eslint-disable-line no-console
 	});
 };
+
+Twinkle.addInitCallback(Twinkle.arv, 'arv');
 })(jQuery);
 
 

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -22,7 +22,6 @@ Twinkle.batchdelete = function twinklebatchdelete() {
 		Twinkle.addPortletLink(Twinkle.batchdelete.callback, 'D-batch', 'tw-batch', 'Delete pages found in this category/on this page');
 	}
 };
-Twinkle.addInitCallback(Twinkle.batchdelete, 'batchdelete');
 
 Twinkle.batchdelete.unlinkCache = {};
 
@@ -703,6 +702,8 @@ Twinkle.batchdelete.callbacks = {
 		pageobj.save(params.unlinker.workerSuccess, params.unlinker.workerFailure);
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.batchdelete, 'batchdelete');
 })(jQuery);
 
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -21,7 +21,6 @@ Twinkle.batchprotect = function twinklebatchprotect() {
 		Twinkle.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');
 	}
 };
-Twinkle.addInitCallback(Twinkle.batchprotect, 'batchprotect');
 
 Twinkle.batchprotect.unlinkCache = {};
 Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
@@ -441,6 +440,8 @@ Twinkle.batchprotect.callbacks = {
 		page.protect(apiobj.params.batchOperation.workerSuccess, apiobj.params.batchOperation.workerFailure);
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.batchprotect, 'batchprotect');
 })(jQuery);
 
 

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -21,7 +21,6 @@ Twinkle.batchundelete = function twinklebatchundelete() {
 	}
 	Twinkle.addPortletLink(Twinkle.batchundelete.callback, 'Und-batch', 'tw-batch-undel', "Undelete 'em all");
 };
-Twinkle.addInitCallback(Twinkle.batchundelete, 'batchundelete');
 
 Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 	var Window = new Morebits.simpleWindow(600, 400);
@@ -202,6 +201,7 @@ Twinkle.batchundelete.callbacks = {
 	}
 };
 
+Twinkle.addInitCallback(Twinkle.batchundelete, 'batchundelete');
 })(jQuery);
 
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -21,7 +21,6 @@ Twinkle.block = function twinkleblock() {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };
-Twinkle.addInitCallback(Twinkle.block, 'block');
 
 Twinkle.block.callback = function twinkleblockCallback() {
 	if (mw.config.get('wgRelevantUserName') === mw.config.get('wgUserName') &&
@@ -1672,6 +1671,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 	pageobj.save();
 };
 
+Twinkle.addInitCallback(Twinkle.block, 'block');
 })(jQuery);
 
 

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1302,7 +1302,6 @@ Twinkle.config.init = function twinkleconfigInit() {
 		}
 	}
 };
-Twinkle.addInitCallback(Twinkle.config.init);
 
 // custom list-related stuff
 
@@ -1711,6 +1710,8 @@ Twinkle.config.saveSuccess = function twinkleconfigSaveSuccess(pageobj) {
 	noticeclear.style.clear = 'both';
 	Morebits.status.root.appendChild(noticeclear);
 };
+
+Twinkle.addInitCallback(Twinkle.config.init);
 })(jQuery);
 
 

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -22,7 +22,6 @@ Twinkle.deprod = function() {
 	}
 	Twinkle.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
 };
-Twinkle.addInitCallback(Twinkle.deprod, 'deprod');
 
 var concerns = {};
 
@@ -182,6 +181,7 @@ var callback_commit = function(event) {
 		});
 	};
 
+Twinkle.addInitCallback(Twinkle.deprod, 'deprod');
 })(jQuery);
 
 

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -31,7 +31,6 @@ Twinkle.diff = function twinklediff() {
 		Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: oldid}), 'Current', 'tw-curdiff', 'Show difference to current revision');
 	}
 };
-Twinkle.addInitCallback(Twinkle.diff, 'diff');
 
 Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 
@@ -76,6 +75,8 @@ Twinkle.diff.callbacks = {
 		});
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.diff, 'diff');
 })(jQuery);
 
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -52,8 +52,6 @@ Twinkle.fluff = function twinklefluff() {
 	}
 };
 
-Twinkle.addInitCallback(Twinkle.fluff, 'fluff');
-
 // A list of usernames, usually only bots, that vandalism revert is jumped
 // over; that is, if vandalism revert was chosen on such username, then its
 // target is on the revision before.  This is for handling quick bots that
@@ -698,6 +696,8 @@ Twinkle.fluff.formatSummary = function(builtInString, userName, userString) {
 
 	return result;
 };
+
+Twinkle.addInitCallback(Twinkle.fluff, 'fluff');
 })(jQuery);
 
 

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -17,7 +17,6 @@ Twinkle.image = function twinkleimage() {
 		Twinkle.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
 	}
 };
-Twinkle.addInitCallback(Twinkle.image, 'image');
 
 Twinkle.image.callback = function twinkleimageCallback() {
 	var Window = new Morebits.simpleWindow(600, 330);
@@ -330,6 +329,8 @@ Twinkle.image.callbacks = {
 		}
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.image, 'image');
 })(jQuery);
 
 

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -21,7 +21,6 @@ Twinkle.prod = function twinkleprod() {
 
 	Twinkle.addPortletLink(Twinkle.prod.callback, 'PROD', 'tw-prod', 'Propose deletion via WP:PROD');
 };
-Twinkle.addInitCallback(Twinkle.prod, 'prod');
 
 // Used in edit summaries, for comparisons, etc.
 var namespace;
@@ -445,6 +444,8 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	wikipedia_api.params = params;
 	wikipedia_api.post();
 };
+
+Twinkle.addInitCallback(Twinkle.prod, 'prod');
 })(jQuery);
 
 

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -22,7 +22,6 @@ Twinkle.protect = function twinkleprotect() {
 	Twinkle.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
 		Morebits.userIsSysop ? 'Protect page' : 'Request page protection');
 };
-Twinkle.addInitCallback(Twinkle.protect, 'protect');
 
 Twinkle.protect.callback = function twinkleprotectCallback() {
 	var Window = new Morebits.simpleWindow(620, 530);
@@ -1559,6 +1558,8 @@ Twinkle.protect.callbacks = {
 		rppPage.save();
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.protect, 'protect');
 })(jQuery);
 
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -28,7 +28,6 @@ Twinkle.speedy = function twinklespeedy() {
 
 	Twinkle.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
 };
-Twinkle.addInitCallback(Twinkle.speedy, 'speedy');
 
 // This function is run when the CSD tab/header link is clicked
 Twinkle.speedy.callback = function twinklespeedyCallback() {
@@ -2173,6 +2172,8 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.speedy.callbacks.user.main);
 };
+
+Twinkle.addInitCallback(Twinkle.speedy, 'speedy');
 })(jQuery);
 
 

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -20,7 +20,6 @@ Twinkle.unlink = function twinkleunlink() {
 	}
 	Twinkle.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');
 };
-Twinkle.addInitCallback(Twinkle.unlink, 'unlink');
 
 // the parameter is used when invoking unlink from admin speedy
 Twinkle.unlink.callback = function(presetReason) {
@@ -289,6 +288,8 @@ Twinkle.unlink.callbacks = {
 		pageobj.save(params.unlinker.workerSuccess, params.unlinker.workerFailure);
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.unlink, 'unlink');
 })(jQuery);
 
 

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -45,7 +45,6 @@ Twinkle.warn = function twinklewarn() {
 		}
 	}
 };
-Twinkle.addInitCallback(Twinkle.warn, 'warn');
 
 // Used to close window when switching to ARV in autolevel
 Twinkle.warn.dialog = null;
@@ -1780,6 +1779,8 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 	wikipedia_page.setFollowRedirect(true, false);
 	wikipedia_page.load(Twinkle.warn.callbacks.main);
 };
+
+Twinkle.addInitCallback(Twinkle.warn, 'warn');
 })(jQuery);
 
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -23,7 +23,6 @@ Twinkle.xfd = function twinklexfd() {
 
 	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a deletion discussion');
 };
-Twinkle.addInitCallback(Twinkle.xfd, 'xfd');
 
 Twinkle.xfd.num2order = function twinklexfdNum2order(num) {
 	switch (num) {
@@ -1998,6 +1997,8 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			break;
 	}
 };
+
+Twinkle.addInitCallback(Twinkle.xfd, 'xfd');
 })(jQuery);
 
 


### PR DESCRIPTION
The gadget files work fine, but to see the benefits from #946 for testing purposes, `Twinkle.addInitCallback` needs to be *below* any function expressions found within the function (`func`) that `addInitCallback` purports to add, such as the callback used by `Twinkle.addPortletLink`; e.g., for XfD, `Twinkle.addInitCallback(Twinkle.xfd, 'xfd')` must be below `Twinkle.xfd.callback`.  These are all function expressions, so are only evaluated when reached.

For visual consistency's sake, I've moved them all to the very end. cc @siddharthvp