### PR TITLE
tag: fix quickfilter (file/redir) and showing of subgroups (redir)

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -197,7 +197,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 						type: 'checkbox',
 						name: 'tags',
 						list: subgroup.map(function (item) {
-							return { value: item.tag, label: '{{' + item.tag + '}}: ' + item.description };
+							return { value: item.tag, label: '{{' + item.tag + '}}: ' + item.description, subgroup: item.subgroup };
 						})
 					});
 				});
@@ -234,7 +234,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 	Window.display();
 
 	// for quick filter:
-	$allCheckboxDivs = $(result).find('[name$=Tags]').parent();
+	$allCheckboxDivs = $(result).find('[name$=tags]').parent();
 	$allHeaders = $(result).find('h5');
 	result.quickfilter.focus();  // place cursor in the quick filter field as soon as window is opened
 	result.quickfilter.autocomplete = 'off'; // disable browser suggestions


### PR DESCRIPTION
- quickfilter: One instance of `Tags` wasn't changed to `tags` in #908/0bfb37d
- subgroups: Accidentally left off in restructing in #1002/97954b8 (noted at https://github.com/azatoth/twinkle/pull/1002#discussion_r456760615)

See also b2c9971