### PR TITLE
Morebits.string: isInfinity to determine whether MW will treat a string as infinite, use in block

### DIFF
--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -101,7 +101,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			{ label: '2 months', value: '2 months' },
 			{ label: '3 months', value: '3 months' },
 			{ label: '1 year', value: '1 year' },
-			{ label: 'indefinite', value: 'indefinite' },
+			{ label: 'indefinite', value: 'infinity' },
 			{ label: 'Custom...', value: 'custom' }
 		]
 	});
@@ -171,7 +171,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			{ label: '2 months', value: '2 months' },
 			{ label: '3 months', value: '3 months' },
 			{ label: '1 year', value: '1 year' },
-			{ label: 'indefinite', value: 'indefinite' },
+			{ label: 'indefinite', value: 'infinity' },
 			{ label: 'Custom...', value: 'custom' }
 		]
 	});
@@ -250,7 +250,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			{ label: '2 months', value: '2 months' },
 			{ label: '3 months', value: '3 months' },
 			{ label: '1 year', value: '1 year' },
-			{ label: 'indefinite', selected: true, value: 'indefinite' },
+			{ label: 'indefinite', selected: true, value: 'infinity' },
 			{ label: 'Custom...', value: 'custom' }
 		]
 	});

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1083,8 +1083,7 @@ Twinkle.block.transformBlockPresets = function twinkleblockTransformBlockPresets
 	$.each(Twinkle.block.blockPresetsInfo, function(preset, settings) {
 		settings.summary = settings.summary || settings.reason;
 		settings.sig = settings.sig !== undefined ? settings.sig : 'yes';
-		// despite this it's preferred that you use 'infinity' as the value for expiry
-		settings.indefinite = settings.indefinite || settings.expiry === 'infinity' || settings.expiry === 'infinite' || settings.expiry === 'indefinite' || settings.expiry === 'never';
+		settings.indefinite = settings.indefinite || Morebits.string.isInfinity(settings.expiry);
 
 		if (!Twinkle.block.isRegistered && settings.indefinite) {
 			settings.expiry = '31 hours';
@@ -1330,7 +1329,7 @@ Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemp
 				Twinkle.block.prev_template_expiry = form.template_expiry.value || '';
 			}
 			form.template_expiry.parentNode.style.display = 'none';
-			form.template_expiry.value = 'indefinite';
+			form.template_expiry.value = 'infinity';
 		} else if (form.template_expiry.parentNode.style.display === 'none') {
 			if (Twinkle.block.prev_template_expiry !== null) {
 				form.template_expiry.value = Twinkle.block.prev_template_expiry;
@@ -1367,7 +1366,7 @@ Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
 		disabletalk: form.disabletalk.checked || (form.notalk ? form.notalk.checked : false),
 		expiry: form.template_expiry ? form.template_expiry.value : form.expiry.value,
 		hardblock: Twinkle.block.isRegistered ? form.autoblock.checked : form.hardblock.checked,
-		indefinite: (/indef|infinit|never|\*|max/).test(form.template_expiry ? form.template_expiry.value : form.expiry.value),
+		indefinite: Morebits.string.isInfinity(form.template_expiry ? form.template_expiry.value : form.expiry.value),
 		reason: form.block_reason.value,
 		template: form.template.value,
 		partial: $(form).find('[name=actiontype][value=partial]').is(':checked'),
@@ -1644,7 +1643,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 		text += '\n\n';
 	}
 
-	params.indefinite = (/indef|infinit|never|\*|max/).test(params.expiry);
+	params.indefinite = Morebits.string.isInfinity(params.expiry);
 
 	if (Twinkle.getPref('blankTalkpageOnIndefBlock') && params.template !== 'uw-lblock' && params.indefinite) {
 		Morebits.status.info('Info', 'Blanking talk page per preferences and creating a new level 2 heading for the date');

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -363,7 +363,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						{ label: '2 months', value: '2 months' },
 						{ label: '3 months', value: '3 months' },
 						{ label: '1 year', value: '1 year' },
-						{ label: 'indefinite', value: 'indefinite' },
+						{ label: 'indefinite', value: 'infinity' },
 						{ label: 'Custom...', value: 'custom' }
 					]
 				});
@@ -434,7 +434,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						{ label: '2 months', value: '2 months' },
 						{ label: '3 months', value: '3 months' },
 						{ label: '1 year', value: '1 year' },
-						{ label: 'indefinite', value: 'indefinite' },
+						{ label: 'indefinite', value: 'infinity' },
 						{ label: 'Custom...', value: 'custom' }
 					]
 				});
@@ -494,7 +494,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 							{ label: '2 months', value: '2 months' },
 							{ label: '3 months', value: '3 months' },
 							{ label: '1 year', value: '1 year' },
-							{ label: 'indefinite', value: 'indefinite' },
+							{ label: 'indefinite', value: 'infinity' },
 							{ label: 'Custom...', value: 'custom' }
 						]
 					});
@@ -561,7 +561,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						{ label: '2 months', value: '2 months' },
 						{ label: '3 months', value: '3 months' },
 						{ label: '1 year', value: '1 year' },
-						{ label: 'indefinite', selected: true, value: 'indefinite' },
+						{ label: 'indefinite', selected: true, value: 'infinity' },
 						{ label: 'Custom...', value: 'custom' }
 					]
 				});
@@ -624,7 +624,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 				label: 'Duration: ',
 				list: [
 					{ label: 'Temporary', value: 'temporary' },
-					{ label: 'Indefinite', value: 'indefinite' },
+					{ label: 'Indefinite', value: 'infinity' },
 					{ label: '', selected: true, value: '' }
 				]
 			});
@@ -690,7 +690,7 @@ Twinkle.protect.formevents = {
 			e.target.form.moveexpiry.value = e.target.form.editexpiry.value;
 		} else if (e.target.form.editlevel.disabled) {
 			e.target.form.movelevel.value = 'sysop';
-			e.target.form.moveexpiry.value = 'indefinite';
+			e.target.form.moveexpiry.value = 'infinity';
 		}
 		e.target.form.movelevel.disabled = !e.target.checked;
 		e.target.form.moveexpiry.disabled = !e.target.checked || (e.target.form.movelevel.value === 'all');
@@ -1095,7 +1095,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 
 			if (/template/.test(form.category.value)) {
 				form.noinclude.checked = true;
-				form.editexpiry.value = form.moveexpiry.value = form.pcexpiry.value = 'indefinite';
+				form.editexpiry.value = form.moveexpiry.value = form.pcexpiry.value = 'infinity';
 			} else if (mw.config.get('wgNamespaceNumber') !== 10) {
 				form.noinclude.checked = false;
 			}
@@ -1494,7 +1494,7 @@ Twinkle.protect.callbacks = {
 			case 'temporary':
 				words = 'Temporary ';
 				break;
-			case 'indefinite':
+			case 'infinity':
 				words = 'Indefinite ';
 				break;
 			default:

--- a/morebits.js
+++ b/morebits.js
@@ -1142,6 +1142,16 @@ Morebits.string = {
 	 */
 	safeReplace: function morebitsStringSafeReplace(string, pattern, replacement) {
 		return string.replace(pattern, replacement.replace(/\$/g, '$$$$'));
+	},
+
+	/**
+	 * Determine if user input expiration will be translated to an
+	 * infinite-length by MW: https://phabricator.wikimedia.org/T68646
+	 * @param {string} expiry
+	 * @returns {boolean}
+	 */
+	isInfinity: function morebitsStringIsInfinity(expiry) {
+		return ['indefinite', 'infinity', 'infinite', 'never'].indexOf(expiry) !== -1;
 	}
 };
 


### PR DESCRIPTION
Organized within core in 2015 in https://phabricator.wikimedia.org/T68646, stored at https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/25d4b6cd388ba1e35129c9d5ded60b3ef5f4a12a/includes/libs/ParamValidator/TypeDef/ExpiryDef.php#19.  This is used used multiple times in block (see also #576) and could be useful elsewhere, so let's pull it out.  This does away with our (non-standard) allowance for `max` and `*`.  Also replaced some indefinites in the code with infinities, just for the sake of clarity/consistency.