### PR TITLE
tag: Fix process for present tags not included in the module

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -552,11 +552,10 @@ Twinkle.tag.updateSortOrder = function(e) {
 		var checkboxes = [];
 		var unCheckedTags = e.target.form.getUnchecked('existingTags');
 		Twinkle.tag.alreadyPresentTags.forEach(function(tag) {
-			var description = Twinkle.tag.article.flatObject[tag].description;
 			var checkbox =
 				{
 					value: tag,
-					label: '{{' + tag + '}}' + (description ? ': ' + description : ''),
+					label: '{{' + tag + '}}' + (Twinkle.tag.article.flatObject[tag] ? ': ' + Twinkle.tag.article.flatObject[tag].description : ''),
 					checked: unCheckedTags.indexOf(tag) === -1,
 					style: 'font-style: italic'
 				};


### PR DESCRIPTION
Because of the restructuring in #1003, if a tag was present but *wasn't* included in our tag module, `makeCheckbox` for already existing tags would whine and die.  Reported at [WT:TW](https://en.wikipedia.org/wiki/Special:Permalink/968776641#Error_on_tag).