### PR TITLE
morebits: getInputData: Fix dumb IE bug

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -735,7 +735,7 @@ Morebits.quickForm.element.generateTooltip = function QuickFormElementGenerateTo
 Morebits.quickForm.getInputData = function(form) {
 	var result = {};
 
-	for (var i in form.elements) { // eslint-disable-line guard-for-in
+	for (var i = 0; i < form.elements.length; i++) {
 		var field = form.elements[i];
 		if (field.disabled || !field.name || !field.type ||
 			field.type === 'submit' || field.type === 'button') {


### PR DESCRIPTION
Apparently IE iterates over names of HTMLform stuff when doing `for (var i in form.elements)`?  We could also use `$.each`.

----

Reported at WT:TW around welcoming, this was super annoying to run down since there weren't any errors logged.

cc @siddharthvp just FYI this is dumb