### PR TITLE
protect: Fix invalid expiry when unprotecting

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1116,6 +1116,14 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 	var form = e.target;
 	var input = Morebits.quickForm.getInputData(form);
 
+	// Define valid expirys to allow unprotection to proceed
+	// Any valid value should work, not just infinity
+	['edit', 'move', 'create', 'pc'].forEach(function(type) {
+		if (input[type + 'level'] && input[type + 'expiry'] === undefined) {
+			input[type + 'expiry'] = 'infinity';
+		}
+	});
+
 	var tagparams;
 	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto')) {
 		tagparams = {


### PR DESCRIPTION
Another fallout from #908/6c38a5d: `getInputData` ignores disabled elements, so the expiry for each unprotection level is `undefined` rather than whatever was there before.  It doesn't matter what the expiry is, but it *needs* to be valid or else the API complains (the create error is... unique).