### PR TITLE
fluff: Don't add rollback links to the top history revision if there's just one user

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -230,7 +230,15 @@ Twinkle.fluff.addLinks = {
 				var first = histList.shift();
 				var vandal = $(first).find('.mw-userlink:not(.history-deleted)').text();
 
-				first.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(vandal, true));
+				// Check for first username different than the top user,
+				// only apply rollback links if/when found
+				// for faster than every
+				for (var i = 0; i < histList.length; i++) {
+					if ($(histList[i]).find('.mw-userlink').text() !== vandal) {
+						first.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(vandal, true));
+						break;
+					}
+				}
 			}
 
 			// oldid


### PR DESCRIPTION
Closes #1062.

Only really makes sense if multiple consecutive revdel'd users are treated as one (#1073).