### PR TITLE
protect: Ensure a valid type of move protection

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -623,9 +623,9 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 				name: 'expiry',
 				label: 'Duration: ',
 				list: [
+					{ label: '', selected: true, value: '' },
 					{ label: 'Temporary', value: 'temporary' },
-					{ label: 'Indefinite', value: 'infinity' },
-					{ label: '', selected: true, value: '' }
+					{ label: 'Indefinite', value: 'infinity' }
 				]
 			});
 			field1.append({
@@ -1160,7 +1160,13 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 						thispage.setEditProtection(input.editlevel, input.editexpiry);
 					}
 					if (input.movemodify) {
-						thispage.setMoveProtection(input.movelevel, input.moveexpiry);
+						// Ensure a level has actually been chosen
+						if (input.movelevel) {
+							thispage.setMoveProtection(input.movelevel, input.moveexpiry);
+						} else {
+							alert('You must chose a move protection level!');
+							return;
+						}
 					}
 				} else {
 					thispage.setCreateProtection(input.createlevel, input.createexpiry);


### PR DESCRIPTION
Since move tries to match edit if present, but autoconfirmed is not an option (see discussion in #451), it's possible for someone to attempt a submission without any level (sysop, template, etc.) selected for move protection if they select move protection while the default edit level of "autoconfirmed" is selected, and then uncheck edit protection.  The query would just fail, but better not to reset the form.

Also moved the empty default selection for filing a request to the top, as might be expected.