### PR TITLE
(batch)protect: Consolidate duplicate lists, filter out improper options

### DIFF
--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -44,37 +44,12 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			}
 		]
 	});
-	var editlevel = form.append({
+	form.append({
 		type: 'select',
 		name: 'editlevel',
 		label: 'Edit protection:',
-		event: Twinkle.protect.formevents.editlevel
-	});
-	editlevel.append({
-		type: 'option',
-		label: 'All',
-		value: 'all'
-	});
-	editlevel.append({
-		type: 'option',
-		label: 'Autoconfirmed',
-		value: 'autoconfirmed'
-	});
-	editlevel.append({
-		type: 'option',
-		label: 'Extended confirmed',
-		value: 'extendedconfirmed'
-	});
-	editlevel.append({
-		type: 'option',
-		label: 'Template editor',
-		value: 'templateeditor'
-	});
-	editlevel.append({
-		type: 'option',
-		label: 'Sysop',
-		value: 'sysop',
-		selected: true
+		event: Twinkle.protect.formevents.editlevel,
+		list: Twinkle.protect.protectionLevels
 	});
 	form.append({
 		type: 'select',
@@ -101,32 +76,15 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			}
 		]
 	});
-	var movelevel = form.append({
+	form.append({
 		type: 'select',
 		name: 'movelevel',
 		label: 'Move protection:',
-		event: Twinkle.protect.formevents.movelevel
-	});
-	movelevel.append({
-		type: 'option',
-		label: 'All',
-		value: 'all'
-	});
-	movelevel.append({
-		type: 'option',
-		label: 'Extended confirmed',
-		value: 'extendedconfirmed'
-	});
-	movelevel.append({
-		type: 'option',
-		label: 'Template editor',
-		value: 'templateeditor'
-	});
-	movelevel.append({
-		type: 'option',
-		label: 'Sysop',
-		value: 'sysop',
-		selected: true
+		event: Twinkle.protect.formevents.movelevel,
+		list: Twinkle.protect.protectionLevels.filter(function(level) {
+			// Autoconfirmed is required for a move, redundant
+			return level.value !== 'autoconfirmed';
+		})
 	});
 	form.append({
 		type: 'select',
@@ -157,37 +115,12 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 			}
 		]
 	});
-	var createlevel = form.append({
+	form.append({
 		type: 'select',
 		name: 'createlevel',
 		label: 'Create protection:',
-		event: Twinkle.protect.formevents.createlevel
-	});
-	createlevel.append({
-		type: 'option',
-		label: 'All',
-		value: 'all'
-	});
-	createlevel.append({
-		type: 'option',
-		label: 'Autoconfirmed',
-		value: 'autoconfirmed'
-	});
-	createlevel.append({
-		type: 'option',
-		label: 'Extended confirmed',
-		value: 'extendedconfirmed'
-	});
-	createlevel.append({
-		type: 'option',
-		label: 'Template editor',
-		value: 'templateeditor'
-	});
-	createlevel.append({
-		type: 'option',
-		label: 'Sysop',
-		value: 'sysop',
-		selected: true
+		event: Twinkle.protect.formevents.createlevel,
+		list: Twinkle.protect.protectionLevels
 	});
 	form.append({
 		type: 'select',

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -85,25 +85,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 				Twinkle.protect.doCustomExpiry(e.target);
 			}
 		},
-		list: [
-			{ label: '1 hour', value: '1 hour' },
-			{ label: '2 hours', value: '2 hours' },
-			{ label: '3 hours', value: '3 hours' },
-			{ label: '6 hours', value: '6 hours' },
-			{ label: '12 hours', value: '12 hours' },
-			{ label: '1 day', value: '1 day' },
-			{ label: '2 days', selected: true, value: '2 days' },
-			{ label: '3 days', value: '3 days' },
-			{ label: '4 days', value: '4 days' },
-			{ label: '1 week', value: '1 week' },
-			{ label: '2 weeks', value: '2 weeks' },
-			{ label: '1 month', value: '1 month' },
-			{ label: '2 months', value: '2 months' },
-			{ label: '3 months', value: '3 months' },
-			{ label: '1 year', value: '1 year' },
-			{ label: 'indefinite', value: 'infinity' },
-			{ label: 'Custom...', value: 'custom' }
-		]
+		list: Twinkle.protect.protectionLengths // Default (2 days) set after render
 	});
 
 	form.append({
@@ -155,25 +137,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 				Twinkle.protect.doCustomExpiry(e.target);
 			}
 		},
-		list: [
-			{ label: '1 hour', value: '1 hour' },
-			{ label: '2 hours', value: '2 hours' },
-			{ label: '3 hours', value: '3 hours' },
-			{ label: '6 hours', value: '6 hours' },
-			{ label: '12 hours', value: '12 hours' },
-			{ label: '1 day', value: '1 day' },
-			{ label: '2 days', selected: true, value: '2 days' },
-			{ label: '3 days', value: '3 days' },
-			{ label: '4 days', value: '4 days' },
-			{ label: '1 week', value: '1 week' },
-			{ label: '2 weeks', value: '2 weeks' },
-			{ label: '1 month', value: '1 month' },
-			{ label: '2 months', value: '2 months' },
-			{ label: '3 months', value: '3 months' },
-			{ label: '1 year', value: '1 year' },
-			{ label: 'indefinite', value: 'infinity' },
-			{ label: 'Custom...', value: 'custom' }
-		]
+		list: Twinkle.protect.protectionLengths // Default (2 days) set after render
 	});
 
 	form.append({
@@ -234,25 +198,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 				Twinkle.protect.doCustomExpiry(e.target);
 			}
 		},
-		list: [
-			{ label: '1 hour', value: '1 hour' },
-			{ label: '2 hours', value: '2 hours' },
-			{ label: '3 hours', value: '3 hours' },
-			{ label: '6 hours', value: '6 hours' },
-			{ label: '12 hours', value: '12 hours' },
-			{ label: '1 day', value: '1 day' },
-			{ label: '2 days', value: '2 days' },
-			{ label: '3 days', value: '3 days' },
-			{ label: '4 days', value: '4 days' },
-			{ label: '1 week', value: '1 week' },
-			{ label: '2 weeks', value: '2 weeks' },
-			{ label: '1 month', value: '1 month' },
-			{ label: '2 months', value: '2 months' },
-			{ label: '3 months', value: '3 months' },
-			{ label: '1 year', value: '1 year' },
-			{ label: 'indefinite', selected: true, value: 'infinity' },
-			{ label: 'Custom...', value: 'custom' }
-		]
+		list: Twinkle.protect.protectionLengths // Default (indefinite) set after render
 	});
 
 	form.append({
@@ -352,6 +298,12 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 		var result = form.render();
 		Window.setContent(result);
+
+		// Set defaults
+		form.editexpiry.value = '2 days';
+		form.moveexpiry.value = '2 days';
+		form.createexpiry.value = 'indefinite';
+
 
 	}, statelem);
 

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -354,26 +354,8 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 							Twinkle.protect.doCustomExpiry(e.target);
 						}
 					},
-					// default expiry selection is conditionally set in Twinkle.protect.callback.changePreset
-					list: [
-						{ label: '1 hour', value: '1 hour' },
-						{ label: '2 hours', value: '2 hours' },
-						{ label: '3 hours', value: '3 hours' },
-						{ label: '6 hours', value: '6 hours' },
-						{ label: '12 hours', value: '12 hours' },
-						{ label: '1 day', value: '1 day' },
-						{ label: '2 days', value: '2 days' },
-						{ label: '3 days', value: '3 days' },
-						{ label: '4 days', value: '4 days' },
-						{ label: '1 week', value: '1 week' },
-						{ label: '2 weeks', value: '2 weeks' },
-						{ label: '1 month', value: '1 month' },
-						{ label: '2 months', value: '2 months' },
-						{ label: '3 months', value: '3 months' },
-						{ label: '1 year', value: '1 year' },
-						{ label: 'indefinite', value: 'infinity' },
-						{ label: 'Custom...', value: 'custom' }
-					]
+					// default expiry selection (2 days) is conditionally set in Twinkle.protect.callback.changePreset
+					list: Twinkle.protect.protectionLengths
 				});
 				field2.append({
 					type: 'checkbox',
@@ -425,26 +407,8 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 							Twinkle.protect.doCustomExpiry(e.target);
 						}
 					},
-					// default expiry selection is conditionally set in Twinkle.protect.callback.changePreset
-					list: [
-						{ label: '1 hour', value: '1 hour' },
-						{ label: '2 hours', value: '2 hours' },
-						{ label: '3 hours', value: '3 hours' },
-						{ label: '6 hours', value: '6 hours' },
-						{ label: '12 hours', value: '12 hours' },
-						{ label: '1 day', value: '1 day' },
-						{ label: '2 days', value: '2 days' },
-						{ label: '3 days', value: '3 days' },
-						{ label: '4 days', value: '4 days' },
-						{ label: '1 week', value: '1 week' },
-						{ label: '2 weeks', value: '2 weeks' },
-						{ label: '1 month', value: '1 month' },
-						{ label: '2 months', value: '2 months' },
-						{ label: '3 months', value: '3 months' },
-						{ label: '1 year', value: '1 year' },
-						{ label: 'indefinite', value: 'infinity' },
-						{ label: 'Custom...', value: 'custom' }
-					]
+					// default expiry selection (2 days) is conditionally set in Twinkle.protect.callback.changePreset
+					list: Twinkle.protect.protectionLengths
 				});
 				if (hasFlaggedRevs) {
 					field2.append({
@@ -485,25 +449,8 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 								Twinkle.protect.doCustomExpiry(e.target);
 							}
 						},
-						list: [
-							{ label: '1 hour', value: '1 hour' },
-							{ label: '2 hours', value: '2 hours' },
-							{ label: '3 hours', value: '3 hours' },
-							{ label: '6 hours', value: '6 hours' },
-							{ label: '12 hours', value: '12 hours' },
-							{ label: '1 day', value: '1 day' },
-							{ label: '2 days', value: '2 days' },
-							{ label: '3 days', value: '3 days' },
-							{ label: '4 days', value: '4 days' },
-							{ label: '1 week', value: '1 week' },
-							{ label: '2 weeks', value: '2 weeks' },
-							{ label: '1 month', selected: true, value: '1 month' },
-							{ label: '2 months', value: '2 months' },
-							{ label: '3 months', value: '3 months' },
-							{ label: '1 year', value: '1 year' },
-							{ label: 'indefinite', value: 'infinity' },
-							{ label: 'Custom...', value: 'custom' }
-						]
+						// default expiry selection (1 month) is conditionally set in Twinkle.protect.callback.changePreset
+						list: Twinkle.protect.protectionLengths
 					});
 				}
 			} else {  // for non-existing pages
@@ -552,25 +499,8 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 							Twinkle.protect.doCustomExpiry(e.target);
 						}
 					},
-					list: [
-						{ label: '1 hour', value: '1 hour' },
-						{ label: '2 hours', value: '2 hours' },
-						{ label: '3 hours', value: '3 hours' },
-						{ label: '6 hours', value: '6 hours' },
-						{ label: '12 hours', value: '12 hours' },
-						{ label: '1 day', value: '1 day' },
-						{ label: '2 days', value: '2 days' },
-						{ label: '3 days', value: '3 days' },
-						{ label: '4 days', value: '4 days' },
-						{ label: '1 week', value: '1 week' },
-						{ label: '2 weeks', value: '2 weeks' },
-						{ label: '1 month', value: '1 month' },
-						{ label: '2 months', value: '2 months' },
-						{ label: '3 months', value: '3 months' },
-						{ label: '1 year', value: '1 year' },
-						{ label: 'indefinite', selected: true, value: 'infinity' },
-						{ label: 'Custom...', value: 'custom' }
-					]
+					// default expiry selection (indefinite) is conditionally set in Twinkle.protect.callback.changePreset
+					list: Twinkle.protect.protectionLengths
 				});
 			}
 			field2.append({
@@ -681,6 +611,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 	Twinkle.protect.callback.showLogAndCurrentProtectInfo();
 };
 
+// NOTE: This function is used by batchprotect as well
 Twinkle.protect.formevents = {
 	editmodify: function twinkleprotectFormEditmodifyEvent(e) {
 		e.target.form.editlevel.disabled = !e.target.checked;
@@ -734,6 +665,28 @@ Twinkle.protect.doCustomExpiry = function twinkleprotectDoCustomExpiry(target) {
 		target.selectedIndex = 0;
 	}
 };
+
+// default expiry selection is conditionally set in Twinkle.protect.callback.changePreset
+// NOTE: This list is used by batchprotect as well
+Twinkle.protect.protectionLengths = [
+	{ label: '1 hour', value: '1 hour' },
+	{ label: '2 hours', value: '2 hours' },
+	{ label: '3 hours', value: '3 hours' },
+	{ label: '6 hours', value: '6 hours' },
+	{ label: '12 hours', value: '12 hours' },
+	{ label: '1 day', value: '1 day' },
+	{ label: '2 days', value: '2 days' },
+	{ label: '3 days', value: '3 days' },
+	{ label: '4 days', value: '4 days' },
+	{ label: '1 week', value: '1 week' },
+	{ label: '2 weeks', value: '2 weeks' },
+	{ label: '1 month', value: '1 month' },
+	{ label: '2 months', value: '2 months' },
+	{ label: '3 months', value: '3 months' },
+	{ label: '1 year', value: '1 year' },
+	{ label: 'indefinite', value: 'infinity' },
+	{ label: 'Custom...', value: 'custom' }
+];
 
 Twinkle.protect.protectionTypes = [
 	{ label: 'Unprotection', value: 'unprotect' },
@@ -1055,22 +1008,22 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 				Twinkle.protect.formevents.editmodify({ target: form.editmodify });
 				form.editlevel.value = item.edit;
 				Twinkle.protect.formevents.editlevel({ target: form.editlevel });
-				form.editexpiry.value = '2 days';
 			} else {
 				form.editmodify.checked = false;
 				Twinkle.protect.formevents.editmodify({ target: form.editmodify });
 			}
+			form.editexpiry.value = '2 days';
 
 			if (item.move) {
 				form.movemodify.checked = true;
 				Twinkle.protect.formevents.movemodify({ target: form.movemodify });
 				form.movelevel.value = item.move;
 				Twinkle.protect.formevents.movelevel({ target: form.movelevel });
-				form.moveexpiry.value = '2 days';
 			} else {
 				form.movemodify.checked = false;
 				Twinkle.protect.formevents.movemodify({ target: form.movemodify });
 			}
+			form.moveexpiry.value = '2 days';
 
 			// Default to indef for highly-visible template
 			if (form.category.value === 'pp-template') {
@@ -1088,12 +1041,14 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 					form.pcmodify.checked = false;
 					Twinkle.protect.formevents.pcmodify({ target: form.pcmodify });
 				}
+				form.pcexpiry.value = '1 month';
 			}
 		} else {
 			if (item.create) {
 				form.createlevel.value = item.create;
 				Twinkle.protect.formevents.createlevel({ target: form.createlevel });
 			}
+			form.createexpiry.value = 'infinity';
 		}
 
 		var reasonField = actiontype === 'protect' ? form.protectReason : form.reason;

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -311,39 +311,15 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						}
 					]
 				});
-				var editlevel = field2.append({
+				field2.append({
 					type: 'select',
 					name: 'editlevel',
 					label: 'Edit protection:',
-					event: Twinkle.protect.formevents.editlevel
-				});
-				editlevel.append({
-					type: 'option',
-					label: 'All',
-					value: 'all'
-				});
-				editlevel.append({
-					type: 'option',
-					label: 'Autoconfirmed',
-					value: 'autoconfirmed'
-				});
-				editlevel.append({
-					type: 'option',
-					label: 'Extended confirmed',
-					value: 'extendedconfirmed'
-				});
-				if (isTemplate) {
-					editlevel.append({
-						type: 'option',
-						label: 'Template editor',
-						value: 'templateeditor'
-					});
-				}
-				editlevel.append({
-					type: 'option',
-					label: 'Sysop',
-					value: 'sysop',
-					selected: true
+					event: Twinkle.protect.formevents.editlevel,
+					list: Twinkle.protect.protectionLevels.filter(function(level) {
+						// Filter TE outside of templates and modules
+						return isTemplate || level.value !== 'templateeditor';
+					})
 				});
 				field2.append({
 					type: 'select',
@@ -369,34 +345,15 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						}
 					]
 				});
-				var movelevel = field2.append({
+				field2.append({
 					type: 'select',
 					name: 'movelevel',
 					label: 'Move protection:',
-					event: Twinkle.protect.formevents.movelevel
-				});
-				movelevel.append({
-					type: 'option',
-					label: 'All',
-					value: 'all'
-				});
-				movelevel.append({
-					type: 'option',
-					label: 'Extended confirmed',
-					value: 'extendedconfirmed'
-				});
-				if (isTemplate) {
-					movelevel.append({
-						type: 'option',
-						label: 'Template editor',
-						value: 'templateeditor'
-					});
-				}
-				movelevel.append({
-					type: 'option',
-					label: 'Sysop',
-					value: 'sysop',
-					selected: true
+					event: Twinkle.protect.formevents.movelevel,
+					list: Twinkle.protect.protectionLevels.filter(function(level) {
+						// Autoconfirmed is required for a move, redundant
+						return level.value !== 'autoconfirmed' && (isTemplate || level.value !== 'templateeditor');
+					})
 				});
 				field2.append({
 					type: 'select',
@@ -423,22 +380,15 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 							}
 						]
 					});
-					var pclevel = field2.append({
+					field2.append({
 						type: 'select',
 						name: 'pclevel',
 						label: 'Pending changes:',
-						event: Twinkle.protect.formevents.pclevel
-					});
-					pclevel.append({
-						type: 'option',
-						label: 'None',
-						value: 'none'
-					});
-					pclevel.append({
-						type: 'option',
-						label: 'Pending changes',
-						value: 'autoconfirmed',
-						selected: true
+						event: Twinkle.protect.formevents.pclevel,
+						list: [
+							{ label: 'None', value: 'none' },
+							{ label: 'Pending change', value: 'autoconfirmed', selected: true }
+						]
 					});
 					field2.append({
 						type: 'select',
@@ -454,41 +404,15 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					});
 				}
 			} else {  // for non-existing pages
-				var createlevel = field2.append({
+				field2.append({
 					type: 'select',
 					name: 'createlevel',
 					label: 'Create protection:',
-					event: Twinkle.protect.formevents.createlevel
-				});
-				createlevel.append({
-					type: 'option',
-					label: 'All',
-					value: 'all'
-				});
-				if (mw.config.get('wgNamespaceNumber') !== 0) {
-					createlevel.append({
-						type: 'option',
-						label: 'Autoconfirmed',
-						value: 'autoconfirmed'
-					});
-				}
-				if (isTemplate) {
-					createlevel.append({
-						type: 'option',
-						label: 'Template editor',
-						value: 'templateeditor'
-					});
-				}
-				createlevel.append({
-					type: 'option',
-					label: 'Extended confirmed',
-					value: 'extendedconfirmed',
-					selected: true
-				});
-				createlevel.append({
-					type: 'option',
-					label: 'Sysop',
-					value: 'sysop'
+					event: Twinkle.protect.formevents.createlevel,
+					list: Twinkle.protect.protectionLevels.filter(function(level) {
+						// Filter TE always, and autoconfirmed in mainspace, redundant since WP:ACPERM
+						return level.value !== 'templateeditor' && (mw.config.get('wgNamespaceNumber') !== 0 || level.value !== 'autoconfirmed');
+					})
 				});
 				field2.append({
 					type: 'select',
@@ -665,6 +589,15 @@ Twinkle.protect.doCustomExpiry = function twinkleprotectDoCustomExpiry(target) {
 		target.selectedIndex = 0;
 	}
 };
+
+// NOTE: This list is used by batchprotect as well
+Twinkle.protect.protectionLevels = [
+	{ label: 'All', value: 'all' },
+	{ label: 'Autoconfirmed', value: 'autoconfirmed' },
+	{ label: 'Extended confirmed', value: 'extendedconfirmed' },
+	{ label: 'Template editor', value: 'templateeditor' },
+	{ label: 'Sysop', value: 'sysop', selected: true }
+];
 
 // default expiry selection is conditionally set in Twinkle.protect.callback.changePreset
 // NOTE: This list is used by batchprotect as well
@@ -1012,7 +945,6 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 				form.editmodify.checked = false;
 				Twinkle.protect.formevents.editmodify({ target: form.editmodify });
 			}
-			form.editexpiry.value = '2 days';
 
 			if (item.move) {
 				form.movemodify.checked = true;
@@ -1023,11 +955,12 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 				form.movemodify.checked = false;
 				Twinkle.protect.formevents.movemodify({ target: form.movemodify });
 			}
-			form.moveexpiry.value = '2 days';
 
 			// Default to indef for highly-visible template
 			if (form.category.value === 'pp-template') {
 				form.editexpiry.value = form.moveexpiry.value = 'infinity';
+			} else {
+				form.editexpiry.value = form.moveexpiry.value = '2 days';
 			}
 
 


### PR DESCRIPTION
Split into separate commits for reviewing purposes, but these can be merged.  In short:

1st commit: Filter out FlaggedRevs and templateeditor a little more consistently/less repetitively, plus minor bugfix attempting to set PC on templates.

2nd commit: Consolidate protection lengths into `Twinkle.protect.protectionLengths`.  Slight change to how menus change, so that each expiry now always uses the default (where before the behavior was inconsistent).

3rd commit: Consolidate protection levels into `Twinkle.protect.protectionLevels` then `.filter` out inappropriate options.