### PR TITLE
welcome: Fix key in autowelcome

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -96,7 +96,7 @@ Twinkle.welcome.welcomeUser = function welcomeUser() {
 	$('#catlinks').remove();
 
 	var params = {
-		value: Twinkle.getPref('quickWelcomeTemplate'),
+		template: Twinkle.getPref('quickWelcomeTemplate'),
 		article: mw.util.getParamValue('vanarticle') || '',
 		mode: 'auto'
 	};


### PR DESCRIPTION
`value` -> `template` in #908 (4490c9ff)

Reported at [WT:TW](http://en.wikipedia.org/wiki/Special:Permalink/970559788#Can't_welcome_with_IE)