### PR TITLE
warn: Append warning to an existing section, even if it's not the last

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1892,32 +1892,36 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 };
 
 Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
-	var text = pageobj.getPageText(),
-		params = pageobj.getCallbackParameters(),
+	var params = pageobj.getCallbackParameters(),
+		date = new Morebits.date(pageobj.getLoadTime()),
 		messageData = params.messageData,
-		date = new Morebits.date(pageobj.getLoadTime());
-
-	var dateHeaderRegex = date.monthHeaderRegex(), dateHeaderRegexLast, dateHeaderRegexResult;
-	while ((dateHeaderRegexLast = dateHeaderRegex.exec(text)) !== null) {
-		dateHeaderRegexResult = dateHeaderRegexLast;
-	}
-	// If dateHeaderRegexResult is null then lastHeaderIndex is never checked. If it is not null but
-	// \n== is not found, then the date header must be at the very start of the page. lastIndexOf
-	// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
-	var lastHeaderIndex = text.lastIndexOf('\n==') + 1;
-
-	if (text.length > 0) {
-		text += '\n\n';
-	}
+		text;
 
 	params.indefinite = Morebits.string.isInfinity(params.expiry);
 
 	if (Twinkle.getPref('blankTalkpageOnIndefBlock') && params.template !== 'uw-lblock' && params.indefinite) {
 		Morebits.status.info('Info', 'Blanking talk page per preferences and creating a new level 2 heading for the date');
 		text = date.monthHeader() + '\n';
-	} else if (!dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex) {
-		Morebits.status.info('Info', 'Will create a new level 2 heading for the date, as none was found for this month');
-		text += date.monthHeader() + '\n';
+	} else {
+		text = pageobj.getPageText();
+
+		var dateHeaderRegex = date.monthHeaderRegex(), dateHeaderRegexLast, dateHeaderRegexResult;
+		while ((dateHeaderRegexLast = dateHeaderRegex.exec(text)) !== null) {
+			dateHeaderRegexResult = dateHeaderRegexLast;
+		}
+		// If dateHeaderRegexResult is null then lastHeaderIndex is never checked. If it is not null but
+		// \n== is not found, then the date header must be at the very start of the page. lastIndexOf
+		// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
+		var lastHeaderIndex = text.lastIndexOf('\n==') + 1;
+
+		if (text.length > 0) {
+			text += '\n\n';
+		}
+
+		if (!dateHeaderRegexResult || dateHeaderRegexResult.index !== lastHeaderIndex) {
+			Morebits.status.info('Info', 'Will create a new level 2 heading for the date, as none was found for this month');
+			text += date.monthHeader() + '\n';
+		}
 	}
 
 	params.expiry = typeof params.template_expiry !== 'undefined' ? params.template_expiry : params.expiry;


### PR DESCRIPTION
There's been some discussion on this front recently (see [here](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_42#Warn_template_bug?_creating_unneeded_new_section_headers) and [here](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle/Archive_43#Multiple_sections_for_one_month)) and I think it's reasonable to do.  The *correct* way would be to set up an additional query to `action=parse`, then go through `prop=sections`, but that seems overkill if we can just check `/\n(==+).+\1/g`.  This changes the single `pageobj.save` to either `pageobj.append` or `pageobj.newSection` as appropriate.

Note that I'm not proposing the same for the block, as I think it's less obviously useful to place a block notice anywhere but the bottom.  I did, however, restructure the block evaluation somewhat, so that we don't bother with the page text if the user is just gonna blank it.

Tested but not extensively with weird talk pages; relies upon `newSection` from #1083.