### PR TITLE
Support for watchlist expiry

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -870,17 +870,7 @@ Twinkle.arv.processSock = function(params) {
 	spiPage.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
 	spiPage.setChangeTags(Twinkle.changeTags);
 	spiPage.setAppendText(text);
-	switch (Twinkle.getPref('spiWatchReport')) {
-		case 'yes':
-			spiPage.setWatchlist(true);
-			break;
-		case 'no':
-			spiPage.setWatchlistFromPreferences(false);
-			break;
-		default:
-			spiPage.setWatchlistFromPreferences(true);
-			break;
-	}
+	spiPage.setWatchlist(Twinkle.getPref('spiWatchReport'));
 	spiPage.append();
 
 	Morebits.wiki.removeCheckpoint();  // all page updates have been started

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -21,7 +21,15 @@
 
 Twinkle.config = {};
 
-Twinkle.config.watchlistEnums = { yes: 'Add to watchlist', no: "Don't add to watchlist", 'default': 'Follow your site preferences' };
+Twinkle.config.watchlistEnums = {
+	yes: 'Add to watchlist (indefinitely)',
+	no: "Don't add to watchlist",
+	'default': 'Follow your site preferences',
+	'1 week': 'Watch for 1 week',
+	'1 month': 'Watch for 1 month',
+	'3 months': 'Watch for 3 months',
+	'6 months': 'Watch for 6 months'
+};
 
 Twinkle.config.commonSets = {
 	csdCriteria: {
@@ -244,7 +252,7 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.deliWatchPage (string)
-			// The watchlist setting of the page tagged for deletion. Either "yes", "no", or "default". Default is "default" (Duh).
+			// The watchlist setting of the page tagged for deletion.
 			{
 				name: 'deliWatchPage',
 				label: 'Add image page to watchlist when tagging',
@@ -253,7 +261,7 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.deliWatchUser (string)
-			// The watchlist setting of the user talk page if a notification is placed. Either "yes", "no", or "default". Default is "default" (Duh).
+			// The watchlist setting of the user talk page if a notification is placed.
 			{
 				name: 'deliWatchUser',
 				label: 'Add user talk page of initial uploader to watchlist when notifying',
@@ -267,12 +275,13 @@ Twinkle.config.sections = [
 		title: 'Proposed deletion (PROD)',
 		module: 'prod',
 		preferences: [
-			// TwinkleConfig.watchProdPages (boolean)
-			// If, when applying prod template to page, to watch the page
+			// TwinkleConfig.watchProdPages (string)
+			// Watchlist setting when applying prod template to page
 			{
 				name: 'watchProdPages',
 				label: 'Add article to watchlist when tagging',
-				type: 'boolean'
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.markProdPagesAsPatrolled (boolean)
@@ -364,6 +373,14 @@ Twinkle.config.sections = [
 				type: 'set',
 				setValues: { agf: 'AGF rollback', norm: 'Normal rollback', vand: 'Vandalism rollback', torev: '"Restore this version"' }
 			},
+			// TwinkleConfig.watchRevertedExpiry
+			// If any of the above items are selected, whether to expire the watch
+			{
+				name: 'watchRevertedExpiry',
+				label: 'When reverting a page, how long to watch it for',
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
+			},
 
 			// TwinkleConfig.offerReasonOnNormalRevert (boolean)
 			// If to offer a prompt for extra summary reason for normal reverts, default to true
@@ -432,6 +449,14 @@ Twinkle.config.sections = [
 				type: 'set',
 				setValues: Twinkle.config.commonSets.csdCriteria,
 				setDisplayOrder: Twinkle.config.commonSets.csdCriteriaDisplayOrder
+			},
+			// TwinkleConfig.watchSpeedyExpiry
+			// If any of the above items are selected, whether to expire the watch
+			{
+				name: 'watchSpeedyExpiry',
+				label: 'When tagging a page, how long to watch it for',
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.markSpeedyPagesAsPatrolled (boolean)
@@ -560,12 +585,14 @@ Twinkle.config.sections = [
 			{
 				name: 'watchTaggedPages',
 				label: 'Add page to watchlist when tagging',
-				type: 'boolean'
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
 			},
 			{
 				name: 'watchMergeDiscussions',
 				label: 'Add talk pages to watchlist when starting merge discussions',
-				type: 'boolean'
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
 			},
 			{
 				name: 'markTaggedPagesAsMinor',
@@ -702,12 +729,13 @@ Twinkle.config.sections = [
 				type: 'boolean'
 			},
 
-			// TwinkleConfig.watchWarnings (boolean)
-			// if true, watch the page which has been dispatched an warning or notice, if false, default applies
+			// TwinkleConfig.watchWarnings (string)
+			// Watchlist setting for the page which has been dispatched an warning or notice
 			{
 				name: 'watchWarnings',
 				label: 'Add user talk page to watchlist when notifying',
-				type: 'boolean'
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
 			},
 
 			// TwinkleConfig.oldSelect (boolean)
@@ -742,7 +770,8 @@ Twinkle.config.sections = [
 				name: 'watchWelcomes',
 				label: 'Add user talk pages to watchlist when welcoming',
 				helptip: 'Doing so adds to the personal element of welcoming a user - you will be able to see how they are coping as a newbie, and possibly help them.',
-				type: 'boolean'
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
 			},
 			{
 				name: 'insertUsername',
@@ -804,8 +833,7 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.xfdWatchPage (string)
-			// The watchlist setting of the page being nominated for XfD. Either "yes" (add to watchlist), "no" (don't
-			// add to watchlist), or "default" (use setting from preferences). Default is "default" (duh).
+			// The watchlist setting of the page being nominated for XfD.
 			{
 				name: 'xfdWatchPage',
 				label: 'Add the nominated page to watchlist',
@@ -816,7 +844,6 @@ Twinkle.config.sections = [
 			// TwinkleConfig.xfdWatchDiscussion (string)
 			// The watchlist setting of the newly created XfD page (for those processes that create discussion pages for each nomination),
 			// or the list page for the other processes.
-			// Either "yes" (add to watchlist), "no" (don't add to watchlist), or "default" (use setting from preferences). Default is "default" (duh).
 			{
 				name: 'xfdWatchDiscussion',
 				label: 'Add the deletion discussion page to watchlist',
@@ -826,9 +853,7 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.xfdWatchList (string)
-			// The watchlist setting of the XfD list page, *if* the discussion is on a separate page. Either "yes" (add to watchlist), "no" (don't
-			// add to watchlist), or "default" (use setting from preferences). Default is "no" (Hehe. Seriously though, who wants to watch it?
-			// Sorry in advance for any false positives.).
+			// The watchlist setting of the XfD list page, *if* the discussion is on a separate page.
 			{
 				name: 'xfdWatchList',
 				label: 'Add the daily log/list page to the watchlist (where applicable)',
@@ -838,8 +863,7 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.xfdWatchUser (string)
-			// The watchlist setting of the user talk page if they receive a notification. Either "yes" (add to watchlist), "no" (don't
-			// add to watchlist), or "default" (use setting from preferences). Default is "default" (duh).
+			// The watchlist setting of the user talk page if they receive a notification.
 			{
 				name: 'xfdWatchUser',
 				label: 'Add user talk page of initial contributor to watchlist (when notifying)',
@@ -848,8 +872,7 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.xfdWatchRelated (string)
-			// The watchlist setting of the target of a redirect being nominated for RfD. Either "yes" (add to watchlist), "no" (don't
-			// add to watchlist), or "default" (use setting from preferences). Default is "default" (duh).
+			// The watchlist setting of the target of a redirect being nominated for RfD.
 			{
 				name: 'xfdWatchRelated',
 				label: "Add the redirect's target page to watchlist (when notifying)",
@@ -1038,7 +1061,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 				}
 				cell = document.createElement('td');
 
-				var label, input;
+				var label, input, gotPref = Twinkle.getPref(pref.name);
 				switch (pref.type) {
 
 					case 'boolean':  // create a checkbox
@@ -1049,7 +1072,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						input.setAttribute('type', 'checkbox');
 						input.setAttribute('id', pref.name);
 						input.setAttribute('name', pref.name);
-						if (Twinkle.getPref(pref.name) === true) {
+						if (gotPref === true) {
 							input.setAttribute('checked', 'checked');
 						}
 						label.appendChild(input);
@@ -1080,8 +1103,8 @@ Twinkle.config.init = function twinkleconfigInit() {
 							input.setAttribute('type', 'number');
 							input.setAttribute('step', '1');  // integers only
 						}
-						if (Twinkle.getPref(pref.name)) {
-							input.setAttribute('value', Twinkle.getPref(pref.name));
+						if (gotPref) {
+							input.setAttribute('value', gotPref);
 						}
 						cell.appendChild(input);
 						break;
@@ -1106,7 +1129,12 @@ Twinkle.config.init = function twinkleconfigInit() {
 						$.each(pref.enumValues, function(enumvalue, enumdisplay) {
 							var option = document.createElement('option');
 							option.setAttribute('value', enumvalue);
-							if (Twinkle.getPref(pref.name) === enumvalue) {
+							if ((gotPref === enumvalue) ||
+								// Hack to convert old boolean watchlist prefs
+								// to corresponding enums (added in v2.1)
+								(typeof gotPref === 'boolean' &&
+								((gotPref && enumvalue === 'yes') ||
+								(!gotPref && enumvalue === 'no')))) {
 								option.setAttribute('selected', 'selected');
 							}
 							option.appendChild(document.createTextNode(enumdisplay));
@@ -1132,12 +1160,12 @@ Twinkle.config.init = function twinkleconfigInit() {
 							check.setAttribute('type', 'checkbox');
 							check.setAttribute('id', pref.name + '_' + itemkey);
 							check.setAttribute('name', pref.name + '_' + itemkey);
-							if (Twinkle.getPref(pref.name) && Twinkle.getPref(pref.name).indexOf(itemkey) !== -1) {
+							if (gotPref && gotPref.indexOf(itemkey) !== -1) {
 								check.setAttribute('checked', 'checked');
 							}
 							// cater for legacy integer array values for unlinkNamespaces (this can be removed a few years down the track...)
 							if (pref.name === 'unlinkNamespaces') {
-								if (Twinkle.getPref(pref.name) && Twinkle.getPref(pref.name).indexOf(parseInt(itemkey, 10)) !== -1) {
+								if (gotPref && gotPref.indexOf(parseInt(itemkey, 10)) !== -1) {
 									check.setAttribute('checked', 'checked');
 								}
 							}
@@ -1177,7 +1205,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						button.addEventListener('click', Twinkle.config.listDialog.display, false);
 						// use jQuery data on the button to store the current config value
 						$(button).data({
-							value: Twinkle.getPref(pref.name),
+							value: gotPref,
 							pref: pref
 						});
 						button.appendChild(document.createTextNode('Edit items'));
@@ -1560,7 +1588,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 
 	// this is the object which gets serialized into JSON; only
 	// preferences that this script knows about are kept
-	var newConfig = {optionsVersion: 2};
+	var newConfig = {optionsVersion: 2.1};
 
 	// a comparison function is needed later on
 	// it is just enough for our purposes (i.e. comparing strings, numbers, booleans,

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -438,9 +438,24 @@ Twinkle.fluff.callbacks = {
 			'undoafter': revertToRevID,
 			'basetimestamp': touched,
 			'starttimestamp': loadtimestamp,
-			'watchlist': Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1 ? 'watch' : undefined,
 			'minor': Twinkle.getPref('markRevertedPagesAsMinor').indexOf('torev') !== -1 ? true : undefined
 		};
+		// Handle watching, possible expiry
+		if (Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1) {
+			var watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
+
+			if (!watchOrExpiry || watchOrExpiry === 'no') {
+				query.watchlist = 'nochange';
+			} else if (watchOrExpiry === 'default' || watchOrExpiry === 'preferences') {
+				query.watchlist = 'preferences';
+			} else {
+				query.watchlist = 'watch';
+				// number allowed but not used in Twinkle.config.watchlistEnums
+				if (typeof watchOrExpiry === 'string' && watchOrExpiry !== 'yes') {
+					query.watchlistexpiry = watchOrExpiry;
+				}
+			}
+		}
 
 		Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 		Morebits.wiki.actionCompleted.notice = 'Reversion completed';
@@ -653,9 +668,24 @@ Twinkle.fluff.callbacks = {
 			'undoafter': params.goodid,
 			'basetimestamp': touched,
 			'starttimestamp': loadtimestamp,
-			'watchlist': Twinkle.getPref('watchRevertedPages').indexOf(params.type) !== -1 ? 'watch' : undefined,
 			'minor': Twinkle.getPref('markRevertedPagesAsMinor').indexOf(params.type) !== -1 ? true : undefined
 		};
+		// Handle watching, possible expiry
+		if (Twinkle.getPref('watchRevertedPages').indexOf(params.type) !== -1) {
+			var watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
+
+			if (!watchOrExpiry || watchOrExpiry === 'no') {
+				query.watchlist = 'nochange';
+			} else if (watchOrExpiry === 'default' || watchOrExpiry === 'preferences') {
+				query.watchlist = 'preferences';
+			} else {
+				query.watchlist = 'watch';
+				// number allowed but not used in Twinkle.config.watchlistEnums
+				if (typeof watchOrExpiry === 'string' && watchOrExpiry !== 'yes') {
+					query.watchlistexpiry = watchOrExpiry;
+				}
+			}
+		}
 
 		if (!Twinkle.fluff.rollbackInPlace) {
 			Morebits.wiki.actionCompleted.redirect = params.pagename;

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -280,17 +280,7 @@ Twinkle.image.callbacks = {
 		pageobj.setPageText(tag + text);
 		pageobj.setEditSummary('This file is up for deletion, per [[WP:CSD#' + params.normalized + '|CSD ' + params.normalized + ']] (' + params.type + ').');
 		pageobj.setChangeTags(Twinkle.changeTags);
-		switch (Twinkle.getPref('deliWatchPage')) {
-			case 'yes':
-				pageobj.setWatchlist(true);
-				break;
-			case 'no':
-				pageobj.setWatchlistFromPreferences(false);
-				break;
-			default:
-				pageobj.setWatchlistFromPreferences(true);
-				break;
-		}
+		pageobj.setWatchlist(Twinkle.getPref('deliWatchPage'));
 		pageobj.setCreateOption('nocreate');
 		pageobj.save();
 	},
@@ -312,17 +302,7 @@ Twinkle.image.callbacks = {
 			usertalkpage.setEditSummary('Notification: tagging for deletion of [[:' + Morebits.pageNameNorm + ']].');
 			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
-			switch (Twinkle.getPref('deliWatchUser')) {
-				case 'yes':
-					usertalkpage.setWatchlist(true);
-					break;
-				case 'no':
-					usertalkpage.setWatchlistFromPreferences(false);
-					break;
-				default:
-					usertalkpage.setWatchlistFromPreferences(true);
-					break;
-			}
+			usertalkpage.setWatchlist(Twinkle.getPref('deliWatchUser'));
 			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append();
 		}

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2010,7 +2010,7 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 	var watchPage, promptForSummary;
 	normalizeds.forEach(function(norm) {
 		if (Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1) {
-			watchPage = true;
+			watchPage = Twinkle.getPref('watchSpeedyExpiry');
 		}
 		if (Twinkle.getPref('promptForSpeedyDeletionSummary').indexOf(norm) !== -1) {
 			promptForSummary = true;
@@ -2068,9 +2068,8 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	});
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-
 	var watchPage = normalizeds.some(function(norm) {
-		return Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1;
+		return Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1 && Twinkle.getPref('watchSpeedyExpiry');
 	});
 	var notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
 		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -700,19 +700,6 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 	form.notifycreator.checked = !form.notifycreator.disabled;
 };
 
-Twinkle.xfd.setWatchPref = function twinklexfdsetWatchPref(pageobj, pref) {
-	switch (pref) {
-		case 'yes':
-			pageobj.setWatchlist(true);
-			break;
-		case 'no':
-			pageobj.setWatchlistFromPreferences(false);
-			break;
-		default:
-			pageobj.setWatchlistFromPreferences(true);
-			break;
-	}
-};
 
 Twinkle.xfd.callbacks = {
 	// Requires having the tag text (params.tagText) set ahead of time
@@ -727,7 +714,7 @@ Twinkle.xfd.callbacks = {
 		talk_page.setNewSectionTitle('Edit request to complete ' + utils.toTLACase(params.venue) + ' nomination');
 		talk_page.setNewSectionText(editRequest);
 		talk_page.setCreateOption('recreate');
-		Twinkle.xfd.setWatchPref(talk_page, Twinkle.getPref('xfdWatchPage'));
+		talk_page.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 		talk_page.setFollowRedirect(true);  // should never be needed, but if the article is moved, we would want to follow the redirect
 		talk_page.setChangeTags(Twinkle.changeTags);
 		talk_page.setCallbackParameters(params);
@@ -910,9 +897,9 @@ Twinkle.xfd.callbacks = {
 		usertalkpage.setCreateOption('recreate');
 		// Different pref for RfD target notifications
 		if (params.venue === 'rfd' && targetNS !== 3) {
-			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchRelated'));
+			usertalkpage.setWatchlist(Twinkle.getPref('xfdWatchRelated'));
 		} else {
-			Twinkle.xfd.setWatchPref(usertalkpage, Twinkle.getPref('xfdWatchUser'));
+			usertalkpage.setWatchlist(Twinkle.getPref('xfdWatchUser'));
 		}
 		usertalkpage.setFollowRedirect(true, false);
 
@@ -1149,7 +1136,7 @@ Twinkle.xfd.callbacks = {
 
 				pageobj.setPageText(text);
 				pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('nocreate');
 				pageobj.save();
 			} else {
@@ -1162,7 +1149,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('afd', params));
 			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('createonly');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1206,7 +1193,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Adding [[:' + params.discussionpage + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchList'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchList'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save();
 		},
@@ -1323,7 +1310,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				if (params.scribunto) {
 					pageobj.setCreateOption('recreate'); // Module /doc might not exist
 				}
@@ -1345,7 +1332,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Listed for merging with [[:' + params.otherTemplateName + ']]; see [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				if (params.scribunto) {
 					pageobj.setCreateOption('recreate'); // Module /doc might not exist
 				}
@@ -1377,7 +1364,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Adding ' + (params.xfdcat === 'tfd' ? 'deletion nomination' : 'merge listing') + ' of [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1469,7 +1456,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('nocreate');
 				pageobj.save();
 			} else {
@@ -1482,7 +1469,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('mfd', params));
 			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('createonly');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1509,7 +1496,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Adding [[:' + params.discussionpage + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchList'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchList'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save();
 		},
@@ -1555,7 +1542,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('recreate');  // it might be possible for a file to exist without a description page
 				pageobj.save();
 			} else {
@@ -1603,7 +1590,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text + '\n\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('ffd', params));
 			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1680,7 +1667,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary(editsummary);
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('recreate');  // since categories can be populated without an actual page at that title
 				pageobj.save();
 			} else {
@@ -1710,7 +1697,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Adding ' + params.action + ' nomination of [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1729,7 +1716,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Listed for speedy renaming; see [[WP:CFDS|Categories for discussion/Speedy]].');
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('recreate');  // since categories can be populated without an actual page at that title
 				pageobj.save(function() {
 					// No user notification for CfDS, so just add this nomination to the user's userspace log
@@ -1755,7 +1742,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1850,7 +1837,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setPageText(params.tagText + text + '\n}}');
 				pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
-				Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchPage'));
+				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('nocreate');
 				pageobj.save();
 			} else {
@@ -1879,7 +1866,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
 			pageobj.save(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
@@ -1933,7 +1920,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setEditSummary('Proposing move' + (params.newname ? ' to [[:' + params.newname + ']]' : ''));
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setCreateOption('recreate'); // since the talk page need not exist
-			Twinkle.xfd.setWatchPref(pageobj, Twinkle.getPref('xfdWatchDiscussion'));
+			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.append(function() {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 				// add this nomination to the user's userspace log

--- a/twinkle.js
+++ b/twinkle.js
@@ -68,6 +68,7 @@ Twinkle.defaultConfig = {
 	rollbackInPlace: false,
 	markRevertedPagesAsMinor: [ 'vand' ],
 	watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
+	watchRevertedExpiry: 'yes',
 	offerReasonOnNormalRevert: true,
 	confirmOnFluff: false,
 	confirmOnMobileFluff: true,
@@ -79,7 +80,7 @@ Twinkle.defaultConfig = {
 	deliWatchUser: 'default',
 
 	// PROD
-	watchProdPages: true,
+	watchProdPages: 'yes',
 	markProdPagesAsPatrolled: false,
 	prodReasonDefault: '',
 	logProdPages: false,
@@ -88,6 +89,7 @@ Twinkle.defaultConfig = {
 	// CSD
 	speedySelectionStyle: 'buttonClick',
 	watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
+	watchSpeedyExpiry: 'yes',
 	markSpeedyPagesAsPatrolled: false,
 
 	// these next two should probably be identical by default
@@ -111,7 +113,7 @@ Twinkle.defaultConfig = {
 	defaultWarningGroup: '1',
 	combinedSingletMenus: false,
 	showSharedIPNotice: true,
-	watchWarnings: true,
+	watchWarnings: 'yes',
 	oldSelect: false,
 	customWarningList: [],
 
@@ -140,8 +142,8 @@ Twinkle.defaultConfig = {
 	// Formerly defaultConfig.friendly:
 	// Tag
 	groupByDefault: true,
-	watchTaggedPages: true,
-	watchMergeDiscussions: true,
+	watchTaggedPages: 'yes',
+	watchMergeDiscussions: 'yes',
 	markTaggedPagesAsMinor: false,
 	markTaggedPagesAsPatrolled: true,
 	tagArticleSortOrder: 'cat',
@@ -151,7 +153,7 @@ Twinkle.defaultConfig = {
 
 	// Welcome
 	topWelcomes: false,
-	watchWelcomes: true,
+	watchWelcomes: 'yes',
 	welcomeHeading: 'Welcome',
 	insertHeadings: true,
 	insertUsername: true,


### PR DESCRIPTION
This is still pretty rough — I whipped it up some time last month — but wanted to put this up as a starting point, in case there's any discussion.  Watchlist expiries in core can be tested at testWiki, but aren't enabled on enWiki (I'm not sure there's been any discussion about that process).

Basically, this:

- Adds a few default options to `watchlistEnums` in twinkleconfig
- Tweaks a few config options, even adding a few as necessary
- Overhauls how morebits handles watchlists, namely by expanding `setWatchlist` and doing away with `setWatchlistFromPreferences`.

The major sticking points are:
1. Does it work?
42. Is any of this a good idea?
42. Handling bespoke watchlist API actions (AFAICT `action=watch` has no way to default to prefs, so can either easily be *mostly* correct or rather convlutedly be correct (see `twinklexfd`)).

@MusikAnimal This is your baby as far as I see, so I'd love your thoughts/feedback on any/all of this at your leisure.  I only played with it minimally after it first went live, so I may have missed some specifics in the implementation...