### PR TITLE
Add intestactions to loadQuery, auto-add XfD edit request 

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2090,6 +2090,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		pageExists: false,
 		editSummary: null,
 		changeTags: null,
+		testActions: null,  // array if any valid actions
 		callbackParameters: null,
 		statusElement: new Morebits.status(currentAction),
 
@@ -2205,6 +2206,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.loadQuery = {
 			action: 'query',
 			prop: 'info|revisions',
+			intestactions: 'edit', // can be expanded
 			curtimestamp: '',
 			meta: 'tokens',
 			type: 'csrf',
@@ -2757,6 +2759,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		return ctx.timestamp;
 	};
 
+	/** @returns {boolean} whether or not you can edit the page */
+	this.canEdit = function() {
+		return !!ctx.testActions && ctx.testActions.indexOf('edit') !== -1;
+	};
+
 	/**
 	 * Retrieves the username of the user who created the page as well as
 	 * the timestamp of creation
@@ -3187,6 +3194,14 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		ctx.lastEditTime = $(xml).find('rev').attr('timestamp');
 		ctx.revertCurID = $(xml).find('page').attr('lastrevid');
+
+		var testactions = $(xml).find('actions');
+		if (testactions.length) {
+			ctx.testActions = []; // was null
+			$.each(testactions[0].attributes, function(_idx, value) {
+				ctx.testActions.push(value.name);
+			});
+		}
 
 		if (ctx.editMode === 'revert') {
 			ctx.revertCurID = $(xml).find('rev').attr('revid');


### PR DESCRIPTION
There are two separate issues here, but the main question is whether adding `intestactions` to the page load query in `Morebits.wiki.page` is a good idea.  I think it adds value being able to confirm early whether an action can take place, and should avoid running into a hard error if handled elegantly.  While this is a simple proof of concept, there's a lot we can think about making use of it.  Right now, I've just added `edit`, but an expansive view could imagine checks for `move` or `delete`, whether in morebits itself or available for modules to use.  Even without additional checks, it'd be a helpful pre-edit early failure check.  I've not tested or thought through the implications for non-load things like `append`.

I've used it here to enable twinklexfd to auto-add edit protected requests when a user can't edit the page in question.  With the exception of TfM other template tagging, `wgIsProbablyEditable` would have sufficed for this implementation. (technically both are making assumptions about "protection" but in practice, that's it).  I'm not certain that it's easier than using promises (cc @siddharthvp) but it's probably more efficient.

At any rate, I'd welcome thoughts on either side of things.