### PR TITLE
xfd/prod: Replace newlines in logged reason with {{pb}}

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -386,7 +386,7 @@ Twinkle.prod.callbacks = {
 		if (params.logEndorsing) {
 			logText += 'endorsed ' + (params.blp ? 'BLP ' : params.book ? 'BOOK' : '') + 'PROD. ~~~~~';
 			if (params.reason) {
-				logText += "\n#* '''Reason''': " + params.reason + '\n';
+				logText += "\n#* '''Reason''': " + params.reason.replace(/\n+/g, '{{pb}}') + '\n';
 			}
 			summaryText = 'Logging endorsement of PROD nomination of [[:' + Morebits.pageNameNorm + ']].';
 		} else {
@@ -396,7 +396,7 @@ Twinkle.prod.callbacks = {
 			}
 			logText += ' ~~~~~\n';
 			if (!params.blp && params.reason) {
-				logText += "#* '''Reason''': " + params.reason + '\n';
+				logText += "#* '''Reason''': " + params.reason.replace(/\n+/g, '{{pb}}') + '\n';
 			}
 			summaryText = 'Logging PROD nomination of [[:' + Morebits.pageNameNorm + ']].';
 		}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -837,7 +837,7 @@ Twinkle.xfd.callbacks = {
 		}
 		appendText += ' ~~~~~';
 		if (params.reason) {
-			appendText += "\n#* '''Reason''': " + params.reason;
+			appendText += "\n#* '''Reason''': " + params.reason.replace(/\n+/g, '{{pb}}');
 		}
 
 		usl.log(appendText, editsummary + Twinkle.getPref('summaryAd'));


### PR DESCRIPTION
Otherwise, new lines entered into the reason box will mess up the numbering

I don't think we want to force `getInputData` to do this on its own, but is there a better way?  There's a reasonable argument this could/should be in `Morebits.string`, alongside something like `formatReasonText`.  I might even prefer that, especially if we want to sidestep the template.