### PR TITLE
prod: Add AfDM to tag_re

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -226,7 +226,7 @@ Twinkle.prod.callbacks = {
 		var params = pageobj.getCallbackParameters();
 
 		// Check for already existing deletion tags
-		var tag_re = /{{(?:db-?|delete|article for deletion\/dated|ffd\b)|#invoke:RfD/i;
+		var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
 		if (tag_re.test(text)) {
 			statelem.warn('Page already tagged with a deletion template, aborting procedure');
 			return;


### PR DESCRIPTION
PROD was missing AfD templates if they weren't the first nomination.  Still used by subsequent nominations via {{Afdx}} despite being moved to {{Article for deletion/dated}} a decade ago.