### PR TITLE
tag: Combine {{Do not move to Commons}} options, add expiry option

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1006,12 +1006,20 @@ Twinkle.tag.fileList = {
 		{
 			label: '{{Do not move to Commons}}: file not suitable for moving to Commons',
 			value: 'Do not move to Commons',
-			subgroup: {
-				type: 'input',
-				name: 'DoNotMoveToCommons',
-				label: 'Reason: ',
-				tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"'
-			}
+			subgroup: [
+				{
+					type: 'input',
+					name: 'DoNotMoveToCommons_reason',
+					label: 'Reason: ',
+					tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"'
+				},
+				{
+					type: 'input',
+					name: 'DoNotMoveToCommons_expiry',
+					label: 'Expiration year: ',
+					tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).'
+				}
+			]
 		},
 		{
 			label: '{{Keep local}}: request to keep local copy of a Commons file',
@@ -1778,7 +1786,10 @@ Twinkle.tag.callbacks = {
 						currentTag += '|1=' + params[tag.replace(/ /g, '_') + 'File'];
 						break;
 					case 'Do not move to Commons':
-						currentTag += '|reason=' + params.DoNotMoveToCommons;
+						currentTag += '|reason=' + params.DoNotMoveToCommons_reason;
+						if (params.DoNotMoveToCommons_expiry) {
+							currentTag += '|expiry=' + params.DoNotMoveToCommons_expiry;
+						}
 						break;
 					case 'Orphaned non-free revisions':
 						currentTag = 'subst:' + currentTag; // subst
@@ -1965,7 +1976,12 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 				checkParameter('Vector version available', 'Vector_version_availableFile', 'the replacement file name')) {
 				return;
 			}
-			if (checkParameter('Do not move to Commons', 'DoNotMoveToCommons')) {
+			if (checkParameter('Do not move to Commons', 'DoNotMoveToCommons_reason')) {
+				return;
+			}
+			if (params.tags.indexOf('Do not move to Commons') !== -1 && params.DoNotMoveToCommons_expiry &&
+				(!/^2\d{3}$/.test(params.DoNotMoveToCommons_expiry) || parseInt(params.DoNotMoveToCommons_expiry, 10) <= new Date().getYear() + 1900)) {
+				alert('Must be a valid future year.');
 				return;
 			}
 			break;

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1003,15 +1003,14 @@ Twinkle.tag.fileList = {
 	],
 	'Wikimedia Commons-related tags': [
 		{ label: '{{Copy to Commons}}: free media that should be copied to Commons', value: 'Copy to Commons' },
-		{ label: '{{Do not move to Commons}} (PD issue): file is PD in the US but not in country of origin', value: 'Do not move to Commons' },
 		{
-			label: '{{Do not move to Commons}} (other reason)',
-			value: 'Do not move to Commons_reason',
+			label: '{{Do not move to Commons}}: file not suitable for moving to Commons',
+			value: 'Do not move to Commons',
 			subgroup: {
 				type: 'input',
 				name: 'DoNotMoveToCommons',
 				label: 'Reason: ',
-				tooltip: 'Enter the reason why this image should not be moved to Commons (required)'
+				tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"'
 			}
 		},
 		{
@@ -1735,11 +1734,11 @@ Twinkle.tag.callbacks = {
 			var tagtext = '', currentTag;
 			$.each(params.tags, function(k, tag) {
 				// when other commons-related tags are placed, remove "move to Commons" tag
-				if (['Keep local', 'Now Commons', 'Do not move to Commons_reason', 'Do not move to Commons'].indexOf(tag) !== -1) {
+				if (['Keep local', 'Now Commons', 'Do not move to Commons'].indexOf(tag) !== -1) {
 					text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, '');
 				}
 
-				currentTag = tag === 'Do not move to Commons_reason' ? 'Do not move to Commons' : tag;
+				currentTag = tag;
 
 				switch (tag) {
 					case 'Now Commons':
@@ -1778,7 +1777,7 @@ Twinkle.tag.callbacks = {
 					case 'Obsolete':
 						currentTag += '|1=' + params[tag.replace(/ /g, '_') + 'File'];
 						break;
-					case 'Do not move to Commons_reason':
+					case 'Do not move to Commons':
 						currentTag += '|reason=' + params.DoNotMoveToCommons;
 						break;
 					case 'Orphaned non-free revisions':
@@ -1966,7 +1965,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 				checkParameter('Vector version available', 'Vector_version_availableFile', 'the replacement file name')) {
 				return;
 			}
-			if (checkParameter('Do not move to Commons_reason', 'DoNotMoveToCommons')) {
+			if (checkParameter('Do not move to Commons', 'DoNotMoveToCommons')) {
 				return;
 			}
 			break;


### PR DESCRIPTION
There were two {{Do not move to Commons}} items, they've now been combined into one with a required `reason` parameter (it's not strictly required in the template, but there's a big red warning without one).  Suggested default in the tooltip.

Also added the expiry year option, alongside a bunch of excessive checks to ensure it's a valid, future year.