### PR TITLE
xfd: Fix bugs in RfD target notifications

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1705,7 +1705,7 @@ Twinkle.xfd.callbacks = {
 						statelem.warn('You (' + mw.config.get('wgUserName') + ') are the target; skipping target page notification');
 					}
 				} else {
-					Twinkle.xfd.callbacks.rfd.targetNotification(params, targetTalk);
+					Twinkle.xfd.callbacks.rfd.targetNotification(params, targetTalk.toText());
 				}
 			}
 		},
@@ -1737,7 +1737,7 @@ Twinkle.xfd.callbacks = {
 			targettalkpage.setFollowRedirect(true);
 			targettalkpage.append(function() {
 				// Add to userspace log if not notifying the creator
-				if (!params.usertalk) {
+				if (!params.notifycreator) {
 					Twinkle.xfd.callbacks.addToLog(params, null);
 				}
 			});


### PR DESCRIPTION
Quite a lineage here!  When first added in #527 (a5ae221f), that left a `mw.Title` object being passed to `targetNotification`, rather than the string that `Morebits.wiki.page` expects.  This appears not to have actually been problem, however, until the ability to avoid following cross-namespace redirects was added in #915 (95445604).  This meant that the `mw.Title` object was being passed into `new mw.Title`, which would quietly complain.

It turns out that bug was epistatic to another misnaming from the addition of `getInputData` in #908 (df2aa163): a single `params.usertalk` remained, when the other had all been converted to `params.notifycreator`.