### PR TITLE
xfd/prod: userspace logging: minor fixes

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -399,7 +399,7 @@ Twinkle.prod.callbacks = {
 			}
 			logText += ' ~~~~~\n';
 			if (!params.blp && params.reason) {
-				logText += "#* '''Reason''': " + params.reason + '\n';
+				logText += "#* '''Reason''': " + Morebits.string.formatReasonForLog(params.reason) + '\n';
 			}
 			summaryText = 'Logging PROD nomination of [[:' + Morebits.pageNameNorm + ']].';
 		}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -808,7 +808,7 @@ Twinkle.xfd.callbacks = {
 			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 			(Morebits.userIsSysop ? '\n\nThis log does not track XfD-related deletions made using Twinkle.' : '');
 
-		var editsummary = 'Logging ' + params.venue + ' nomination of [[:' + Morebits.pageNameNorm + ']].';
+		var editsummary = 'Logging ' + toTLACase(params.venue) + ' nomination of [[:' + Morebits.pageNameNorm + ']].';
 		// Provide Wikipedian TLA style: AfD, RfD, CfDS, RM, SfD, etc.
 		var toTLACase = function(str) {
 			// return str.toString().toUpperCase().replace(/\BF/, 'f');

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -885,7 +885,7 @@ Twinkle.xfd.callbacks = {
 		}
 		appendText += ' ~~~~~';
 		if (params.reason) {
-			appendText += "\n#* '''Reason''': " + params.reason;
+			appendText += "\n#* '''Reason''': " + Morebits.string.formatReasonForLog(params.reason);
 		}
 
 		usl.changeTags = Twinkle.changeTags;

--- a/morebits.js
+++ b/morebits.js
@@ -1132,6 +1132,20 @@ Morebits.string = {
 	},
 
 	/**
+	 * Formats a "reason" (from a textarea) for inclusion in a userspace log
+	 * @param {string} str
+	 * @returns {string}
+	 */
+	formatReasonForLog: function(str) {
+		return str
+			// handle line breaks, which otherwise break numbering
+			.replace(/\n+/g, '{{pb}}')
+			// put an extra # in front before bulleted or numbered list items
+			.replace(/^(#+)/mg, '#$1')
+			.replace(/^(\*+)/mg, '#$1');
+	},
+
+	/**
 	 * Like `String.prototype.replace()`, but escapes any dollar signs in the replacement string.
 	 * Useful when the the replacement string is arbitrary, such as a username or freeform user input,
 	 * and could contain dollar signs.


### PR DESCRIPTION
Fixes to userspace logging: 

Commit 1: use TLACase in edit summary 

Commit 2: handle lists in reason. 

Numbered or bulleted lists in the reason mangles the formatting of the log and breaks numbering. This can be prevented by including an extra leading # before the hashes or bullets. See for example [this fix](https://en.wikipedia.org/w/index.php?title=User:AleatoryPonderings/XfD_log&diff=prev&oldid=974659849).

Created Morebits.string.formatReasonForLog() to hold the code, as discussed before in #1092. 

