### PR TITLE
speedy: Obey watchSpeedyPages pref when deleting

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1331,6 +1331,7 @@ Twinkle.speedy.callbacks = {
 			var deleteMain = function(callback) {
 				thispage.setEditSummary(reason);
 				thispage.setChangeTags(Twinkle.changeTags);
+				thispage.setWatchlist(params.watch);
 				thispage.deletePage(function() {
 					thispage.getStatusElement().info('done');
 					typeof callback === 'function' && callback();


### PR DESCRIPTION
This stems from over four years ago to #300 (26d974ce0) when the ability to delete under multiple rationales was to mirror tagging.  That being said, the user-facing description only mentioned tagging after 13ebf0e1 (part of (but unrelated to) #563).  Closes #1113.