### PR TITLE
morebits: remove quickForm.element.autoNWSW, unused

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -700,10 +700,6 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 	return [ node, childContainder ];
 };
 
-Morebits.quickForm.element.autoNWSW = function() {
-	return $(this).offset().top > ($(document).scrollTop() + ($(window).height() / 2)) ? 'sw' : 'nw';
-};
-
 /**
  * Create a jquery.ui-based tooltip.
  * @requires jquery.ui


### PR DESCRIPTION
Was only used for the tipsy tooltips, removed in cefc232f / #971; unused elsewhere.

----

I don't see a need to adapt this function for the new ui-based tooltips?