### PR TITLE
Don't follow user talk page redirects when issuing block templates.

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1559,7 +1559,6 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 
 	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setCallbackParameters(params);
-	wikipedia_page.setFollowRedirect(false);
 	wikipedia_page.load(Twinkle.block.callback.main);
 };
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1559,7 +1559,7 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 
 	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setCallbackParameters(params);
-	wikipedia_page.setFollowRedirect(true, false);
+	wikipedia_page.setFollowRedirect(false);
 	wikipedia_page.load(Twinkle.block.callback.main);
 };
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1285,7 +1285,6 @@ Twinkle.speedy.callbacks = {
 			usertalkpage.setEditSummary(editsummary);
 			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
-			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {


### PR DESCRIPTION
This patch fixes security/harassment issue #912 by preventing following of redirects when issuing a block.