### PR TITLE
morebits: stabilize api properly uses watchlist parameter

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3773,12 +3773,9 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			protectlevel: ctx.flaggedRevs.level,
 			expiry: ctx.flaggedRevs.expiry,
 			// tags: ctx.changeTags, // flaggedrevs tag support: [[phab:T247721]]
-			reason: ctx.editSummary
+			reason: ctx.editSummary,
+			watchlist: ctx.watchlistOption
 		};
-		// [[phab:T247915]]
-		if (ctx.watchlistOption === 'watch') {
-			query.watchlist = 'true';
-		}
 
 		ctx.stabilizeProcessApi = new Morebits.wiki.api('configuring stabilization settings...', query, ctx.onStabilizeSuccess, ctx.statusElement, ctx.onStabilizeFailure);
 		ctx.stabilizeProcessApi.setParent(this);


### PR DESCRIPTION
As of 1.36-wmf.8, see [[phab:T247915]] and #888 / 0849fad8