### PR TITLE
talkback: Add more noticeboards and remove adminNoticeHeading preference

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -292,8 +292,7 @@ Twinkle.talkback.changeTarget = function(e) {
 Twinkle.talkback.noticeboards = {
 	'an': {
 		label: "WP:AN (Administrators' noticeboard)",
-		text: '== ' + Twinkle.getPref('adminNoticeHeading') + ' ==\n' +
-		"{{subst:ANI-notice|thread=$SECTION|noticeboard=Wikipedia:Administrators' noticeboard}} ~~~~",
+		text: '{{subst:AN-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Administrators\' noticeboard]]'
 	},
 	'an3': {
@@ -303,8 +302,8 @@ Twinkle.talkback.noticeboards = {
 	},
 	'ani': {
 		label: "WP:ANI (Administrators' noticeboard/Incidents)",
-		text: '== ' + Twinkle.getPref('adminNoticeHeading') + ' ==\n' +
-		"{{subst:ANI-notice|thread=$SECTION|noticeboard=Wikipedia:Administrators' noticeboard/Incidents}} ~~~~",
+		text: "== Notice of Administrators' noticeboard/Incidents discussion ==\n" +
+		'{{subst:ANI-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Administrators\' noticeboard/Incidents]]',
 		defaultSelected: true
 	},

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -314,6 +314,11 @@ Twinkle.talkback.noticeboards = {
 		text: '{{subst:AFCHD/u|$SECTION}} ~~~~',
 		editSummary: 'You have replies at the [[Wikipedia:AFCHD|Articles for Creation Help Desk]]'
 	},
+	'blpn': {
+		label: 'WP:BLPN (Biographies of living persons noticeboard)',
+		text: '{{subst:BLPN-notice|thread=$SECTION}} ~~~~',
+		editSummary: 'Notice of discussion at [[Wikipedia:Biographies of living persons noticeboard]]'
+	},
 	'coin': {
 		label: 'WP:COIN (Conflict of interest noticeboard)',
 		text: '{{subst:Coin-notice|thread=$SECTION}} ~~~~',
@@ -329,10 +334,35 @@ Twinkle.talkback.noticeboards = {
 		text: '{{EFFPReply|1=$SECTION|2=~~~~}}',
 		editSummary: 'You have replies to your [[Wikipedia:Edit filter/False positives/Reports|edit filter false positive report]]'
 	},
+	'eln': {
+		label: 'WP:ELN (External links noticeboard)',
+		text: '{{subst:ELN-notice|thread=$SECTION}} ~~~~',
+		editSummary: 'Notice of discussion at [[Wikipedia:External links/noticeboard]]'
+	},
+	'ftn': {
+		label: 'WP:FTN (Fringe theories noticeboard)',
+		text: '{{subst:Ftn-notice|thread=$SECTION}} ~~~~',
+		editSummary: 'Notice of discussion at [[Wikipedia:Fringe theories/Noticeboard]]'
+	},
 	'hd': {
 		label: 'WP:HD (Help desk)',
 		text: '== Your question at the Help desk ==\n' + '{{helpdeskreply|1=$SECTION|ts=~~~~~}}',
 		editSummary: 'You have replies at the [[Wikipedia:Help desk|Wikipedia help desk]]'
+	},
+	'norn': {
+		label: 'WP:NORN (Reliable sources noticeboard)',
+		text: '{{subst:Norn-notice|thread=$SECTION}} ~~~~',
+		editSummary: 'Notice of discussion at [[Wikipedia:Reliable sources/Noticeboard]]'
+	},
+	'npovn': {
+		label: 'WP:NPOVN (Neutral point of view noticeboard)',
+		text: '{{subst:NPOVN-notice|thread=$SECTION}} ~~~~',
+		editSummary: 'Notice of discussion at [[Wikipedia:Neutral point of view/noticeboard]]'
+	},
+	'rsn': {
+		label: 'WP:RSN (Reliable sources noticeboard)',
+		text: '{{subst:RSN-notice|thread=$SECTION}} ~~~~',
+		editSummary: 'Notice of discussion at [[Wikipedia:Reliable sources/noticeboard]]'
 	},
 	'th': {
 		label: 'WP:THQ (Teahouse question forum)',

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -616,12 +616,6 @@ Twinkle.config.sections = [
 				type: 'string'
 			},
 			{
-				name: 'adminNoticeHeading',
-				label: "Section heading to use for administrators' noticeboard notices",
-				helptip: 'Only relevant for AN and ANI.',
-				type: 'string'
-			},
-			{
 				name: 'mailHeading',
 				label: "Section heading to use for \"you've got mail\" notices",
 				type: 'string'

--- a/twinkle.js
+++ b/twinkle.js
@@ -164,7 +164,6 @@ Twinkle.defaultConfig = {
 	markTalkbackAsMinor: true,
 	insertTalkbackSignature: true,  // always sign talkback templates
 	talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
-	adminNoticeHeading: 'Notice',
 	mailHeading: "You've got mail!",
 
 	// Shared


### PR DESCRIPTION
1: Add BLPN, ELN, FTN, NORN, NPOVN, RSN

2: Remove `adminNoticeHeading`.  It's only used by ANI and AN, but since {{AN-notice}} has a built-in header (as with nearly every other noticeboard notice), we've been using {{ANI-notice}} for AN.  This just hardcodes a relevant header in for ANI, and removes the preference entirely.

cc @siddharthvp