### PR TITLE
tag: Offer separate watchlist options for different tagging venues

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1270,7 +1270,9 @@ Twinkle.tag.callbacks = {
 
 			pageobj.setPageText(pageText);
 			pageobj.setEditSummary(summaryText);
-			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+			if ((mw.config.get('wgNamespaceNumber') === 0 && Twinkle.getPref('watchTaggedVenues').indexOf('articles') !== -1) || (mw.config.get('wgNamespaceNumber') === 118 && Twinkle.getPref('watchTaggedVenues').indexOf('drafts') !== -1)) {
+				pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+			}
 			pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 			pageobj.setCreateOption('nocreate');
 			pageobj.save(function() {
@@ -1738,7 +1740,9 @@ Twinkle.tag.callbacks = {
 
 		pageobj.setPageText(pageText);
 		pageobj.setEditSummary(summaryText);
-		pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+		if (Twinkle.getPref('watchTaggedPages').indexOf('redirects') !== -1) {
+			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+		}
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 		pageobj.setCreateOption('nocreate');
 		pageobj.save();
@@ -1845,7 +1849,9 @@ Twinkle.tag.callbacks = {
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summary.substring(0, summary.length - 2));
 		pageobj.setChangeTags(Twinkle.changeTags);
-		pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+		if (Twinkle.getPref('watchTaggedPages').indexOf('files') !== -1) {
+			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+		}
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 		pageobj.setCreateOption('nocreate');
 		pageobj.save();

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -583,8 +583,14 @@ Twinkle.config.sections = [
 		module: 'tag',
 		preferences: [
 			{
+				name: 'watchTaggedVenues',
+				label: 'Add page to watchlist when tagging these type of pages',
+				type: 'set',
+				setValues: { articles: 'Articles', drafts: 'Drafts', redirects: 'Redirects', files: 'Files' }
+			},
+			{
 				name: 'watchTaggedPages',
-				label: 'Add page to watchlist when tagging',
+				label: 'When tagging a page, how long to watch it for',
 				type: 'enum',
 				enumValues: Twinkle.config.watchlistEnums
 			},

--- a/twinkle.js
+++ b/twinkle.js
@@ -142,6 +142,7 @@ Twinkle.defaultConfig = {
 	// Formerly defaultConfig.friendly:
 	// Tag
 	groupByDefault: true,
+	watchTaggedVenues: ['articles', 'drafts', 'redirects', 'files'],
 	watchTaggedPages: 'yes',
 	watchMergeDiscussions: 'yes',
 	markTaggedPagesAsMinor: false,


### PR DESCRIPTION
Update:

Add `watchTaggedVenues` as a setValues option, similar to xfd and csd options.  Makes the most sense given parallelisms there and conversion as part of #1090.

----

There is an [on-wiki request](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#A_separate_preference_to_toggle_adding_redirects_to_watchlist_after_tagging) for this; I think it's reasonable but would welcome other input.

<s>There are two commits because I whipped it up two ways.

- The first simply adds `watchTaggedRedirects` and `watchTaggedFiles` alongside `watchTaggedPages`, and uses those for redirect and file tagging.
- The second changes the preference from a boolean to a setValue, allowing the user to select the specific modes/venues for which they want to use the watchlist, with the options being articles, drafts, redirects, and files.

If it's to happen, I prefer the second option, but with #1090 would add some extra complication to the tag module #1090 à la xfd and speedy.

----

If #1090 does indeed come to pass, this needs to modified as such:

- Option 1: Change booleans to enum (easy, handler built-in to #1090 if this were merged beforehand)
- Option 2: Add separate expiry pref (similar to what's done in #1090) to select expiry

Thinking about it that way, I suppose it comes down to which is better:

- Option 1: Three prefs, separate watchlist/expiry for venues ([articles&drafts, redirects, files])
- Option 2: Two prefs, same watchlist/expiry for all venues</s>