### PR TITLE
config: Fix jump-to-section behavior

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1227,8 +1227,10 @@ Twinkle.config.init = function twinkleconfigInit() {
 		contentform.appendChild(footerbox);
 
 		// since all the section headers exist now, we can try going to the requested anchor
-		if (location.hash) {
-			window.location.hash = location.hash;
+		if (window.location.hash) {
+			var loc = window.location.hash;
+			window.location.hash = '';
+			window.location.hash = loc;
 		}
 
 	} else if (mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').user &&


### PR DESCRIPTION
Added in 46cd08038, but won't jump if there's no change, so pass a null value first.  See also #1131.

----

Feel like there must be a better way of doing this, but this works and I don't see any false jumping?