### PR TITLE
morebits: Fix bug in getting new token

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1852,7 +1852,7 @@ Morebits.wiki.api.prototype = {
 			return Morebits.wiki.api.getToken().then(function(token) {
 				this.query.token = token;
 				return this.post(callerAjaxParameters);
-			});
+			}.bind(this));
 		}
 
 		this.statelem.error(this.errorText + ' (' + this.errorCode + ')');


### PR DESCRIPTION
Stems from af13dcede/#1038.  Looks like, since `Morebits.wiki.api.getToken` explicitly creates a new construct, `this` in `returnError`'s return ends up going global (`window`).

[Reported at WT:TW](https://en.wikipedia.org/w/index.php?oldid=982033312#%22Getting_token%22_and_what?)