### PR TITLE
xfd: Fix AfD bug attempting to triage wrong page

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1055,7 +1055,7 @@ Twinkle.xfd.callbacks = {
 				}
 				// Mark the page as curated/patrolled, if wanted
 				if (Twinkle.getPref('markXfdPagesAsPatrolled')) {
-					pageobj.triage();
+					new Morebits.wiki.page(Morebits.pageNameNorm).triage();
 				}
 			});
 		},


### PR DESCRIPTION
Since #1093 (7a450cb56), in an attempt to avoid pointless errors leading to *actual* errors, I moved the `pageobj.triage()` call to after the `Twinkle.xfd.currentRationale = null` limits such errors.  This, however, meant that since then, AfD nominations were always trying to triage the *nomination* page, not the *nominated* page.  This fixes that, although like #1093, in a somewhat kludgy way; anywhere else and we risk the page nomination resolving first (#1036).  Increasingly thinking the original version of #930 would be the cleaner way to handle this.