### PR TITLE
xfd: tfd: auto-select type=inline for inline templates

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -450,7 +450,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				] : [
 					{ type: 'option', value: 'standard', label: 'Standard', selected: true },
 					{ type: 'option', value: 'sidebar', label: 'Sidebar/infobox', selected: $('.infobox').length },
-					{ type: 'option', value: 'inline', label: 'Inline template' },
+					{ type: 'option', value: 'inline', label: 'Inline template', selected: $('.mw-parser-output > p .Inline-Template').length },
 					{ type: 'option', value: 'tiny', label: 'Tiny inline' }
 				]
 			});


### PR DESCRIPTION
Inline tag templates (eg. Template:Dead link, Template:More citations needed) use the class "Inline-Template". The selector `.mw-parser-output > p .Inline-Template` ensures that any inline tags used in the template documentation aren't considered.