### PR TITLE
morebits: Fix bug inverting whether we need to query protection status

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3019,7 +3019,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		// do we need to fetch the edit protection expiry?
 		if (Morebits.userIsSysop && !ctx.suppressProtectWarning) {
-			if (new mw.Title(Morebits.pageNameNorm).getPrefixedText() === new mw.Title(ctx.pageName).getPrefixedText()) {
+			if (new mw.Title(Morebits.pageNameNorm).getPrefixedText() !== new mw.Title(ctx.pageName).getPrefixedText()) {
 				return false;
 			}
 


### PR DESCRIPTION
Stems from #917, specifically 7a413f482 with a [blind copy](https://github.com/azatoth/twinkle/pull/917#discussion_r411278366).  We need to query if we're not on the page in question