### PR TITLE
morebits: swallow fake triage success

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3487,9 +3487,17 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		var triageStat = new Morebits.status('Marking page as curated');
 
-		ctx.triageProcessApi = new Morebits.wiki.api('curating page...', query, null, triageStat, fnProcessTriageError);
+		ctx.triageProcessApi = new Morebits.wiki.api('curating page...', query, fnProcessTriageSuccess, triageStat, fnProcessTriageError);
 		ctx.triageProcessApi.setParent(this);
 		ctx.triageProcessApi.post();
+	};
+
+	// callback from triageProcessApi.post()
+	var fnProcessTriageSuccess = function() {
+		// Swallow succesful return if nothing changed i.e. page in queue and already triaged
+		if ($(ctx.triageProcessApi.getResponse()).find('pagetriageaction').attr('pagetriage_unchanged_status')) {
+			ctx.triageProcessApi.getStatusElement().unlink();
+		}
 	};
 
 	// callback from triageProcessApi.post()


### PR DESCRIPTION
If the page is in the queue but is already triaged, there'll be a false success.

Real pain, this action is, increasinly seemingly like the more involved #930 would be cleaner.