### PR TITLE
Lint via GitHub actions rather than travis-ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Linter
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Lint
+      run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js: "node"
-cache:
-  directories:
-    - "node_modules"
-script:
-  - npm run lint

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twinkle [![Build Status](https://travis-ci.org/azatoth/twinkle.svg?branch=master)](https://travis-ci.org/azatoth/twinkle)
+# Twinkle ![Linter](https://github.com/azatoth/twinkle/workflows/Linter/badge.svg)
 
 Twinkle is a JavaScript application that gives Wikipedians a quick way of performing common maintenance tasks, such as nominating pages for deletion and cleaning up vandalism.
 


### PR DESCRIPTION
Travis is [still running requests](https://travis-ci.org/azatoth/twinkle/requests), but the connection to the GitHub web interface recently stopped.  It's not a bad excuse to <s>play around with</s> move to GitHub's actions!  I've been thinking about doing so for a while, so why not now?  (ping @MusikAnimal )

If so, @azatoth I think you'll need to enable some options at https://github.com/azatoth/twinkle/settings/actions

If not, I think you'll have to reauthorize the connection; this is one of those things that only the repository owner can do, since this isn't [an organization](https://github.com/azatoth/twinkle/issues/1140#issuecomment-703013774).