### PR TITLE
fluff: Fix bug in identifying revid

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -500,7 +500,7 @@ Twinkle.fluff.callbacks = {
 					// Okay to test on user since it will either fail or sysop will correctly access it
 					// Besides, none of the trusted bots are going to be revdel'd
 					Twinkle.fluff.trustedBots.indexOf(top.getAttribute('user')) !== -1 && revs.length > 1 &&
-					revs[1].getAttribute('pageId') === params.revid) {
+					revs[1].getAttribute('revid') === params.revid) {
 				Morebits.status.info('Info', [ 'Latest revision was made by ', Morebits.htmlNode('strong', lastuser), ', a trusted bot, and the revision before was made by our vandal, so we will proceed with the revert.' ]);
 				index = 2;
 			} else {


### PR DESCRIPTION
This has been comparing a revid against a revision's `pageId` for over a decade, but `pageId` isn't part of a revision (or anything) and `pageid` would be the wrong thing to compare anyway!  I *think* it's possible there was a `pageId` parameter being returned back in the day, but there certainly isn't now.