### PR TITLE
Various fixes around cascading protection

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3698,7 +3698,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 		// fetch existing protection levels
 		var prs = $(xml).find('pr');
-		var editprot = prs.filter('[type="edit"]');
+		var editprot = prs.filter('[type="edit"]:not([source])');
 		var moveprot = prs.filter('[type="move"]');
 		var createprot = prs.filter('[type="create"]');
 


### PR DESCRIPTION
These are all incredibly minor.  tl;dr: 

- Morebits: fixes an inconsequential bug, properly detect existing cascading protection, prompt for confirmation if not `sysop` level
- protect: More accurate description of cascading protection

----

1: morebits: Don't overwrite unprovided edit protection with cascading

If someone tried to set just move protection on an unprotected page that was covered by cascading protection, we were picking up that cascading protection and pushing it into the query.  This could lead to some weird results - oddly mismatched edit/move protection, the highest protection level when none was intended - but of course it has literally never mattered since the page was covered by cascading protection anyway.  It *could* theoretically matter if cascading protection was removed down the line, but at any rate, we might as well be correct.

2: morebits: Properly detect and process existing cascading protection

Cascading protection status now properly fallsback to any previously existing protection; previously, Morebits would default to disable already-existing cascading protection unless explicitly turned on (via `setCascadingProtection`).  That's not particularly helpful or intuitive, and it's in contrast to how we handle protection levels in general.  I've also added a check in case cascading is enabled but the underlying protection options don't match (aka not `edit=sysop|move=sysop`); the API will let any move protection level pass through, but the page will indeed end-up cascade protected ([[phab:T265626]]).  As part of all this, `ctx.protectCascade` now defaults to `null`, like nearly everything else, rather than `false`, which allows us to detect when the value has been explicitly disabled by the user.

3: protect: Better note presence of cascading protections.

Adds a note if a page is covered by cascading protection (rather than is the source), and made the fact that a page is providing cascading protetion (is the source of cascading protection) more prominent.

Also removed catch for AFT protection, removed everywhere ~6 years ago.