### PR TITLE
batchprotect: Fix bug in setting defaults

### DIFF
--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -233,9 +233,9 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		Window.setContent(result);
 
 		// Set defaults
-		form.editexpiry.value = '2 days';
-		form.moveexpiry.value = '2 days';
-		form.createexpiry.value = 'indefinite';
+		result.editexpiry.value = '2 days';
+		result.moveexpiry.value = '2 days';
+		result.createexpiry.value = 'infinity';
 
 
 	}, statelem);


### PR DESCRIPTION
From #1074 (35ee0a6fe): turns out `result` isn't the same as `form`, and `infinity` isn't `indefinite`.  Was only affecting the initial menu selections.