### PR TITLE
tag: Add an input for redirect page name for R avoided double redirect

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1680,9 +1680,8 @@ Twinkle.tag.callbacks = {
 				if (params.altLangTo) {
 					tagText += '|to=' + params.altLangTo;
 				}
-				if (params.doubleRedirectTarget) {
-					tagText += '|1=' + params.doubleRedirectTarget;
-				}
+			} else if (tagName === 'R avoided double redirect' && params.doubleRedirectTarget) {
+				tagText += '|1=' + params.doubleRedirectTarget;
 			}
 			tagText += '}}';
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -921,7 +921,7 @@ Twinkle.tag.redirectList = {
 				subgroup: {
 					name: 'doubleRedirectTarget',
 					type: 'input',
-					label: 'Redirect page name',
+					label: 'Redirect target name',
 					tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
 				}
 			},

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -918,14 +918,12 @@ Twinkle.tag.redirectList = {
 			{ 
 				tag: 'R avoided double redirect',
 				description: 'redirect from an alternative title for another redirect',
-				subgroup: [
-					{
-						name: 'doubleRedirectTarget',
-						type: 'input',
-						label: 'Redirect page name',
-						tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
-					}
-				]
+				subgroup: {
+					name: 'doubleRedirectTarget',
+					type: 'input',
+					label: 'Redirect page name',
+					tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
+				}
 			},
 			{ tag: 'R from file metadata link', description: 'redirect of a wikilink created from EXIF, XMP, or other information (i.e. the "metadata" section on some image description pages)' },
 			{ tag: 'R to list entry', description: 'redirect to a list which contains brief descriptions of subjects not notable enough to have separate articles' },

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -915,7 +915,18 @@ Twinkle.tag.redirectList = {
 	'Navigation aids': {
 		'Navigation': [
 			{ tag: 'R to anchor', description: 'redirect from a topic that does not have its own page to an anchored part of a page on the subject' },
-			{ tag: 'R avoided double redirect', description: 'redirect from an alternative title for another redirect' },
+			{ 
+				tag: 'R avoided double redirect',
+				description: 'redirect from an alternative title for another redirect',
+				subgroup: [
+					{
+						name: 'doubleRedirectTarget',
+						type: 'input',
+						label: 'Redirect page name',
+						tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
+					}
+				]
+			},
 			{ tag: 'R from file metadata link', description: 'redirect of a wikilink created from EXIF, XMP, or other information (i.e. the "metadata" section on some image description pages)' },
 			{ tag: 'R to list entry', description: 'redirect to a list which contains brief descriptions of subjects not notable enough to have separate articles' },
 
@@ -1670,6 +1681,9 @@ Twinkle.tag.callbacks = {
 				}
 				if (params.altLangTo) {
 					tagText += '|to=' + params.altLangTo;
+				}
+				if (params.doubleRedirectTarget) {
+					tagText += '|1=' + params.doubleRedirectTarget;
 				}
 			}
 			tagText += '}}';


### PR DESCRIPTION
Added an input to allow the user to enter the redirect page name for the R avoided double redirect template.