### PR TITLE
tag: fix bugs in processing of existing tags

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1559,7 +1559,8 @@ Twinkle.tag.callbacks = {
 
 		// To-be-retained existing tags that are groupable
 		params.tagsToRemain.forEach(function(tag) {
-			if (!Twinkle.tag.article.flatObject[tag].excludeMI) {
+			// If the tag is unknown to us, we consider it non-groupable
+			if (Twinkle.tag.article.flatObject[tag] && !Twinkle.tag.article.flatObject[tag].excludeMI) {
 				groupableExistingTags.push(tag);
 			}
 		});

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -259,13 +259,15 @@ Twinkle.tag.callback = function friendlytagCallback() {
 				if (e.className.indexOf('box-') === 0) {
 					if (e.classList[0] === 'box-Multiple_issues') {
 						$(e).find('.ambox').each(function(idx, e) {
-							var tag = e.classList[0].slice(4).replace(/_/g, ' ');
-							Twinkle.tag.alreadyPresentTags.push(tag);
+							if (e.classList[0].indexOf('box-') === 0) {
+								var tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
+								Twinkle.tag.alreadyPresentTags.push(tag);
+							}
 						});
 						return true; // continue
 					}
 
-					var tag = e.classList[0].slice(4).replace(/_/g, ' ');
+					var tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
 					Twinkle.tag.alreadyPresentTags.push(tag);
 				}
 			});


### PR DESCRIPTION
1: For tags within {{multiple issues}}, check if the class name begins with "box-", don't just assume that it does.

2: For tags already present on the page (and not unchecked for removal), `Twinkle.tag.article.flatObject[tag]` would be undefined, and when we do `Twinkle.tag.article.flatObject[tag].excludeMI`, the result is `*_*`