### PR TITLE
block: Don't add expiry to template if it's a date, not a duration

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1752,7 +1752,8 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 		if (!/te?mp|^\s*$|min/.exec(params.expiry)) {
 			if (params.indefinite) {
 				text += '|indef=yes';
-			} else if (!params.blank_duration) {
+			} else if (!params.blank_duration && !new Morebits.date(params.expiry).isValid()) {
+				// Block template wants a duration, not date
 				text += '|time=' + params.expiry;
 			}
 		}


### PR DESCRIPTION
The block templates ask for a duration in the `time` parameter, not a date: someone manually set an actual date as the block expiry, which is acceptable to MediaWiki, the block template would say something like `...blocked from editing for a period of April 1, 1984 13:00`.  This simply excludes the duration if the string is a valid date (thus not a duration).