### PR TITLE
morebits: Use new error formats (default to html) in api; use $.parseHTML in status messages

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4645,6 +4645,7 @@ Morebits.status.onError = function(handler) {
 
 Morebits.status.prototype = {
 	stat: null,
+	statRaw: null,
 	text: null,
 	textRaw: null,
 	type: 'status',
@@ -4669,7 +4670,9 @@ Morebits.status.prototype = {
 	},
 
 	/**
-	 * Create a document fragment with the status text.
+	 * Create a document fragment with the status text, parsing as HTML.
+	 * Runs upon construction for text (part before colon) and upon
+	 * render/update for status (part after colon).
 	 *
 	 * @param {(string|Element|Array)} obj
 	 * @returns {DocumentFragment}
@@ -4681,11 +4684,13 @@ Morebits.status.prototype = {
 		var result;
 		result = document.createDocumentFragment();
 		for (var i = 0; i < obj.length; ++i) {
-			if (typeof obj[i] === 'string') {
-				result.appendChild(document.createTextNode(obj[i]));
-			} else if (obj[i] instanceof Element) {
+			if (obj[i] instanceof Element) {
 				result.appendChild(obj[i]);
-			} // Else cosmic radiation made something shit
+			} else {
+				$.parseHTML(obj[i]).forEach(function(elem) {
+					result.appendChild(elem);
+				});
+			}
 		}
 		return result;
 
@@ -4699,6 +4704,7 @@ Morebits.status.prototype = {
 	 * (red), or 'error' (bold red). FIXME TODO possible options
 	 */
 	update: function(status, type) {
+		this.statRaw = status;
 		this.stat = this.codify(status);
 		if (type) {
 			this.type = type;
@@ -4712,7 +4718,7 @@ Morebits.status.prototype = {
 				}
 
 				// also log error messages in the browser console
-				console.error(this.textRaw + ': ' + status); // eslint-disable-line no-console
+				console.error(this.textRaw + ': ' + this.statRaw); // eslint-disable-line no-console
 			}
 		}
 		this.render();

--- a/morebits.js
+++ b/morebits.js
@@ -1960,6 +1960,16 @@ Morebits.wiki.api = function(currentAction, query, onSuccess, statusElement, onE
 	this.currentAction = currentAction;
 	this.query = query;
 	this.query.assert = 'user';
+	// Enforce newer error formats, preferring html
+	if (!query.errorformat || ['wikitext', 'plaintext'].indexOf(query.errorformat) === -1) {
+		this.query.errorformat = 'html';
+	}
+	// Explicitly use the wiki's content language to minimize confusion,
+	// see #1179 for discussion
+	this.query.uselang = 'content';
+	this.query.errorlang = 'uselang';
+	this.query.errorsuselocal = 1;
+
 	this.onSuccess = onSuccess;
 	this.onError = onError;
 	if (statusElement) {
@@ -2048,12 +2058,18 @@ Morebits.wiki.api.prototype = {
 			function onAPIsuccess(response, statusText) {
 				this.statusText = statusText;
 				this.response = this.responseXML = response;
+				// Limit to first error
 				if (this.query.format === 'json') {
-					this.errorCode = response.error && response.error.code;
-					this.errorText = response.error && response.error.info;
+					this.errorCode = response.errors && response.errors[0].code;
+					if (this.query.errorformat === 'html') {
+						this.errorText = response.errors && response.errors[0].html;
+					} else if (this.query.errorformat === 'wikitext' || this.query.errorformat === 'plaintext') {
+						this.errorText = response.errors && response.errors[0].text;
+					}
 				} else {
-					this.errorCode = $(response).find('error').attr('code');
-					this.errorText = $(response).find('error').attr('info');
+					this.errorCode = $(response).find('errors error').eq(0).attr('code');
+					// Sufficient for html, wikitext, or plaintext errorformats
+					this.errorText = $(response).find('errors error').eq(0).text();
 				}
 
 				if (typeof this.errorCode === 'string') {

--- a/tests/mocking/mb_repl_head.js
+++ b/tests/mocking/mb_repl_head.js
@@ -9,6 +9,7 @@ global.window = new JSDOM('', { pretendToBeVisual: true }).window;
 global.document = window.document;
 
 global.HTMLFormElement = window.HTMLFormElement;
+global.Element = window.Element;
 
 global.jQuery = require('jquery');
 


### PR DESCRIPTION
2nd commit uses/enforces the [newer API error messages](mediawiki.org/wiki/API:Errors_and_warnings) in `Morebits.wiki.api`, defaulting to `html`, but allowing `plaintext` and `wikitext`; `raw`, `none`, and the legacy `bc` will be converted to `html`.  Provides `errorlang: mw.config.get('wgUserLanguage')`.  Errors are limited to the first found, which was the case with the old syntax and is assumed by our uses of `errorCode`/`errorText`, but maybe something to refactor at some point (not a huge gain IMO).

The 1st commit enables the html showing up nicely, by using `$.parseHTML` in `Morebits.status.codify()`.  There's a whole long commit message, but the tl;dr is: it will now automatically parse html, not wikitext; and there's now a `statRaw` for error logging.