### PR TITLE
Detect RfD nomination in Morebits.wiki.isPageRedirect, use in CSD

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -281,7 +281,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		work_area.append({ type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.talkList, mode) });
 	}
 
-	if (!mw.config.get('wgIsRedirect')) {
+	if (!Morebits.wiki.isPageRedirect()) {
 		switch (namespace) {
 			case 0:  // article
 			case 1:  // talk
@@ -453,7 +453,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 			}
 		}
 
-		if (mw.config.get('wgIsRedirect') && criterion.hideWhenRedirect) {
+		if (Morebits.wiki.isPageRedirect() && criterion.hideWhenRedirect) {
 			return null;
 		}
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -146,7 +146,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	categories.append({
 		type: 'option',
 		label: 'RfD (Redirects for discussion)',
-		selected: Morebits.wiki.isPageRedirect(),
+		selected: mw.config.get('wgIsRedirect'),
 		value: 'rfd'
 	});
 	categories.append({
@@ -1749,7 +1749,7 @@ Twinkle.xfd.callbacks = {
 				if (!apiobj.params.rfdtarget) { // Not a softredirect
 					var target = $xmlDoc.find('redirects r').first().attr('to');
 					if (!target) {
-						var message = 'This page does not appear to be a redirect, aborting';
+						var message = 'No target found. this page does not appear to be a redirect, aborting';
 						if (mw.config.get('wgAction') === 'history') {
 							message += '. If this is a soft redirect, try again from the content page, not the page history.';
 						}

--- a/morebits.js
+++ b/morebits.js
@@ -1639,10 +1639,11 @@ Morebits.wiki = {};
 /**
  * Determines whether the current page is a redirect or soft redirect
  * (fails to detect soft redirects on edit, history, etc. pages)
+ * Will attempt to detect Module:RfD, with the same failure points
  * @returns {boolean}
  */
 Morebits.wiki.isPageRedirect = function wikipediaIsPageRedirect() {
-	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect'));
+	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-RfD').length);
 };
 
 


### PR DESCRIPTION
It's been long desired to show the redirect CSDs on redirects nominated at RfD.  This adds detection of that box to `Morebits.wiki.isPageRedirect` and uses it in twinklespeedy.  Should also improve things elsewhere that it's used, in particular redirect tagging in the tag module.  XfD will have problems with it, namely finding the redirect target for RfD.

----

As noted in https://github.com/azatoth/twinkle/issues/1065#issuecomment-720045907, this will only work when `view`ing the page.  If we wanted to include editing, we'd have to use the page content, doing something like `document.getElementById('wpTextbox1').value.indexOf('#invoke:RfD') !== -1` or `/#redirect/i.test(document.getElementById('wpTextbox1').value)` or something.