### PR TITLE
block/protect: Align current/log displays, show expiry/timestamp of last action

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -139,6 +139,7 @@ Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
 			}
 
 			Twinkle.block.hasBlockLog = !!data.query.logevents.length;
+			Twinkle.block.blockLog = Twinkle.block.hasBlockLog && data.query.logevents;
 			// Used later to check if block status changed while filling out the form
 			Twinkle.block.blockLogId = Twinkle.block.hasBlockLog ? data.query.logevents[0].logid : false;
 
@@ -604,7 +605,15 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	}
 
 	if (Twinkle.block.hasBlockLog) {
-		var $blockloglink = $('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgRelevantUserName'), type: 'block'}) + '">block log</a>)');
+		var $blockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgRelevantUserName'), type: 'block'}) + '">block log</a>)'));
+		if (!Twinkle.block.currentBlockInfo) {
+			var lastBlockAction = Twinkle.block.blockLog[0];
+			if (lastBlockAction.action === 'unblock') {
+				$blockloglink.append(' (unblocked ' + new Morebits.date(lastBlockAction.timestamp).calendar('utc') + ')');
+			} else { // block or reblock
+				$blockloglink.append(' (expired ' + new Morebits.date(lastBlockAction.params.expiry).calendar('utc') + ')');
+			}
+		}
 
 		Morebits.status.init($('div[name="hasblocklog"] span').last()[0]);
 		Morebits.status.warn(Twinkle.block.currentBlockInfo ? 'Previous blocks' : 'This user has been blocked in the past', $blockloglink[0]);

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -217,8 +217,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		});
 
 		field_block_options = new Morebits.quickForm.element({ type: 'field', label: 'Block options', name: 'field_block_options' });
-		field_block_options.append({ type: 'div', name: 'hasblocklog', label: ' ' });
 		field_block_options.append({ type: 'div', name: 'currentblock', label: ' ' });
+		field_block_options.append({ type: 'div', name: 'hasblocklog', label: ' ' });
 		field_block_options.append({
 			type: 'select',
 			name: 'expiry_preset',
@@ -582,19 +582,11 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		$form.find('fieldset[name="field_template_options"]').hide();
 	}
 
-	if (Twinkle.block.hasBlockLog) {
-		var $blockloglink = $('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgRelevantUserName'), type: 'block'}) + '">block log</a>)');
-
-		Morebits.status.init($('div[name="hasblocklog"] span').last()[0]);
-		Morebits.status.warn('This user has been blocked in the past', $blockloglink[0]);
-	}
-
-
 	if (Twinkle.block.currentBlockInfo) {
 		Morebits.status.init($('div[name="currentblock"] span').last()[0]);
 		var statusStr = relevantUserName + ' is ' + (Twinkle.block.currentBlockInfo.partial === '' ? 'partially blocked' : 'blocked sitewide');
 		if (Twinkle.block.currentBlockInfo.expiry === 'infinity') {
-			statusStr += ' (indef)';
+			statusStr += ' (indefinite)';
 		} else if (new Morebits.date(Twinkle.block.currentBlockInfo.expiry).isValid()) {
 			statusStr += ' (expires ' + new Morebits.date(Twinkle.block.currentBlockInfo.expiry).calendar('utc') + ')';
 		}
@@ -604,10 +596,18 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		} else if (Twinkle.block.currentBlockInfo.partial === '' && !partialBox) {
 			infoStr += ', converting it to a sitewide block';
 		}
+		infoStr += '.';
 		Morebits.status.warn(statusStr, infoStr);
 
 		// Default to the current block conditions on intial form generation
 		Twinkle.block.callback.update_form(e, Twinkle.block.currentBlockInfo);
+	}
+
+	if (Twinkle.block.hasBlockLog) {
+		var $blockloglink = $('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgRelevantUserName'), type: 'block'}) + '">block log</a>)');
+
+		Morebits.status.init($('div[name="hasblocklog"] span').last()[0]);
+		Morebits.status.warn(Twinkle.block.currentBlockInfo ? 'Previous blocks' : 'This user has been blocked in the past', $blockloglink[0]);
 	}
 
 	// Make sure all the fields are correct based on initial defaults

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -282,7 +282,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 			if (settings.expiry === 'infinity') {
 				protectionNode.push(' (indefinite) ');
 			} else {
-				protectionNode.push(' (expires ' + new Date(settings.expiry).toUTCString() + ') ');
+				protectionNode.push(' (expires ' + new Morebits.date(settings.expiry).calendar('utc') + ') ');
 			}
 			if (settings.admin) {
 				var adminLink = '<a target="_blank" href="' + mw.util.getUrl('User talk:' + settings.admin) + '">' + settings.admin + '</a>';


### PR DESCRIPTION
1st commit:
- block: Show block log under current block info, tweak messages
- protect: Use `Morebits.date.calendar` to format expiry

2nd commit: Show timestamp for an unblock or unprotection action, and expiry for a block or protection, but only if the user/page is not currently blocked/protected.  For protection it's not particularly smart about finding the last expiry, it just grabs the first level, which defaults to edit.  That means that if the last action was to adjust the edit protection to expire before move protection expired, this would show the wrong one.

I'm wary of getting too cluttered here.