### PR TITLE
morebits: Rename Morebits.wiki.isPageRedirect to Morebits.isPageRedirect

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -14,7 +14,7 @@
 
 Twinkle.tag = function friendlytag() {
 	// redirect tagging
-	if (Morebits.wiki.isPageRedirect()) {
+	if (Morebits.isPageRedirect()) {
 		Twinkle.tag.mode = 'redirect';
 		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Tag redirect');
 	// file tagging

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -13,7 +13,7 @@
  */
 
 Twinkle.image = function twinkleimage() {
-	if (mw.config.get('wgNamespaceNumber') === 6 && mw.config.get('wgArticleId') && !document.getElementById('mw-sharedupload') && !Morebits.wiki.isPageRedirect()) {
+	if (mw.config.get('wgNamespaceNumber') === 6 && mw.config.get('wgArticleId') && !document.getElementById('mw-sharedupload') && !Morebits.isPageRedirect()) {
 		Twinkle.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
 	}
 };

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -15,7 +15,7 @@
 
 Twinkle.prod = function twinkleprod() {
 	if ((([0, 6, 108].indexOf(mw.config.get('wgNamespaceNumber')) === -1) && (mw.config.get('wgNamespaceNumber') !== 2 || mw.config.get('wgCategories').indexOf('Wikipedia books (user books)') === -1))
-		|| !mw.config.get('wgCurRevisionId') || Morebits.wiki.isPageRedirect()) {
+		|| !mw.config.get('wgCurRevisionId') || Morebits.isPageRedirect()) {
 		return;
 	}
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -281,7 +281,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		work_area.append({ type: radioOrCheckbox, name: 'csd', list: Twinkle.speedy.generateCsdList(Twinkle.speedy.talkList, mode) });
 	}
 
-	if (!Morebits.wiki.isPageRedirect()) {
+	if (!Morebits.isPageRedirect()) {
 		switch (namespace) {
 			case 0:  // article
 			case 1:  // talk
@@ -453,7 +453,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 			}
 		}
 
-		if (Morebits.wiki.isPageRedirect() && criterion.hideWhenRedirect) {
+		if (Morebits.isPageRedirect() && criterion.hideWhenRedirect) {
 			return null;
 		}
 

--- a/morebits.js
+++ b/morebits.js
@@ -1032,10 +1032,10 @@ HTMLFormElement.prototype.getUnchecked = function(name, type) {
  */
 RegExp.escape = function(text, space_fix) {
 	if (space_fix) {
-		console.log('NOTE: RegExp.escape from Morebits was deprecated September 2020, please replace it with Morebits.string.escapeRegExp'); // eslint-disable-line no-console
+		console.warn('NOTE: RegExp.escape from Morebits was deprecated September 2020, please replace it with Morebits.string.escapeRegExp'); // eslint-disable-line no-console
 		return Morebits.string.escapeRegExp(text);
 	}
-	console.log('NOTE: RegExp.escape from Morebits was deprecated September 2020, please replace it with mw.util.escapeRegExp'); // eslint-disable-line no-console
+	console.warn('NOTE: RegExp.escape from Morebits was deprecated September 2020, please replace it with mw.util.escapeRegExp'); // eslint-disable-line no-console
 	return mw.util.escapeRegExp(text);
 };
 
@@ -1302,6 +1302,16 @@ Morebits.select2 = {
 
 };
 
+
+/**
+ * Determines whether the current page is a redirect or soft redirect
+ * (fails to detect soft redirects on edit, history, etc. pages)
+ * Will attempt to detect Module:RfD, with the same failure points
+ * @returns {boolean}
+ */
+Morebits.isPageRedirect = function() {
+	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-RfD').length);
+};
 
 /**
  * **************** Morebits.pageNameNorm ****************
@@ -1640,16 +1650,11 @@ $.extend(Morebits.date.prototype, {
  */
 Morebits.wiki = {};
 
-/**
- * Determines whether the current page is a redirect or soft redirect
- * (fails to detect soft redirects on edit, history, etc. pages)
- * Will attempt to detect Module:RfD, with the same failure points
- * @returns {boolean}
- */
+/** @deprecated in favor of Morebits.isPageRedirect */
 Morebits.wiki.isPageRedirect = function wikipediaIsPageRedirect() {
-	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-RfD').length);
+	console.warn('NOTE: Morebits.wiki.isPageRedirect has been deprecated, use Morebits.isPageRedirect instead.'); // eslint-disable-line no-console
+	return Morebits.isPageRedirect();
 };
-
 
 
 /**


### PR DESCRIPTION
The more I look at it, the more I realize that `Morebits.wiki.isPageRedirect` fits much better with `Morebits.pageNameNorm` and the like.  Inspired by looking at #1182, which isn't a terrible time to change it.  <s>Should wait until that's resolved as this will obviously conflict.</s>