### PR TITLE
morebits: zero-pad date in constructor

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1414,6 +1414,10 @@ Morebits.date = function() {
 		args[0] = args[0].replace(/(\d\d:\d\d),/, '$1').replace(/\(UTC\)/, 'UTC');
 		// Safari is particular about timezone offsets, so this is intentionally specific
 		args[0] = args[0].replace(/(\d\d:\d\d) (\d{1,2}) ([A-Z][a-z]+) (\d{4}) UTC$/, function(match, time, date, monthname, year) {
+			// zero-pad date
+			if (date < 10) {
+				date = '0' + date;
+			}
 			return [year, mw.config.get('wgMonthNames').indexOf(monthname), date].join('-') + 'T' + time + 'Z';
 		});
 	}


### PR DESCRIPTION
The regex added in #1174 would match the date number, but didn't provide the leading zero needed for ISO-8601 formats.  Reported at [WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=987793556#Twinkle_auto-select_user_warning_level_not_working_(Again))