### PR TITLE
Expand and standardize Morebits jsdocs, export to html and markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you believe you have found a security issue, follow the guidelines in [SECURI
 
 If you'd like to help with Twinkle's development, wonderful!  Anyone can contribute, and it's easy to get set up to do so.
 
-First, familiarize yourself with the code; most likely, the changes you want are to one of the [modules](./modules); you can also check out the [individual Gadget pages][twinkle_gadget] onwiki.  If you want to propose changes yourself, [fork the repository](https://help.github.com/articles/fork-a-repo/) to make sure you always have the latest versions.  If you're new to GitHub or Git in general, you probably want to read [Getting started with GitHub](https://help.github.com/en/github/getting-started-with-github) first.
+First, familiarize yourself with the code; most likely, the changes you want are to one of the [modules](./modules); you can also check out the [individual Gadget pages][twinkle_gadget] onwiki.  If the changes are to the [Morebits library](./morebits.js), you can view the full docs at http://azatoth.github.io/twinkle or on the [GitHub Wiki](https://github.com/azatoth/twinkle/wiki/morebits).  If you want to propose changes yourself, [fork the repository](https://help.github.com/articles/fork-a-repo/) to make sure you always have the latest versions.  If you're new to GitHub or Git in general, you probably want to read [Getting started with GitHub](https://help.github.com/en/github/getting-started-with-github) first.
 
 Once you've got a local fork up and running, commit your changes!
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you'd like to start contributing, awesome!  Check out [CONTRIBUTING.md](CONTR
 
 ## Layout of this repository
 
-* `morebits.js`: The central library used by Twinkle and many other scripts. Contains code to interact with the MediaWiki API, display forms and dialogs, generate status logs, and do various other useful things. The vast majority of code in here is not Twinkle-specific.
+* `morebits.js`: The central library used by Twinkle and many other scripts. Contains code to interact with the MediaWiki API, display forms and dialogs, generate status logs, and do various other useful things. The vast majority of code in here is not Twinkle-specific; see docs ([1](https://azatoth.github.io/twinkle/Morebits.html) and [2](https://github.com/azatoth/twinkle/wiki/morebits))
 * `twinkle.js`: General Twinkle-specific code, mostly related to preferences and exposing Twinkle in the UI. Significantly, it contains the default set of preferences of Twinkle.
 * `modules`: Contains the individual Twinkle modules. Descriptions for these can be found in header comments or in the [Twinkle documentation][]. The module `twinkleconfig.js` powers the [Twinkle preferences panel][WP:TWPREFS].
 


### PR DESCRIPTION
Not perfect, but largely completes jsdoc documentation for the library, and does so in an exportable way (see first commit).  I've done that in two ways (2nd commit):

- HTML.  Ideally, the docs directory would be hosted via github pages (@azatoth); I've enabled it from my fork at https://amorymeltzer.github.io/twinkle/ if you want to see it.
- Markdown, via `jsdoc-to-markdown`.  I've already uploaded the results to https://github.com/azatoth/twinkle/wiki/morebits for perusal.

There are advantages to both methods, but I've found both to be helpful.  `npm run ghpages` and `npm run wiki`, or both with `npm run docs` (via `./dev/docs.sh` shim).

Another option is to *not* muddy the main branch with the output files, but host them in a separate, gh-pages branch, akin to the old-school style.

cc @MusikAnimal @siddharthvp 