### PR TITLE
xfd: Adjust portlet tooltip to be more accurate

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -21,7 +21,7 @@ Twinkle.xfd = function twinklexfd() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a deletion discussion');
+	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a discussion');
 };
 
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -21,7 +21,32 @@ Twinkle.xfd = function twinklexfd() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', 'Start a discussion');
+	var tooltip = 'Start a discussion for deleting';
+	if (mw.config.get('wgIsRedirect')) {
+		tooltip += ' or retargeting this redirect';
+	} else {
+		switch (mw.config.get('wgNamespaceNumber')) {
+			case 0:
+				tooltip += ' or moving this article';
+				break;
+			case 10:
+				tooltip += ' or merging this template';
+				break;
+			case 828:
+				tooltip += ' or merging this module';
+				break;
+			case 6:
+				tooltip += ' this file';
+				break;
+			case 14:
+				tooltip += ', merging or renaming this category';
+				break;
+			default:
+				tooltip += ' this page';
+				break;
+		}
+	}
+	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', tooltip);
 };
 
 


### PR DESCRIPTION
This was [briefly discussed on WT:TW](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Move_requests_deeply_hidden), but the portlet tooltip of `Start a deletion discussion` is rarely, if ever, sufficiently accurate, and indeed elides and even hides functionality (namely, RM).  I've put the two ideas up here:

- 1st commit: `Start a discussion`
- 2nd commit: Be more specific for each venue (suggested by @siddharthvp, correct me if I misinterpreted)

I (clearly) favor the former as being simpler and not duplicating checks, but honestly the more detail from the second is probably nicer and likely to be more popular.  It'll be inaccurate if folks choose something else (or in the specific cases of things like userboxes, stubs, etc.) but by the time the module window is open, I don't think *anyone* cares what the tooltip was.