### PR TITLE
xfd: Notify WT:TW/WT:AWB/WT:REDWARN automatically (rework of #1001)

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -495,6 +495,19 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				]
 			});
 
+			work_area.append({
+				type: 'checkbox',
+				list: [
+					{
+						label: 'Notify users of the template',
+						value: 'devpages',
+						name: 'devpages',
+						tooltip: 'A notification template will be sent to Twinkle, AWB, and RedWarn if this is true.',
+						checked: true
+					}
+				]
+			});
+
 			appendReasonBox();
 			work_area = work_area.render();
 			old_area.parentNode.replaceChild(work_area, old_area);
@@ -1334,6 +1347,21 @@ Twinkle.xfd.callbacks = {
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
 			} else {
 				Twinkle.xfd.callbacks.addToLog(params, null);
+			}
+
+			// Notify developer(s) of script(s) that use(s) the nominated template
+			if (params.devpages) {
+				var inCategories = mw.config.get('wgCategories');
+				var categoryNotificationPageMap = {
+					'Templates used by Twinkle': 'Wikipedia talk:Twinkle',
+					'Templates used by AutoWikiBrowser': 'Wikipedia talk:AutoWikiBrowser',
+					'Templates used by RedWarn': 'Wikipedia talk:RedWarn'
+				};
+				$.each(categoryNotificationPageMap, function(category, page) {
+					if (inCategories.indexOf(category) !== -1) {
+						Twinkle.xfd.callbacks.notifyUser(params, page, true, 'Notifying ' + page + ' of template nomination');
+					}
+				});
 			}
 
 		},


### PR DESCRIPTION
@mdaniels5757 This is a rework of your work in #1001, basically making use of the work in #1153.  I've restructured your PR into the first commit here; there are some renamings but it should roughly match what you created.  You're still attributed so feel free to double check it all!

The second commit expands on that a bit, mainly by moving the checkbox up top and showing it for every venue, but *only* if at least one category is found.  I think it's a better look and structure, but YMMV.

It still uses `wgCategories`; @siddharthvp's [note](https://github.com/azatoth/twinkle/pull/1001#discussion_r446497108) about [T206250](https://phabricator.wikimedia.org/T206250) is of course a concern, but I largely agree.  We could, I suppose lazy-execute a query on form opening, that shouldn't be too bad, although the potential for the form jumping ain't great.