### PR TITLE
warn: Fix duplicate warning if found section is 0

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1768,7 +1768,7 @@ Twinkle.warn.callbacks = {
 				sectionNumber = 0;
 				// Find this month's section, preferring the bottom-most
 				sectionExists = sections.reverse().some(function(sec, idx) {
-					return dateHeaderRegex.test(sec) && (sectionNumber = sections.length - 1 - idx);
+					return dateHeaderRegex.test(sec) && typeof (sectionNumber = sections.length - 1 - idx) === 'number';
 				});
 			}
 		}


### PR DESCRIPTION
`0` treated as `false`, duh.  Closes #1205 and #1206.