### PR TITLE
morebits.date: Don't import methods that collide with PageTriage (T268513)

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1819,9 +1819,12 @@ Morebits.date.prototype = {
 
 // Allow native Date.prototype methods to be used on Morebits.date objects
 Object.getOwnPropertyNames(Date.prototype).forEach(function(func) {
-	Morebits.date.prototype[func] = function() {
-		return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
-	};
+	// Exclude methods that collide with PageTriage's Date.js external, which clobbers native Date: [[phab:T268513]]
+	if (['add', 'getDayName', 'getMonthName'].indexOf(func) === -1) {
+		Morebits.date.prototype[func] = function() {
+			return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
+		};
+	}
 });
 
 


### PR DESCRIPTION
See https://phabricator.wikimedia.org/T268513 and #1209 for more details, but basically:

- PageTriage loads an outdated version of an external library (Date.js)
- It adds *a lot* of methods to the native JS Date prototype, including a few that collide with Morebits.date
- In particular, clobbering of `add` broke `format` which broke XfD listings

This just skips importing the three that collide with us: `add`, `getDayName`, and `getMonthName`