### PR TITLE
add dev/server.js

### DIFF
--- a/dev/patch-test.js
+++ b/dev/patch-test.js
@@ -6,7 +6,7 @@
  *
  * How to use:
  * - Run `npm run patchtest` which generates patch-test-loader.js
- * - Set up a localhost server (such as by using server.js or by running
+ * - Set up a localhost server (such as by using npm run server or by running
  *   php -S 127.0.0.1:5500) and load patch-test-loader.js in the wiki environment,
  *   using the browser console or the common.js page.
  * - You can provide a different port by running `npm run patchtest -- 1234`

--- a/dev/server.js
+++ b/dev/server.js
@@ -1,0 +1,29 @@
+/* eslint-env node, es6 */
+
+const http = require('http');
+const fs = require('fs');
+
+const server = http.createServer((request, response) => {
+	const filePath = '.' + request.url;
+	let contentType;
+	if (request.url.endsWith('.js')) {
+		contentType = 'text/javascript';
+	} else if (request.url.endsWith('.css')) {
+		contentType = 'text/css';
+	}
+	fs.readFile(filePath, function(error, content) {
+		if (error) {
+			response.end('Oops, something went wrong: ' + error.code + ' ..\n');
+		} else {
+			response.writeHead(200, { 'Content-Type': contentType });
+			response.end(content, 'utf-8');
+		}
+	});
+});
+
+const hostname = '127.0.0.1';
+const port = isNaN(Number(process.argv[2])) ? '5500' : process.argv[2];
+
+server.listen(port, hostname, () => {
+	console.log(`Server running at http://${hostname}:${port}/`);
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"patchtest": "node dev/patch-test.js",
+	  	"server": "node dev/server.js",
 		"sync": "perl dev/sync.pl",
 		"deployall": "perl dev/sync.pl --mode=deploy --all"
 	},


### PR DESCRIPTION
The server.js file from #911. No dependencies. While it's possible to set up a server using `php -S` and `python -m SimpleHTTPServer` etc, putting it in package.json means IDEs can provide a one-click button for running it.