### PR TITLE
Convert all morebits/twinkle modules to use json, not xml, by default

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1416,13 +1416,16 @@ Twinkle.tag.callbacks = {
 				'redirects': 1,  // follow redirect if the class name turns out to be a redirect page
 				'lhnamespace': '10',  // template namespace only
 				'lhshow': 'redirect',
-				'lhlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
+				'lhlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
+				'format': 'json'
 			}, function removeRedirectTag(apiobj) {
-
-				$(apiobj.responseXML).find('page').each(function(idx, page) {
+				var pages = apiobj.getResponse().query.pages.filter(function(p) {
+					return !p.missing && !!p.linkshere;
+				});
+				pages.forEach(function(page) {
 					var removed = false;
-					$(page).find('lh').each(function(idx, el) {
-						var tag = $(el).attr('title').slice(9);
+					page.linkshere.forEach(function(el) {
+						var tag = el.title.slice(9);
 						var tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
 						if (tag_re.test(pageText)) {
 							pageText = pageText.replace(tag_re, '');
@@ -1432,7 +1435,7 @@ Twinkle.tag.callbacks = {
 					});
 					if (!removed) {
 						Morebits.status.warn('Info', 'Failed to find {{' +
-						$(page).attr('title').slice(9) + '}} on the page... excluding');
+						page.title.slice(9) + '}} on the page... excluding');
 					}
 
 				});
@@ -1633,12 +1636,16 @@ Twinkle.tag.callbacks = {
 				'redirects': 1,
 				'lhnamespace': '10', // template namespace only
 				'lhshow': 'redirect',
-				'lhlimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
+				'lhlimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
+				'format': 'json'
 			}, function replaceRedirectTag(apiobj) {
-				$(apiobj.responseXML).find('page').each(function(idx, page) {
+				var pages = apiobj.getResponse().query.pages.filter(function(p) {
+					return !p.missing && !!p.linkshere;
+				});
+				pages.forEach(function(page) {
 					var found = false;
-					$(page).find('lh').each(function(idx, el) {
-						var tag = $(el).attr('title').slice(9);
+					page.linkshere.forEach(function(el) {
+						var tag = el.title.slice(9);
 						var tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?)');
 						if (tag_re.test(pageText)) {
 							tagText += tag_re.exec(pageText)[1];
@@ -1649,7 +1656,7 @@ Twinkle.tag.callbacks = {
 					});
 					if (!found) {
 						Morebits.status.warn('Info', 'Failed to find the existing {{' +
-						$(page).attr('title').slice(9) + '}} on the page... skip repositioning');
+						page.title.slice(9) + '}} on the page... skip repositioning');
 					}
 				});
 				addNewTagsToMI();

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -100,7 +100,8 @@ Twinkle.talkback.callback = function() {
 		prop: 'extlinks',
 		titles: 'User talk:' + mw.config.get('wgRelevantUserName'),
 		elquery: 'userjs.invalid/noTalkback',
-		ellimit: '1'
+		ellimit: '1',
+		format: 'json'
 	};
 	var wpapi = new Morebits.wiki.api('Fetching talkback opt-out status', query, Twinkle.talkback.callback.optoutStatus);
 	wpapi.post();
@@ -109,10 +110,10 @@ Twinkle.talkback.callback = function() {
 Twinkle.talkback.optout = '';
 
 Twinkle.talkback.callback.optoutStatus = function(apiobj) {
-	var $el = $(apiobj.getXML()).find('el');
-	if ($el.length) {
+	var el = apiobj.getResponse().query.pages[0].extlinks;
+	if (el && el.length) {
 		Twinkle.talkback.optout = mw.config.get('wgRelevantUserName') + ' prefers not to receive talkbacks';
-		var url = $el.text();
+		var url = el[0].url;
 		var reason = mw.util.getParamValue('reason', url);
 		Twinkle.talkback.optout += reason ? ': ' + reason : '.';
 	}

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -52,7 +52,8 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 		'rvlimit': 1,
 		'rvprop': [ 'ids', 'user' ],
 		'rvstartid': mw.config.get('wgCurRevisionId') - 1, // i.e. not the current one
-		'rvuser': user
+		'rvuser': user,
+		'format': 'json'
 	};
 	Morebits.status.init(document.getElementById('mw-content-text'));
 	var wikipedia_api = new Morebits.wiki.api('Grabbing data of initial contributor', query, Twinkle.diff.callbacks.main);
@@ -62,8 +63,8 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 
 Twinkle.diff.callbacks = {
 	main: function(self) {
-		var xmlDoc = self.responseXML;
-		var revid = $(xmlDoc).find('rev').attr('revid');
+		var rev = self.response.query.pages[0].revisions;
+		var revid = rev && rev[0].revid;
 
 		if (!revid) {
 			self.statelem.error('no suitable earlier revision found, or ' + self.params.user + ' is the only contributor. Aborting.');

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -187,7 +187,6 @@ var params = {};
 
 Twinkle.prod.callbacks = {
 	checkPriors: function twinkleprodcheckPriors() {
-
 		var talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
 		// Talk page templates for PROD-able discussions
 		var blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
@@ -198,18 +197,19 @@ Twinkle.prod.callbacks = {
 			'action': 'query',
 			'titles': talk_title,
 			'prop': 'templates',
-			'tltemplates': blocking_templates
+			'tltemplates': blocking_templates,
+			'format': 'json'
 		};
 
 		var wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
 		return wikipedia_api.post().then(function(apiobj) {
-			var xmlDoc = apiobj.responseXML;
 			var statelem = apiobj.statelem;
 
 			// Check talk page for templates indicating prior XfD or PROD
-			var numTemplates = $(xmlDoc).find('templates tl').length;
+			var templates = apiobj.getResponse().query.pages[0].templates;
+			var numTemplates = templates && templates.length;
 			if (numTemplates) {
-				var template = $(xmlDoc).find('templates tl')[0].getAttribute('title');
+				var template = templates[0].title;
 				if (numTemplates === 1 && template === 'Template:Old prod') {
 					params.oldProdPresent = true; // Mark for reference later, when deciding if to endorse
 				// if there are multiple templates, at least one of them would be a prior xfd template
@@ -496,7 +496,6 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 			window.location.href = mw.util.getUrl(mw.config.get('wgPageName'));
 		}, Morebits.wiki.actionCompleted.timeOut);
 	});
-
 };
 
 Twinkle.addInitCallback(Twinkle.prod, 'prod');

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -58,29 +58,22 @@ Twinkle.unlink.callback = function(presetReason) {
 		size: 60
 	});
 
-	var query;
+	var query = {
+		action: 'query',
+		list: 'backlinks',
+		bltitle: mw.config.get('wgPageName'),
+		bllimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
+		blnamespace: Twinkle.getPref('unlinkNamespaces'),
+		rawcontinue: true,
+		format: 'json'
+	};
 	if (mw.config.get('wgNamespaceNumber') === 6) {  // File:
-		query = {
-			'action': 'query',
-			'list': [ 'backlinks', 'imageusage' ],
-			'bltitle': mw.config.get('wgPageName'),
-			'iutitle': mw.config.get('wgPageName'),
-			'bllimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-			'iulimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-			'blnamespace': Twinkle.getPref('unlinkNamespaces'),
-			'iunamespace': Twinkle.getPref('unlinkNamespaces'),
-			'rawcontinue': true
-		};
+		query.list += '|imageusage';
+		query.iutitle = query.bltitle;
+		query.iulimit = query.bllimit;
+		query.iunamespace = query.blnamespace;
 	} else {
-		query = {
-			'action': 'query',
-			'list': 'backlinks',
-			'bltitle': mw.config.get('wgPageName'),
-			'blfilterredir': 'nonredirects',
-			'bllimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
-			'blnamespace': Twinkle.getPref('unlinkNamespaces'),
-			'rawcontinue': true
-		};
+		query.blfilterredir = 'nonredirects';
 	}
 	var wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.unlink.callbacks.display.backlinks);
 	wikipedia_api.params = { form: form, Window: Window, image: mw.config.get('wgNamespaceNumber') === 6 };
@@ -133,15 +126,15 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 Twinkle.unlink.callbacks = {
 	display: {
 		backlinks: function twinkleunlinkCallbackDisplayBacklinks(apiobj) {
-			var xmlDoc = apiobj.responseXML;
+			var response = apiobj.getResponse();
 			var havecontent = false;
 			var list, namespaces, i;
 
 			if (apiobj.params.image) {
-				var imageusage = $(xmlDoc).find('query imageusage iu');
+				var imageusage = response.query.imageusage;
 				list = [];
 				for (i = 0; i < imageusage.length; ++i) {
-					var usagetitle = imageusage[i].getAttribute('title');
+					var usagetitle = imageusage[i].title;
 					list.push({ label: usagetitle, value: usagetitle, checked: true });
 				}
 				if (!list.length) {
@@ -157,7 +150,7 @@ Twinkle.unlink.callbacks = {
 						label: 'Selected namespaces: ' + namespaces.join(', '),
 						tooltip: 'You can change this with your Twinkle preferences, at [[WP:TWPREFS]]'
 					});
-					if ($(xmlDoc).find('query-continue').length) {
+					if (response['query-continue'] && response['query-continue'].imageusage) {
 						apiobj.params.form.append({
 							type: 'div',
 							label: 'First ' + mw.language.convertNumber(list.length) + ' file usages shown.'
@@ -187,11 +180,11 @@ Twinkle.unlink.callbacks = {
 				}
 			}
 
-			var backlinks = $(xmlDoc).find('query backlinks bl');
+			var backlinks = response.query.backlinks;
 			if (backlinks.length > 0) {
 				list = [];
 				for (i = 0; i < backlinks.length; ++i) {
-					var title = backlinks[i].getAttribute('title');
+					var title = backlinks[i].title;
 					list.push({ label: title, value: title, checked: true });
 				}
 				apiobj.params.form.append({ type: 'header', label: 'Backlinks' });
@@ -204,7 +197,7 @@ Twinkle.unlink.callbacks = {
 					label: 'Selected namespaces: ' + namespaces.join(', '),
 					tooltip: 'You can change this with your Twinkle preferences, at [[WP:TWPREFS]]'
 				});
-				if ($(xmlDoc).find('query-continue').length) {
+				if (response['query-continue'] && response['query-continue'].backlinks) {
 					apiobj.params.form.append({
 						type: 'div',
 						label: 'First ' + mw.language.convertNumber(list.length) + ' backlinks shown.'

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -149,11 +149,13 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 				rvstartid: vanrevid,
 				rvlimit: 2,
 				rvdir: 'newer',
-				rvprop: 'user'
+				rvprop: 'user',
+				format: 'json'
 			};
 
 			new Morebits.wiki.api('Checking if you successfully reverted the page', query, function(apiobj) {
-				var revertUser = $(apiobj.getResponse()).find('revisions rev')[1].getAttribute('user');
+				var rev = apiobj.getResponse().query.pages[0].revisions;
+				var revertUser = rev && rev[1].user;
 				if (revertUser && revertUser !== mw.config.get('wgUserName')) {
 					message += ' Someone else reverted the page and may have already warned the user.';
 					$('#twinkle-warn-warning-messages').text('Note:' + message);
@@ -181,10 +183,12 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 				action: 'query',
 				prop: 'revisions',
 				rvprop: 'timestamp',
-				revids: vanrevid
+				revids: vanrevid,
+				format: 'json'
 			};
 			new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
-				vantimestamp = $(apiobj.getResponse()).find('revisions rev').attr('timestamp');
+				var rev = apiobj.getResponse().query.pages[0].revisions;
+				vantimestamp = rev && rev[0].timestamp;
 				checkStale(vantimestamp);
 			}).post();
 		}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1021,8 +1021,8 @@ Twinkle.xfd.callbacks = {
 
 	afd: {
 		main: function(apiobj) {
-			var xmlDoc = apiobj.responseXML;
-			var titles = $(xmlDoc).find('allpages p');
+			var response = apiobj.getResponse();
+			var titles = response.query.allpages;
 
 			// There has been no earlier entries with this prefix, just go on.
 			if (titles.length <= 0) {
@@ -1030,7 +1030,7 @@ Twinkle.xfd.callbacks = {
 			} else {
 				var number = 0;
 				for (var i = 0; i < titles.length; ++i) {
-					var title = titles[i].getAttribute('title');
+					var title = titles[i].title;
 
 					// First, simple test, is there an instance with this exact name?
 					if (title === 'Wikipedia:Articles for deletion/' + Morebits.pageNameNorm) {
@@ -1396,8 +1396,8 @@ Twinkle.xfd.callbacks = {
 
 	mfd: {
 		main: function(apiobj) {
-			var xmlDoc = apiobj.responseXML;
-			var titles = $(xmlDoc).find('allpages p');
+			var response = apiobj.getResponse();
+			var titles = response.query.allpages;
 
 			// There has been no earlier entries with this prefix, just go on.
 			if (titles.length <= 0) {
@@ -1405,7 +1405,7 @@ Twinkle.xfd.callbacks = {
 			} else {
 				var number = 0;
 				for (var i = 0; i < titles.length; ++i) {
-					var title = titles[i].getAttribute('title');
+					var title = titles[i].title;
 
 					// First, simple test, is there an instance with this exact name?
 					if (title === 'Wikipedia:Miscellany for deletion/' + Morebits.pageNameNorm) {
@@ -1779,7 +1779,8 @@ Twinkle.xfd.callbacks = {
 			// avoid relying on the client clock to build the log page
 			var query = {
 				'action': 'query',
-				'curtimestamp': true
+				'curtimestamp': true,
+				'format': 'json'
 			};
 			if (document.getElementById('softredirect')) {
 				// For soft redirects, define the target early
@@ -1797,11 +1798,11 @@ Twinkle.xfd.callbacks = {
 		// This is a closure for the callback from the above API request, which gets the target of the redirect
 		findTargetCallback: function(callback) {
 			return function(apiobj) {
-				var $xmlDoc = $(apiobj.responseXML);
-				var curtimestamp = $xmlDoc.find('api').attr('curtimestamp');
-				apiobj.params.curtimestamp = curtimestamp;
+				var response = apiobj.getResponse();
+				apiobj.params.curtimestamp = response.curtimestamp;
+
 				if (!apiobj.params.rfdtarget) { // Not a softredirect
-					var target = $xmlDoc.find('redirects r').first().attr('to');
+					var target = response.query.redirects && response.query.redirects[0].to;
 					if (!target) {
 						var message = 'No target found. this page does not appear to be a redirect, aborting';
 						if (mw.config.get('wgAction') === 'history') {
@@ -1811,7 +1812,7 @@ Twinkle.xfd.callbacks = {
 						return;
 					}
 					apiobj.params.rfdtarget = target;
-					var section = $xmlDoc.find('redirects r').first().attr('tofragment');
+					var section = response.query.redirects[0].tofragment;
 					apiobj.params.section = section;
 				}
 				callback(apiobj.params);
@@ -1993,7 +1994,8 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				'apprefix': 'Articles for deletion/' + Morebits.pageNameNorm,
 				'apnamespace': 4,
 				'apfilterredir': 'nonredirects',
-				'aplimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
+				'aplimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
+				'format': 'json'
 			};
 			wikipedia_api = new Morebits.wiki.api('Tagging article with deletion tag', query, Twinkle.xfd.callbacks.afd.main);
 			wikipedia_api.params = params;
@@ -2035,7 +2037,8 @@ Twinkle.xfd.callback.evaluate = function(e) {
 				'apprefix': 'Miscellany for deletion/' + Morebits.pageNameNorm,
 				'apnamespace': 4,
 				'apfilterredir': 'nonredirects',
-				'aplimit': 'max' // 500 is max for normal users, 5000 for bots and sysops
+				'aplimit': 'max', // 500 is max for normal users, 5000 for bots and sysops
+				'format': 'json'
 			};
 			wikipedia_api = new Morebits.wiki.api('Looking for prior nominations of this page', query, Twinkle.xfd.callbacks.mfd.main);
 			wikipedia_api.params = params;


### PR DESCRIPTION
Does what it says on the tin.  `xml` is still the default for `Morebits.wiki.api` for backwards compatibility, but this should convert everyone.

Not live on test.wiki since that's being actively tested, but I had it up for a month or so this fall, everything was smooth.