### PR TITLE
morebits.wikitext.parseTemplate: Fixes for unnamed parameters, internal templates

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4308,30 +4308,31 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 			--level;
 			continue;
 		}
-		// Leaving a template
+		// Either leaving a template or an internal template/parser function
 		if (test2 === '}}') {
+			// Regardless, decrement the level
 			current += test2;
 			++i;
 			--level;
 
-			// Find the final parameter if this is the end of the template
-			if (level <= 0) {
+			// Find the final parameter if this really is the end
+			if (level === -1) {
 				findParam(true);
 				break;
 			}
 			continue;
 		}
 
-		if (text.charAt(i) === '|' && level <= 0) {
-			// Pipe found, so parameter coming up!
+		if (text.charAt(i) === '|' && level === 0) {
+			// Another pipe found, toplevel, so parameter coming up!
 			findParam();
 			current = '';
-		} else if (equals === -1 && text.charAt(i) === '=' && level <= 0) {
-			// Equals found
+		} else if (equals === -1 && text.charAt(i) === '=' && level === 0) {
+			// Equals found, toplevel
 			equals = current.length;
 			current += text.charAt(i);
 		} else {
-			// Nothing to do, advance the position
+			// Just advance the position
 			current += text.charAt(i);
 		}
 	}

--- a/morebits.js
+++ b/morebits.js
@@ -4255,18 +4255,42 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 	};
 	var key, value;
 
+	/**
+	 * Function to handle finding parameter values.
+	 *
+	 * @param {boolean} [final=false] - Whether this is the final
+	 * parameter and we need to remove the trailing `}}`.
+	 */
+	var findParam = function(final) {
+		// Nothing found yet, this must be the template name
+		if (count === -1) {
+			result.name = current.substring(2).trim();
+			++count;
+		} else {
+			// In a parameter
+			if (equals !== -1) {
+				// We found an equals, so save the parameter as key: value
+				key = current.substring(0, equals).trim();
+				value = final ? current.substring(equals + 1, current.length - 2).trim() : current.substring(equals + 1).trim();
+				result.parameters[key] = value;
+				equals = -1;
+			} else {
+				// No equals, so it must be unnamed; no trim since whitespace allowed
+				var param = final ? current.substring(equals + 1, current.length - 2) : current;
+				if (param) {
+					result.parameters[++unnamed] = param;
+					++count;
+				}
+			}
+		}
+	};
+
 	for (var i = start; i < text.length; ++i) {
 		var test3 = text.substr(i, 3);
-		if (test3 === '{{{') {
-			current += '{{{';
+		if (test3 === '{{{' || test3 === '}}}') {
+			current += test3;
 			i += 2;
-			++level;
-			continue;
-		}
-		if (test3 === '}}}') {
-			current += '}}}';
-			i += 2;
-			--level;
+			test3 === '}}}' ? --level : ++level;
 			continue;
 		}
 		var test2 = text.substr(i, 2);
@@ -4292,27 +4316,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 
 			// Find the final parameter if this is the end of the template
 			if (level <= 0) {
-				// Nothing found yet, this must be the template name
-				if (count === -1) {
-					result.name = current.substring(2).trim();
-					++count;
-				} else {
-					// In a parameter
-					if (equals !== -1) {
-						// We found an equals, so save the parameter as key: value
-						key = current.substring(0, equals).trim();
-						value = current.substring(equals + 1, current.length - 2).trim();
-						result.parameters[key] = value;
-						equals = -1;
-					} else {
-						// No equals, so it must be unnamed; no trim since whitespace allowed
-						var param = current.substring(equals + 1, current.length - 2);
-						if (param) {
-							result.parameters[++unnamed] = param;
-							++count;
-						}
-					}
-				}
+				findParam(true);
 				break;
 			}
 			continue;
@@ -4320,26 +4324,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 
 		if (text.charAt(i) === '|' && level <= 0) {
 			// Pipe found, so parameter coming up!
-			if (count === -1) {
-				// Nothing found yet, this must be the template name
-				result.name = current.substring(2).trim();
-				++count;
-			} else {
-				// In a parameter
-				if (equals !== -1) {
-					// We found an equals, so save the parameter as key: value
-					key = current.substring(0, equals).trim();
-					value = current.substring(equals + 1).trim();
-					result.parameters[key] = value;
-					equals = -1;
-				} else {
-					// No equals, so it must be unnamed; no trim since whitespace allowed
-					if (current) {
-						result.parameters[++unnamed] = current;
-						++count;
-					}
-				}
-			}
+			findParam();
 			current = '';
 		} else if (equals === -1 && text.charAt(i) === '=' && level <= 0) {
 			// Equals found

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -31,6 +31,18 @@ QUnit.test('parseTemplate', assert => {
 	// Try a variety of whitespace options
 	var whitespace = '{{' + involved.name + ' |concern = ' + involved.parameters.concern + ' | timestamp =' + involved.parameters.timestamp + '| nom= ' + involved.parameters.nom + '|help = ' + involved.parameters.help + ' }}';
 	assert.deepEqual(Morebits.wikitext.parseTemplate(whitespace), involved, 'Involved parameters with whitespace');
+
+	var unnamed = {
+		name: 'db-meta',
+		parameters: {
+			criterion: 'G13',
+			1: ' reason ', // Note the surrounding whitespace, unnamed parameters can retain these
+			middle: '',
+			2: 'extra'
+		}
+	};
+	var unnamedTemplate = '{{' + unnamed.name + '|criterion=' + unnamed.parameters.criterion + '||' + unnamed.parameters['1'] + '| middle =|2= ' + unnamed.parameters['2'] + '|}}';
+	assert.deepEqual(Morebits.wikitext.parseTemplate(unnamedTemplate), unnamed, 'Unnamed and empty parameters');
 });
 QUnit.test('Morebits.wikitext.page', assert => {
 	var text = '{{short description}}{{about}}[[File:Fee.svg]]O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!';

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -54,6 +54,27 @@ QUnit.test('parseTemplate', assert => {
 		}
 	};
 	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(multiLevel)), multiLevel, 'Multiple levels');
+	var parser = {
+		name: 'toplevel',
+		parameters: {
+			named: 'namedtop',
+			other: '{{#if:{{{namedintro|{{{3|asd}}}|really=yes|a}}}|true|false}}',
+			1: 'onetop',
+			final: '{{{last|iswear}}}'
+		}
+	};
+	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(parser)), parser, 'Parser function');
+
+	var internal = {
+		name: 'internal',
+		parameters: {
+			named: 'parameter {{tq|with an internal}} template',
+			other: '{{#if:{{{namedintro|{{{3|asd}}}|really=yes|a}}}|true|false}}',
+			1: 'onetop',
+			final: '{{{last|iswear}}}'
+		}
+	};
+	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(internal)), internal, 'Internal templates');
 });
 QUnit.test('Morebits.wikitext.page', assert => {
 	var text = '{{short description}}{{about}}[[File:Fee.svg]]O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!';

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -16,7 +16,7 @@ QUnit.test('parseTemplate', assert => {
 			morereason: 'I said so',
 			timestamp: '42'
 		}};
-	assert.deepEqual(Morebits.wikitext.parseTemplate('Template: ' + makeTemplate(simple) + ' in text', 10), simple, 'Basic parameter test');
+	assert.deepEqual(Morebits.wikitext.parseTemplate('Template: ' + makeTemplate(simple) + ' in text', 10), simple, 'Basic parameters');
 
 	var involved = {
 		name: 'Proposed deletion/dated',
@@ -26,7 +26,7 @@ QUnit.test('parseTemplate', assert => {
 			nom: 'Jimbo Wales',
 			help: 'off'
 		}};
-	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(involved)), involved, 'Involved parameter test');
+	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(involved)), involved, 'Involved parameters');
 
 	// Try a variety of whitespace options
 	var whitespace = '{{' + involved.name + ' |concern = ' + involved.parameters.concern + ' | timestamp =' + involved.parameters.timestamp + '| nom= ' + involved.parameters.nom + '|help = ' + involved.parameters.help + ' }}';
@@ -43,6 +43,17 @@ QUnit.test('parseTemplate', assert => {
 	};
 	var unnamedTemplate = '{{' + unnamed.name + '|criterion=' + unnamed.parameters.criterion + '||' + unnamed.parameters['1'] + '| middle =|2= ' + unnamed.parameters['2'] + '|}}';
 	assert.deepEqual(Morebits.wikitext.parseTemplate(unnamedTemplate), unnamed, 'Unnamed and empty parameters');
+
+	var multiLevel = {
+		name: 'toplevel',
+		parameters: {
+			named: 'namedtop',
+			other: '{{{namedintro|{{{3|asd}}}|really=yes|a}}}',
+			1: 'onetop',
+			final: '{{{last|iswear}}}'
+		}
+	};
+	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(multiLevel)), multiLevel, 'Multiple levels');
 });
 QUnit.test('Morebits.wikitext.page', assert => {
 	var text = '{{short description}}{{about}}[[File:Fee.svg]]O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!';


### PR DESCRIPTION
Okay woof, think I got most cases sorted.  *Vastly* simpler with #1213.

- Use separate var `unnamed` rather than `count` to track unnamed parameters, since templates are 1-based and are only incremented for unnamed parameters
- `.trim()` shouldn't be used on unnamed/unspecified parameters, since whitespace is passed through those
- Ignore unprovided parameters (i.e. `{{template|}}`)
- Require returning to the original `level` so as not to abort early when running into internal templates/parser functions/etc.

Like #1214, this was only ever used by twinkledeprod.js for the `reason` parameter in PROD templates, hence these not being found until now.

I tidied up some duplicate functions and added some inline comments to make it a bit more clear what is happening at each step.