### PR TITLE
tag: fix minor bug (from #1216)

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1470,7 +1470,7 @@ Twinkle.tag.callbacks = {
 					var subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
 					subgroups.forEach(function(gr) {
 						if (gr.parameter && (params[gr.name] || gr.required)) {
-							currentTag += '|' + gr.parameter + '=' + params[gr.name];
+							currentTag += '|' + gr.parameter + '=' + (params[gr.name] || '');
 						}
 					});
 				}

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -781,6 +781,7 @@ Twinkle.tag.article.tagList = {
 					type: 'hidden',
 					name: 'expandLangTopic',
 					parameter: 'topic',
+					value: '',
 					required: true // force empty topic param in output
 				}, {
 					name: 'expandLanguageLangCode',


### PR DESCRIPTION
Affects {{Expand language}} only. This tag is weird in that for some reason we want to add the parameter topic= with no value into the wikitext. #1216 has a somewhat hacky way to accommodate this situation. But it had a bug in that undefined was being put into the wikitext instead of the empty string. That is, it was adding `{{Expand language|topic=undefined}}` when `{{Expand language|topic=}}` is desired.


[Example affected edit](https://en.wikipedia.org/w/index.php?title=Byron_Hyland&diff=next&oldid=919634235&diffmode=source)  