### PR TITLE
tests: Expand Morebits.date tests, begin basic unit tests for Morebits.taskManager

### DIFF
--- a/tests/morebits.batchOperation.js
+++ b/tests/morebits.batchOperation.js
@@ -1,8 +1,8 @@
 QUnit.module('Morebits.batchOperation');
-var batch = new Morebits.batchOperation();
 QUnit.test('Contruction', assert => {
-	assert.true(batch instanceof Morebits.batchOperation, 'Correct instance');
+	assert.true(new Morebits.batchOperation() instanceof Morebits.batchOperation, 'Correct instance');
 });
+var batch = new Morebits.batchOperation();
 var pageList = ['Macbeth', 'Hamlet', 'Romeo and Juliet', 'Much Ado About Nothing', 'Tempest'];
 batch.setPageList(pageList);
 var chunkLength = 2;

--- a/tests/morebits.date.js
+++ b/tests/morebits.date.js
@@ -1,26 +1,66 @@
 QUnit.module('Morebits.date');
+// Allow off-by-one values in milliseconds for not-quite-simultaneous date contructions
+QUnit.assert.pmOne = function(actual, expected, message) {
+	this.pushResult({
+		result: actual === expected || actual === expected+1 || actual === expected-1,
+		actual: actual,
+		expected: expected,
+		message: message
+	});
+};
+
 var now = Date.now();
 var timestamp = '16:26, 7 November 2020 (UTC)';
 QUnit.test('Construction', assert => {
-	assert.strictEqual(new Morebits.date().getTime(), new Date().getTime(), 'Basic constructor');
+	// getTime and toISOString imply testing of inherited methods
+	assert.pmOne(new Morebits.date().getTime(), new Date().getTime(), 'Basic constructor');
+
 	assert.strictEqual(new Morebits.date(now).getTime(), new Date(now).getTime(), 'Constructor from timestring');
 	assert.strictEqual(new Morebits.date(2020, 11, 7, 16, 26).getTime(), new Date(2020, 11, 7, 16, 26).getTime(), 'Constructor from parts');
 	assert.strictEqual(new Morebits.date(timestamp).toISOString(), '2020-11-07T16:26:00.000Z', 'enWiki timestamp format');
 });
 var date = new Morebits.date(timestamp);
-QUnit.test('Formats', assert => {
-	assert.strictEqual(new Morebits.date(now).format('YYYY-MM-DDTHH:mm:ss.SSSZ', 'utc'), new Date(now).toISOString(), 'ISO format');
-	assert.strictEqual(date.format('dddd D MMMM YY h:mA', 'utc'), 'Saturday 7 November 20 4:26PM', 'Some weirder stuff');
-	assert.strictEqual(date.format('MMt[h month], [d]a[y] D, h [o\'clock] A', 'utc'), '11th month, day 7, 4 o\'clock PM', 'Format escapes');
+QUnit.test('Methods', assert => {
+	assert.true(date.isValid(), 'Valid');
+	// Logs a message; not a failure, but annoying
+	assert.false(new Morebits.date('no').isValid(), 'Invalid');
+
+	// Ideally we would test the differences between UTC and non-UTC dates
+	assert.strictEqual(date.getDayName(), 'Saturday', 'getDayName');
+	assert.strictEqual(date.getDayNameAbbrev(), 'Sat', 'DayNameAbbrev');
+	assert.strictEqual(date.getMonthName(), 'November', 'MonthName');
+	assert.strictEqual(date.getMonthNameAbbrev(), 'Nov', 'MonthNameAbbrev');
+
+	assert.true(new Morebits.date(now).isAfter(date), 'isAfter');
+	assert.true(date.isBefore(new Date(now)), 'isBefore');
+});
+QUnit.test('RegEx headers', assert => {
+	assert.strictEqual(date.monthHeader(), '== November 2020 ==', 'Month header default');
+	assert.strictEqual(date.monthHeader(3), '=== November 2020 ===', 'Month header 3');
+	assert.strictEqual(date.monthHeader(0), 'November 2020', 'Month header text');
+
+	assert.true(date.monthHeaderRegex().test('==November 2020=='), 'Header RegEx');
+	assert.true(date.monthHeaderRegex().test('====November 2020===='), 'Deeper');
+	assert.true(date.monthHeaderRegex().test('== Nov 2020 =='), 'Shortened month');
+	// assert.false(date.monthHeaderRegex().test('=== Nov 2020 =='), 'Mismatched level');
+	assert.false(date.monthHeaderRegex().test('==December 2020=='), 'Wrong month');
 });
 QUnit.test('add/subtract', assert => {
 	assert.strictEqual(new Morebits.date(timestamp).add(1, 'day').toISOString(), '2020-11-08T16:26:00.000Z', 'Add 1 day');
 	assert.strictEqual(new Morebits.date(timestamp).subtract(1, 'day').toISOString(), '2020-11-06T16:26:00.000Z', 'Subtract 1 day');
 	assert.throws(() => new Morebits.date(timestamp).add(1), 'throws: no unit');
-	assert.throws(() => new Morebits.date(timestamp).subtract(1, 'date'), 'throws: bad unit');
+	assert.throws(() => new Morebits.date(timestamp).subtract(1, 'dayo'), 'throws: bad unit');
+});
+QUnit.test('Formats', assert => {
+	assert.strictEqual(new Morebits.date(now).format('YYYY-MM-DDTHH:mm:ss.SSSZ', 'utc'), new Date(now).toISOString(), 'ISO format');
+	assert.strictEqual(date.format('dddd D MMMM YY h:mA', 'utc'), 'Saturday 7 November 20 4:26PM', 'Some weirder stuff');
+	assert.strictEqual(date.format('MMt[h month], [d]a[y] D, h [o\'clock] A', 'utc'), '11th month, day 7, 4 o\'clock PM', 'Format escapes');
+	assert.strictEqual(date.format('dddd D MMMM YY h:mA', 600), 'Sunday 8 November 20 2:26AM', 'non-UTC formatting');
+	assert.strictEqual(date.format('MMt[h month], [d]a[y] D, h [o\'clock] A', 600), '11th month, day 8, 2 o\'clock AM', 'non-UTC escapes');
 });
 QUnit.test('Calendar', assert => {
 	assert.strictEqual(date.calendar('utc'), '2020-11-07', 'Old calendar');
+	assert.strictEqual(date.calendar(600), '2020-11-08', 'Old non-UTC');
 	assert.strictEqual(new Morebits.date(now).calendar('utc'), 'Today at ' + new Morebits.date(now).format('h:mm A', 'utc'), 'New calendar');
 	assert.strictEqual(new Morebits.date(now).subtract(1, 'day').calendar('utc'), 'Yesterday at ' + new Morebits.date(now).format('h:mm A', 'utc'), 'Close calendar');
 });

--- a/tests/morebits.taskManager.js
+++ b/tests/morebits.taskManager.js
@@ -1,0 +1,41 @@
+QUnit.module('Morebits.taskManager');
+QUnit.test('Contruction', assert => {
+	var tm = new Morebits.taskManager();
+	assert.true(tm instanceof Morebits.taskManager, 'Correct instance');
+});
+
+// Helper to generate functions as well as testing output in proper order;
+// verifySteps not used because it would require some extra duplication
+var data = {};
+var generateFuncs = () => {
+	data.out = [];
+	['one', 'two', 'three', 'four'].forEach((step) => {
+		data[step] = () => {
+			data.out.push(step);
+			return jQuery.Deferred().resolve();
+		};
+	});
+};
+
+QUnit.test('Simple', assert => {
+	generateFuncs();
+	var simple = new Morebits.taskManager();
+	simple.add(data.one, []);
+	simple.add(data.two, [data.one]);
+	simple.add(data.three, [data.two]);
+	simple.add(data.four, [data.three]);
+	return simple.execute().then(() => {
+		assert.deepEqual(data.out, ['one', 'two', 'three', 'four'], 'Simple order');
+	});
+});
+QUnit.test('Complex', assert => {
+	generateFuncs();
+	var complex = new Morebits.taskManager();
+	complex.add(data.one, [data.two]);
+	complex.add(data.two, [data.three, data.four]);
+	complex.add(data.three, []);
+	complex.add(data.four, [data.three]);
+	return complex.execute().then(() => {
+		assert.deepEqual(data.out, ['three', 'four', 'two', 'one'], 'Complex order');
+	});
+});

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -35,6 +35,7 @@ QUnit.test('parseTemplate', assert => {
 QUnit.test('Morebits.wikitext.page', assert => {
 	var text = '{{short description}}{{about}}[[File:Fee.svg]]O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!';
 	var page = new Morebits.wikitext.page(text);
+	assert.true(page instanceof Morebits.wikitext.page, 'Correct instance');
 	assert.strictEqual(page.getText(), text, 'text');
 	assert.strictEqual(page.addToImageComment('Fee.svg', 'thumb|size=42').getText(), '{{short description}}{{about}}[[File:Fee.svg|thumb|size=42]]O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!', 'Add data');
 	assert.strictEqual(page.commentOutImage('Fee.svg', 'too pretty').getText(), '{{short description}}{{about}}<!-- too pretty: [[File:Fee.svg|thumb|size=42]] -->O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!', 'Comment out');


### PR DESCRIPTION
Expands the `Morebits.date` tests to include some representative methods, notably: getters, `isAfter`/`isBefore`, the month header functions, and a couple non-UTC timezone formatting.  It also fixes the issue where testing the basic constructor (`new Morebits.date()` or `new Date()`) would occasionally (~0.068% of the time on my laptop) fail as the two times would be off by ` in the millisecond portion.  This creates a new assertion that allows values of +1 or -1 to pass, used just there.

The `taskManager` tests don't make use of the `steps`/`verifySteps` assertions mainly because I didn't like the way I had to duplicate function creation.

A few minor cleanups as well.