### PR TITLE
morebits.date.monthHeaderRegex: Require matching level markers

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1804,8 +1804,8 @@ Morebits.date.prototype = {
 	 * @returns {RegExp}
 	 */
 	monthHeaderRegex: function() {
-		return new RegExp('^==+\\s*(?:' + this.getUTCMonthName() + '|' + this.getUTCMonthNameAbbrev() +
-			')\\s+' + this.getUTCFullYear() + '\\s*==+', 'mg');
+		return new RegExp('^(==+)\\s*(?:' + this.getUTCMonthName() + '|' + this.getUTCMonthNameAbbrev() +
+			')\\s+' + this.getUTCFullYear() + '\\s*\\1', 'mg');
 	},
 
 	/**

--- a/tests/morebits.date.js
+++ b/tests/morebits.date.js
@@ -42,7 +42,7 @@ QUnit.test('RegEx headers', assert => {
 	assert.true(date.monthHeaderRegex().test('==November 2020=='), 'Header RegEx');
 	assert.true(date.monthHeaderRegex().test('====November 2020===='), 'Deeper');
 	assert.true(date.monthHeaderRegex().test('== Nov 2020 =='), 'Shortened month');
-	// assert.false(date.monthHeaderRegex().test('=== Nov 2020 =='), 'Mismatched level');
+	assert.false(date.monthHeaderRegex().test('=== Nov 2020 =='), 'Mismatched level');
 	assert.false(date.monthHeaderRegex().test('==December 2020=='), 'Wrong month');
 });
 QUnit.test('add/subtract', assert => {


### PR DESCRIPTION
Mediawiki will interpret extra `=`s as literal "="s in the subject, but it ain't what we're looking for.

Depends/builds on #1228