### PR TITLE
morebits.wiki.page: Get watched status of page, only apply watchlist expiry if unwatched

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -364,6 +364,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		'action': 'query',
 		'prop': ['info', 'revisions', 'flagged'],
 		'titles': pagename,
+		'inprop': 'watched',
 		'intestactions': 'edit',
 		'rvlimit': Twinkle.getPref('revertMaxRevisions'),
 		'rvprop': [ 'ids', 'timestamp', 'user' ],
@@ -385,6 +386,7 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 		'action': 'query',
 		'prop': ['info', 'revisions'],
 		'titles': mw.config.get('wgPageName'),
+		'inprop': 'watched',
 		'rvlimit': 1,
 		'rvstartid': oldrev,
 		'rvprop': [ 'ids', 'user' ],
@@ -456,8 +458,8 @@ Twinkle.fluff.callbacks = {
 			} else {
 				query.watchlist = 'watch';
 				// number allowed but not used in Twinkle.config.watchlistEnums
-				if (typeof watchOrExpiry === 'string' && watchOrExpiry !== 'yes') {
-					query.watchlistexpiry = watchOrExpiry;
+				if (!page.watched && typeof watchOrExpiry === 'string' && watchOrExpiry !== 'yes') {
+					query.expiry = watchOrExpiry;
 				}
 			}
 		}
@@ -689,8 +691,8 @@ Twinkle.fluff.callbacks = {
 			} else {
 				query.watchlist = 'watch';
 				// number allowed but not used in Twinkle.config.watchlistEnums
-				if (typeof watchOrExpiry === 'string' && watchOrExpiry !== 'yes') {
-					query.watchlistexpiry = watchOrExpiry;
+				if (!page.watched && typeof watchOrExpiry === 'string' && watchOrExpiry !== 'yes') {
+					query.expiry = watchOrExpiry;
 				}
 			}
 		}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1240,8 +1240,8 @@ Twinkle.xfd.callbacks = {
 					token: mw.user.tokens.get('watchToken')
 				};
 				// Expiry
-				if (watchModule && watchPref !== 'default' && watchPref !== 'yes') {
-					watch_query.watchlistexpiry = watchPref;
+				if (!pageobj.getWatched() && watchModule && watchPref !== 'default' && watchPref !== 'yes') {
+					watch_query.expiry = watchPref;
 				}
 			}
 

--- a/morebits.js
+++ b/morebits.js
@@ -2359,6 +2359,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		contentModel: null,
 		revertCurID: null,
 		revertUser: null,
+		watched: false,
 		fullyProtected: false,
 		suppressProtectWarning: false,
 		conflictRetries: 0,
@@ -2425,6 +2426,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		ctx.loadQuery = {
 			action: 'query',
 			prop: 'info|revisions',
+			inprop: 'watched',
 			intestactions: 'edit', // can be expanded
 			curtimestamp: '',
 			meta: 'tokens',
@@ -2449,7 +2451,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			ctx.loadQuery.rvsection = ctx.pageSection;
 		}
 		if (Morebits.userIsSysop) {
-			ctx.loadQuery.inprop = 'protection';
+			ctx.loadQuery.inprop += '|protection';
 		}
 
 		ctx.loadApi = new Morebits.wiki.api('Retrieving page...', ctx.loadQuery, fnLoadSuccess, ctx.statusElement, ctx.onLoadFailure);
@@ -2519,7 +2521,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.tags = ctx.changeTags;
 		}
 
-		if (ctx.watchlistExpiry) {
+		if (ctx.watchlistExpiry && !ctx.watched) {
 			query.watchlistexpiry = ctx.watchlistExpiry;
 		}
 
@@ -3006,6 +3008,11 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		return ctx.contentModel;
 	};
 
+	/** @returns {boolean} - Watched status of the page. */
+	this.getWatched = function () {
+		return ctx.watched;
+	};
+
 	/**
 	 * @returns {string} ISO 8601 timestamp at which the page was last loaded.
 	 */
@@ -3445,6 +3452,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		}
 
 		ctx.contentModel = page.contentmodel;
+		ctx.watched = page.watched;
 
 		// extract protection info, to alert admins when they are about to edit a protected page
 		// Includes cascading protection
@@ -3825,7 +3833,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.tags = ctx.changeTags;
 		}
 
-		if (ctx.watchlistExpiry) {
+		if (ctx.watchlistExpiry && !ctx.watched) {
 			query.watchlistexpiry = ctx.watchlistExpiry;
 		}
 		if (ctx.moveTalkPage) {
@@ -3969,7 +3977,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.tags = ctx.changeTags;
 		}
 
-		if (ctx.watchlistExpiry) {
+		if (ctx.watchlistExpiry && !ctx.watched) {
 			query.watchlistexpiry = ctx.watchlistExpiry;
 		}
 
@@ -4032,7 +4040,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.tags = ctx.changeTags;
 		}
 
-		if (ctx.watchlistExpiry) {
+		if (ctx.watchlistExpiry && !ctx.watched) {
 			query.watchlistexpiry = ctx.watchlistExpiry;
 		}
 
@@ -4165,7 +4173,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			query.tags = ctx.changeTags;
 		}
 
-		if (ctx.watchlistExpiry) {
+		if (ctx.watchlistExpiry && !ctx.watched) {
 			query.watchlistexpiry = ctx.watchlistExpiry;
 		}
 		if (ctx.protectCascade) {


### PR DESCRIPTION
Watchlist expiry is ideal for Twinkle since a lot of edits or taggings are transitory.  If, however, you have a page you've watched indefinitely, the API will overwrite that with the expiry settings, which is generally *not* what folks want.  Until https://phabricator.wikimedia.org/T268834, there's no reliable or convenient way to query an individual page's watchlist expiration, so for now we rely simply on whether the page is being watched or not.  It's not ideal*, but especially early on, is probably a fair assumption.  Exposed via `getWatched`.

I had thought I tested this before rollout, but it was being masked by a silly bug: for `action=watch`, it's `expiry` not `watchlistexpiry`.  Regardless, that's now fixed for the ad-hoc watching mechanisms in xfd (`mb.w.page`) and fluff (`mb.w.api`), and the above technique used as well.

----

As written, dependent on #1224 'cause I'm bored of rewriting things, but trivial to do otherwise.

\* If the page isn't loaded, this won't help, but afaik doing otherwise would require always `load`ing the page.