### PR TITLE
morebits: page: allow binding to existing statusElement

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2264,12 +2264,13 @@ Morebits.wiki.api.getToken = function() {
  * @class
  * @param {string} pageName - The name of the page, prefixed by the namespace (if any).
  * For the current page, use `mw.config.get('wgPageName')`.
- * @param {string} [currentAction] - A string describing the action about to be undertaken.
+ * @param {string|Morebits.status} [status] - A string describing the action about to be undertaken,
+ * or a Morebits.status object
  */
-Morebits.wiki.page = function(pageName, currentAction) {
+Morebits.wiki.page = function(pageName, status) {
 
-	if (!currentAction) {
-		currentAction = 'Opening page "' + pageName + '"';
+	if (!status) {
+		status = 'Opening page "' + pageName + '"';
 	}
 
 	/**
@@ -2288,7 +2289,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 		changeTags: null,
 		testActions: null,  // array if any valid actions
 		callbackParameters: null,
-		statusElement: new Morebits.status(currentAction),
+		statusElement: status instanceof Morebits.status ? status : new Morebits.status(status),
 
 		// - edit
 		pageText: null,
@@ -2942,6 +2943,13 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	 */
 	this.getCallbackParameters = function() {
 		return ctx.callbackParameters;
+	};
+
+	/**
+	 * @param {Morebits.status} statusElement
+	 */
+	this.setStatusElement = function(statusElement) {
+		ctx.statusElement = statusElement;
 	};
 
 	/**


### PR DESCRIPTION
This makes it possible for a morebits.wiki.page object to use an existing Morebits.status object rather than always creating a new one.

This can be done either using `.setStatusElement()` or by just providing a Morebits.status object to the constructor as second argument rather than a string.