### PR TITLE
morebits: userspaceLogger: return a promise

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -438,11 +438,7 @@ Twinkle.prod.callbacks = {
 		}
 		usl.changeTags = Twinkle.changeTags;
 
-		usl.log(logText, summaryText);
-		return $.Deferred().resolve(); // KLUDGE: this should actually return resolved/
-		// rejected after the logging succeeded/failed, but Morebits.userspaceLogger#log
-		// doesn't support callbacks, and it seems wasteful to add them just for this.
-		// This isn't a real issue since no other task depend on this one.
+		return usl.log(logText, summaryText);
 	}
 
 };

--- a/morebits.js
+++ b/morebits.js
@@ -4590,14 +4590,16 @@ Morebits.userspaceLogger = function(logPageName) {
 	 *
 	 * @param {string} logText - Doesn't include leading `#` or `*`.
 	 * @param {string} summaryText - Edit summary.
+	 * @returns {JQuery.Promise}
 	 */
 	this.log = function(logText, summaryText) {
+		var def = $.Deferred();
 		if (!logText) {
-			return;
+			return def.reject();
 		}
 		var page = new Morebits.wiki.page('User:' + mw.config.get('wgUserName') + '/' + logPageName,
 			'Adding entry to userspace log'); // make this '... to ' + logPageName ?
-		return page.load(function(pageobj) {
+		page.load(function(pageobj) {
 			// add blurb if log page doesn't exist or is blank
 			var text = pageobj.getPageText() || this.initialText;
 
@@ -4611,8 +4613,9 @@ Morebits.userspaceLogger = function(logPageName) {
 			pageobj.setEditSummary(summaryText);
 			pageobj.setChangeTags(this.changeTags);
 			pageobj.setCreateOption('recreate');
-			pageobj.save();
+			pageobj.save(def.resolve, def.reject);
 		}.bind(this));
+		return def;
 	};
 };
 


### PR DESCRIPTION
Needed for taskManager to know when the logging has finished in promise-based rewrites. Resolves the kludge in twinkleprod.

Of course this would have been much simpler if Morebits.wiki.page methods themselves returned promises (#911).