### PR TITLE
morebits/xfd: improve formatReasonText

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -744,11 +744,7 @@ Twinkle.xfd.callbacks = {
 		var text = '{{subst:' + venue + '2';
 		var reasonKey = venue === 'ffd' ? 'Reason' : 'text';
 		// Add a reason unconditionally, so that at least a signature is added
-		if (params.reason) {
-			text += '|' + reasonKey + '=' + Morebits.string.formatReasonText(params.reason) + ' ~~~~';
-		} else {
-			text += '|' + reasonKey + '=~~~~';
-		}
+		text += '|' + reasonKey + '=' + Morebits.string.formatReasonText(params.reason, true);
 
 		if (venue === 'afd' || venue === 'mfd') {
 			text += '|pg=' + Morebits.pageNameNorm;

--- a/morebits.js
+++ b/morebits.js
@@ -1221,16 +1221,25 @@ Morebits.string = {
 	 * Formats freeform "reason" (from a textarea) for deletion/other
 	 * templates that are going to be substituted, (e.g. PROD, XFD, RPP).
 	 * Handles `|` outside a nowiki tag.
+	 * Optionally, also adds a signature if not present already.
 	 *
 	 * @param {string} str
+	 * @param {boolean} [addSig]
 	 * @returns {string}
 	 */
-	formatReasonText: function(str) {
-		var result = str.toString().trim();
-		var unbinder = new Morebits.unbinder(result);
+	formatReasonText: function(str, addSig) {
+		var reason = (str || '').toString().trim();
+		var unbinder = new Morebits.unbinder(reason);
 		unbinder.unbind('<no' + 'wiki>', '</no' + 'wiki>');
 		unbinder.content = unbinder.content.replace(/\|/g, '{{subst:!}}');
-		return unbinder.rebind();
+		reason = unbinder.rebind();
+		if (addSig) {
+			var sig = '~~~~', sigIndex = reason.lastIndexOf(sig);
+			if (sigIndex === -1 || sigIndex !== reason.length - sig.length) {
+				reason += ' ' + sig;
+			}
+		}
+		return reason.trim();
 	},
 
 	/**

--- a/tests/morebits.string.js
+++ b/tests/morebits.string.js
@@ -14,10 +14,19 @@ QUnit.test('formatReasonForLog', assert => {
 QUnit.test('formatReasonText', assert => {
 	var reason = 'They were correct';
 	assert.strictEqual(Morebits.string.formatReasonText(reason), reason, 'Simple, unchanged');
+	assert.strictEqual(Morebits.string.formatReasonText(reason, true), reason + ' ~~~~', 'Simple');
 	var more = 'Technically correct';
 	assert.strictEqual(Morebits.string.formatReasonText(reason + '|' + more ), reason + '{{subst:!}}' + more, 'Replace pipe');
+	assert.strictEqual(Morebits.string.formatReasonText(reason + '|' + more, true), reason + '{{subst:!}}' + more + ' ~~~~', 'Replace pipe');
 	reason += 'The <nowiki>{{best|kind|of}}</nowiki> correct: ';
 	assert.strictEqual(Morebits.string.formatReasonText(reason + more ), reason + more, 'No replace in nowiki');
+	assert.strictEqual(Morebits.string.formatReasonText(), '', 'Empty');
+	var alreadySigned = 'already signed ~~~~';
+	assert.strictEqual(Morebits.string.formatReasonText(alreadySigned, true), alreadySigned, 'No sig duplication');
+	assert.strictEqual(Morebits.string.formatReasonText('alreadySigned~~~~  ', true), 'alreadySigned~~~~', 'trims and avoids duplicating sig');
+	assert.strictEqual(Morebits.string.formatReasonText('Wow', true), 'Wow ~~~~', '3-letter reason');
+	assert.strictEqual(Morebits.string.formatReasonText('', true), '~~~~', 'Empty');
+	assert.strictEqual(Morebits.string.formatReasonText(undefined, true), '~~~~', 'Undefined');
 });
 QUnit.test('isInfinity', assert => {
 	assert.true(Morebits.string.isInfinity('infinity'), 'Infinity');


### PR DESCRIPTION
Morebits.string.formatReasonText:

- Add a `addSig` option which appends a signature to the reason, but not if one already existed. Used in XFD module. This should remove duplicate sigs often seen in XFD nominations.
- Return empty string (or just a signature when addSig=true) if input is undefined (or null), rather than erroring out. 