### PR TITLE
morebits.wikitext.page: bugfix: Exactly match templates and files

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4469,7 +4469,7 @@ Morebits.wikitext.page.prototype = {
 
 		// Check for normal image links, i.e. [[File:Foobar.png|...]]
 		// Will eat the whole link
-		var links_re = new RegExp('\\[\\[(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string);
+		var links_re = new RegExp('\\[\\[(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
 		var allLinks = Morebits.array.uniq(Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]'));
 		for (var i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
@@ -4483,7 +4483,7 @@ Morebits.wikitext.page.prototype = {
 		// Check for gallery images, i.e. instances that must start on a new line,
 		// eventually preceded with some space, and must include File: prefix
 		// Will eat the whole line.
-		var gallery_image_re = new RegExp('(^\\s*(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '.*?$)', 'mg');
+		var gallery_image_re = new RegExp('(^\\s*(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
 		unbinder.content = unbinder.content.replace(gallery_image_re, '<!-- ' + reason + '$1 -->');
 
 		// unbind the newly created comments
@@ -4513,7 +4513,7 @@ Morebits.wikitext.page.prototype = {
 			first_char_regex = '[' + Morebits.string.escapeRegExp(first_char.toUpperCase()) + Morebits.string.escapeRegExp(first_char.toLowerCase()) + ']';
 		}
 		var image_re_string = '(?:[Ii]mage|[Ff]ile):\\s*' + first_char_regex + Morebits.string.escapeRegExp(image.substr(1));
-		var links_re = new RegExp('\\[\\[' + image_re_string);
+		var links_re = new RegExp('\\[\\[' + image_re_string + '\\s*[\\|(?:\\]\\])]');
 		var allLinks = Morebits.array.uniq(Morebits.string.splitWeightedByKeys(this.text, '[[', ']]'));
 		for (var i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
@@ -4540,7 +4540,7 @@ Morebits.wikitext.page.prototype = {
 	removeTemplate: function(template) {
 		var first_char = template.substr(0, 1);
 		var template_re_string = '(?:[Tt]emplate:)?\\s*[' + first_char.toUpperCase() + first_char.toLowerCase() + ']' + Morebits.string.escapeRegExp(template.substr(1));
-		var links_re = new RegExp('\\{\\{' + template_re_string);
+		var links_re = new RegExp('\\{\\{' + template_re_string + '\\s*[\\|(?:\\}\\})]');
 		var allTemplates = Morebits.array.uniq(Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]));
 		for (var i = 0; i < allTemplates.length; ++i) {
 			if (links_re.test(allTemplates[i])) {

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -105,6 +105,13 @@ QUnit.test('Morebits.wikitext.page', assert => {
 			params: ['Fee.svg', 'too pretty']
 		},
 		{
+			name: 'simple gallery',
+			method: 'commentOutImage',
+			input: '<gallery>\nFile:Fee.svg|1\nFile:Gvs.eef|2\n</gallery>',
+			expected: '<gallery>\n<!-- too pretty: File:Fee.svg|1 -->\nFile:Gvs.eef|2\n</gallery>',
+			params: ['Fee.svg', 'too pretty']
+		},
+		{
 			name: 'simple',
 			method: 'addToImageComment',
 			input: text,
@@ -131,6 +138,20 @@ QUnit.test('Morebits.wikitext.page', assert => {
 			input: 'O, [[Juliet|she]] [[juliet|doth]] {{plural|teach}} [[Romeo|the]] [[:Juliet|torches]] [[juliet|to]] burn bright!',
 			expected: 'O, she doth {{plural|teach}} [[Romeo|the]] torches to burn bright!',
 			params: ['juliet']
+		},
+		{
+			name: 'multiple',
+			method: 'commentOutImage',
+			input: 'O, [[File:Fee.svg]] she [[File:Fee.svg|doth|teach]] the [[File:Fee.svg|torches]] to burn bright!',
+			expected: 'O, <!-- [[File:Fee.svg]] --> she <!-- [[File:Fee.svg|doth|teach]] --> the <!-- [[File:Fee.svg|torches]] --> to burn bright!',
+			params: ['Fee.svg']
+		},
+		{
+			name: 'multiple gallery',
+			method: 'commentOutImage',
+			input: '<gallery>\nFile:Fee.svg|1\nFile:Gvs.eef|2\nFile:Fee.svg    |\n</gallery>',
+			expected: '<gallery>\n<!-- too pretty: File:Fee.svg|1 -->\nFile:Gvs.eef|2\n<!-- too pretty: File:Fee.svg    | -->\n</gallery>',
+			params: ['Fee.svg', 'too pretty']
 		},
 		{
 			name: 'multiple',
@@ -201,6 +222,34 @@ QUnit.test('Morebits.wikitext.page', assert => {
 			input: 'O, she doth {{Template:plural|teach}} the torches to burn bright!',
 			expected: 'O, she doth  the torches to burn bright!',
 			params: ['Template:plural']
+		},
+		{
+			name: 'Similar names',
+			method: 'commentOutImage',
+			input: 'O, [[File:Fee.tif|she]] doth [[File:Fee.tiff|teach]] the [[File:Fee.tifff]] torches to burn bright!',
+			expected: 'O, <!-- [[File:Fee.tif|she]] --> doth [[File:Fee.tiff|teach]] the [[File:Fee.tifff]] torches to burn bright!',
+			params: ['Fee.tif']
+		},
+		{
+			name: 'Similar gallery',
+			method: 'commentOutImage',
+			input: '<gallery>\nFile:Fee.tif|1\nFile:Fee.tiff|2\nFile:Fee.tifff    |\n</gallery>',
+			expected: '<gallery>\n<!-- File:Fee.tif|1 -->\nFile:Fee.tiff|2\nFile:Fee.tifff    |\n</gallery>',
+			params: ['Fee.tif']
+		},
+		{
+			name: 'Similar names',
+			method: 'addToImageComment',
+			input: 'O, [[File:Fee.tif|she]] doth [[File:Fee.tiff|teach]] the [[File:Fee.tifff]] torches to burn bright!',
+			expected: 'O, [[File:Fee.tif|she|thumb|size=42]] doth [[File:Fee.tiff|teach]] the [[File:Fee.tifff]] torches to burn bright!',
+			params: ['Fee.tif', 'thumb|size=42']
+		},
+		{
+			name: 'Similar names',
+			method: 'removeTemplate',
+			input: 'O, {{plural|she|}} doth {{pluralize|teach}} the {{plural  | torches}} t{{plural \n\n |}}o {{plural temp|burn}} bright!',
+			expected: 'O,  doth {{pluralize|teach}} the  to {{plural temp|burn}} bright!',
+			params: ['plural']
 		}
 	];
 


### PR DESCRIPTION
`removeTemplate` would remove any template that merely *began* with the template string provided, which could clearly cause unanticipated side effects.  Likewise, `addToImageComment` and `commentOutImage` would detect any images that began with the string provided, albeit that's less likely since there are likely fewer filename collisions.  Also added some missing tests for galleries using `commentOutImage`.