### PR TITLE
mb.wikitext.page: Fix ancient bug where multiple occurences were not being processed

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4495,11 +4495,11 @@ Morebits.wikitext.page.prototype = {
 		// Check for normal image links, i.e. [[File:Foobar.png|...]]
 		// Will eat the whole link
 		var links_re = new RegExp('\\[\\[(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
-		var allLinks = Morebits.array.uniq(Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]'));
+		var allLinks = Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]');
 		for (var i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
 				var replacement = '<!-- ' + reason + allLinks[i] + ' -->';
-				unbinder.content = unbinder.content.replace(allLinks[i], replacement, 'g');
+				unbinder.content = unbinder.content.replace(allLinks[i], replacement);
 			}
 		}
 		// unbind the newly created comments
@@ -4539,13 +4539,13 @@ Morebits.wikitext.page.prototype = {
 		}
 		var image_re_string = '(?:[Ii]mage|[Ff]ile):\\s*' + first_char_regex + Morebits.string.escapeRegExp(image.substr(1));
 		var links_re = new RegExp('\\[\\[' + image_re_string + '\\s*[\\|(?:\\]\\])]');
-		var allLinks = Morebits.array.uniq(Morebits.string.splitWeightedByKeys(this.text, '[[', ']]'));
+		var allLinks = Morebits.string.splitWeightedByKeys(this.text, '[[', ']]');
 		for (var i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
 				var replacement = allLinks[i];
 				// just put it at the end?
 				replacement = replacement.replace(/\]\]$/, '|' + data + ']]');
-				this.text = this.text.replace(allLinks[i], replacement, 'g');
+				this.text = this.text.replace(allLinks[i], replacement);
 			}
 		}
 		var gallery_re = new RegExp('^(\\s*' + image_re_string + '.*?)\\|?(.*?)$', 'mg');
@@ -4555,7 +4555,7 @@ Morebits.wikitext.page.prototype = {
 	},
 
 	/**
-	 * Removes transclusions of template from page text.
+	 * Remove all transclusions of a template from page text.
 	 *
 	 * @param {string} template - Page name whose transclusions are to be removed,
 	 * include namespace prefix only if not in template namespace.
@@ -4566,10 +4566,10 @@ Morebits.wikitext.page.prototype = {
 		var first_char = template.substr(0, 1);
 		var template_re_string = '(?:[Tt]emplate:)?\\s*[' + first_char.toUpperCase() + first_char.toLowerCase() + ']' + Morebits.string.escapeRegExp(template.substr(1));
 		var links_re = new RegExp('\\{\\{' + template_re_string + '\\s*[\\|(?:\\}\\})]');
-		var allTemplates = Morebits.array.uniq(Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]));
+		var allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
 		for (var i = 0; i < allTemplates.length; ++i) {
 			if (links_re.test(allTemplates[i])) {
-				this.text = this.text.replace(allTemplates[i], '', 'g');
+				this.text = this.text.replace(allTemplates[i], '');
 			}
 		}
 		return this;

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -161,6 +161,13 @@ QUnit.test('Morebits.wikitext.page', assert => {
 			params: ['Fee.svg', ['thumb', 'size=42', 'test'].join('|')]
 		},
 		{
+			name: 'multiple',
+			method: 'removeTemplate',
+			input: '{{O}}, {{she|doth}} teach the t{{o}}rches to burn bright!{{o}}',
+			expected: ', {{she|doth}} teach the trches to burn bright!',
+			params: ['o']
+		},
+		{
 			name: 'preRegex',
 			method: 'insertAfterTemplates',
 			input: '{{short description}}{{About}}<!-- random -->{{xfd}}O, [[Juliet|she]] doth {{plural|teach}} the torches to burn bright!',
@@ -247,8 +254,8 @@ QUnit.test('Morebits.wikitext.page', assert => {
 		{
 			name: 'Template namespace',
 			method: 'removeTemplate',
-			input: 'O, she doth {{Template:plural|teach}} the torches to burn bright!',
-			expected: 'O, she doth  the torches to burn bright!',
+			input: 'O, she doth {{Template:plural|teach}} the {{template:plural|torches}} to burn bright!',
+			expected: 'O, she doth  the  to burn bright!',
 			params: ['Template:plural']
 		},
 		{


### PR DESCRIPTION
`string.replace(text, '', 'g')` has been present in `removeTemplate`, `commentOutImage`, and `addToImageComment` for ages, but it's not a valid form of `string.replace`.  The `'g'` was being entirely ignored!  Instead of creating a `new RegExp` relying on the output from `splitWeightedByKeys`, we can just not remove the duplicated items; thus, each item refers to a single element needing action.

In theory I'd be a little wary about changing these given the off chance something was relying on them not working fully - although the initial capitalization changes would have been processed - but it's clear the intent of these was to work, so I think it's fine.  Besides, there aren't many non-Twinkle uses.  `removeTemplate` probably worked just fine if the "template" was in another namespaces, as this generally worked fine for `commentOutImage` and `addToImageComment` since they included the namespace.