### PR TITLE
protect: Don't overwrite indefinite watching with expiry

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -152,7 +152,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		letype: 'protect',
 		letitle: mw.config.get('wgPageName'),
 		prop: hasFlaggedRevs ? 'info|flagged' : 'info',
-		inprop: 'protection',
+		inprop: 'protection|watched',
 		titles: mw.config.get('wgPageName')
 	});
 	var stableDeferred = api.get({
@@ -178,6 +178,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 
 		var pageid = protectData[0].query.pageids[0];
 		var page = protectData[0].query.pages[pageid];
+		Twinkle.protect.isWatched = page.watched === ''; // Dumb kludge to ensure we don't overwrite indefinite watching with expiry
 		var current = {}, adminEditDeferred;
 
 		$.each(page.protection, function(index, protection) {
@@ -1090,6 +1091,9 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 							return;
 						}
 					}
+					if (!Twinkle.protect.isWatched) {
+						thispage.setWatchlist(Twinkle.getPref('watchProtectedPages'));
+					}
 				} else {
 					thispage.setCreateProtection(input.createlevel, input.createexpiry);
 					thispage.setWatchlist(false);
@@ -1109,7 +1113,6 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 				}
 
 				thispage.setChangeTags(Twinkle.changeTags);
-				thispage.setWatchlist(Twinkle.getPref('watchProtectedPages'));
 				thispage.protect(next);
 			};
 
@@ -1134,7 +1137,9 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 					statusInited = true;
 				}
 
-				thispage.setWatchlist(Twinkle.getPref('watchProtectedPages'));
+				if (!Twinkle.protect.isWatched) {
+					thispage.setWatchlist(Twinkle.getPref('watchProtectedPages'));
+				}
 				thispage.stabilize(allDone, function(error) {
 					if (error.errorCode === 'stabilize_denied') { // [[phab:T234743]]
 						thispage.getStatusElement().error('Failed trying to modify pending changes settings, likely due to a mediawiki bug. Other actions (tagging or regular protection) may have taken place. Please reload the page and try again.');
@@ -1390,7 +1395,9 @@ Twinkle.protect.callbacks = {
 
 		protectedPage.setEditSummary(summary);
 		protectedPage.setChangeTags(Twinkle.changeTags);
-		protectedPage.setWatchlist(Twinkle.getPref('watchPPTaggedPages'));
+		if (!Twinkle.protect.isWatched) {
+			protectedPage.setWatchlist(Twinkle.getPref('watchPPTaggedPages'));
+		}
 		protectedPage.setPageText(text);
 		protectedPage.setCreateOption('nocreate');
 		protectedPage.suppressProtectWarning(); // no need to let admins know they are editing through protection


### PR DESCRIPTION
#1133 was merged without fully accounting for the fact that providing a watchlist expiry would overwrite indefinite watching, which is nonideal; see #1230.  Like #1230, this is imperfect, as it only provides a boolean for watched or not, and doesn't give any information on an expiry.  We can at least rely on the information being available, though.