### PR TITLE
morebits: use blue colour for "Redirected from" message

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3542,7 +3542,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 				}
 
 				// only notify user for redirects, not normalization
-				Morebits.status.info('Info', 'Redirected from ' + ctx.pageName + ' to ' + resolvedName);
+				new Morebits.status('Note', 'Redirected from ' + ctx.pageName + ' to ' + resolvedName);
 			}
 
 			ctx.pageName = resolvedName; // update to redirect target or normalized name


### PR DESCRIPTION
Morebits.status.info() creates a green-coloured message, which should ideally be reserved for success messages.

 Blue colour is suitable for other info. The "Redirected form X to Y" message being in green, it's easy to miss among the rest.