### PR TITLE
morebits: Fix missing letter in fnLookupNonRedirectCreator

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3714,7 +3714,7 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnLookupNonRedirectCreator = function() {
-		var response = ctx.ookupCreationApi.getResponse().query;
+		var response = ctx.lookupCreationApi.getResponse().query;
 		var revs = response.pages[0].revisions;
 
 		revs.forEach(function(rev) {


### PR DESCRIPTION
The 'l' in `ctx.lookupCreationApi` got left off in #1220 / b4a99751