### PR TITLE
tag: Fix rcat matching when 1= is explicitly used

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1722,7 +1722,7 @@ Twinkle.tag.callbacks = {
 		// Check for all Rcat shell redirects (from #433)
 		if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
 			// Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
-			var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|)((?:[^|{}]*|{{[^}]*}})+)(}})\s*/i);
+			var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|(?:\s*1=)?)((?:[^|{}]*|{{[^}]*}})+)(}})\s*/i);
 			pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
 		} else {
 			// Fold any pre-existing Rcats into taglist and under Rcatshell


### PR DESCRIPTION
Reported at [WT:TW](https://en.wikipedia.org/w/index.php?oldid=994564628#Tag_redirect)