### PR TITLE
Add the {{uw-addalink}} single notice

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1018,6 +1018,10 @@ Twinkle.warn.messages = {
 	},
 
 	singlenotice: {
+		'uw-addalink': {
+			label: 'Mistakes with the Add a Link newcomer task',
+			summary: 'Notice: Mistakes with the Add a Link newcomer task'
+		},
 		'uw-agf-sock': {
 			label: 'Use of multiple accounts (assuming good faith)',
 			summary: 'Notice: Using multiple accounts'


### PR DESCRIPTION
{{[uw-addalink](https://en.wikipedia.org/wiki/Template:Uw-addalink)}} is a new notice template for the Add a Link structured newcomer task, which often ends up with mistaken or superfluous links being added. The discussion that led to the notice (and requested its Twinkle implementation) [can be found here](https://en.wikipedia.org/wiki/Wikipedia_talk:Growth_Team_features#Suggested_links_is_adding_links_to_disambiguation_pages), and the commit [has been tested here](https://test.wikipedia.org/w/index.php?title=User_talk:Chaotic_Enby&diff=prev&oldid=675590).