### PR TITLE
twinkle: show menu on page Special:IPContributions

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -358,7 +358,7 @@ $.ajax({
 Twinkle.load = function () {
 	// Don't activate on special pages other than those listed here, so
 	// that others load faster, especially the watchlist.
-	let activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+	let activeSpecialPageList = [ 'Block', 'Contributions', 'IPContributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
 	if (Morebits.userIsSysop) {
 		activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
 	}


### PR DESCRIPTION
fixes #2223 Special:IPContributions should display the same Twinkle options as Special:Contributions

I manually tested this as a user without advanced permissions, and it just displays a TW -> Config menu, which is acceptable. There must be some code somewhere that detects the permission error and only displays a limited menu.

Hotfix for temporary accounts, so will skip code review. Please comment with any issues, and will do in a follow up.