### PR TITLE
twinklearv.js: Add notice for temporary accounts

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -81,7 +81,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 	});
 
 	// Temporary account notice
-	if (mw.config.get('wgRelevantUserName') && mw.util.isTemporaryUser(mw.config.get('wgRelevantUserName'))) {
+	if (mw.config.get('wgRelevantUserName') && mw.util.isTemporaryUser(mw.config.get('wgRelevantUserName')) && !mw.config.get('wgCheckUserTemporaryAccountIPRevealAllowed')) {
 		const temporaryAccountNotice = form.append({
 			type: 'field',
 			label: 'Temporary account notice',


### PR DESCRIPTION
Exactly what it says on the tin. Wording of the notice by Tamzin, tested on test.wikipedia. Notice color set to `--morebits-color-info` but can be freely changed if needed for readability.