### PR TITLE
twinkleblock.js: add {{uw-tempevadeblock}} (with autoblock) and forTempAccountsOnly

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1092,6 +1092,7 @@ Twinkle.block.blockPresetsInfo = {
 	},
 	'uw-ipevadeblock': {
 		forIPsOnly: true,
+		expiry: '1 week',
 		nocreate: true,
 		reason: '[[WP:Blocking policy#Evasion of blocks|Block evasion]]',
 		summary: 'Your IP address has been blocked from editing because it has been used to [[WP:EVADE|evade a previous block]]'
@@ -1185,6 +1186,7 @@ Twinkle.block.blockPresetsInfo = {
 	},
 	'uw-tempevadeblock': {
 		autoblock: true,
+		expiry: 'infinity',
 		forTempAccountsOnly: true,
 		nocreate: true,
 		reason: '[[WP:Blocking policy#Evasion of blocks|Block evasion]]',


### PR DESCRIPTION
Splits the previous {{uw-ipevadeblock}} (previously used for both IPs and TAs) in two. [Tested on test.wikipedia](https://test.wikipedia.org/wiki/User_talk:~2024-1604), the two warning options show only for IPs and TAs respectively.