### PR TITLE
warn: Remove checks for unused warnings

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1688,8 +1688,7 @@ Twinkle.warn.callbacks = {
 		}
 		if (reason && !isCustom) {
 			// add extra message
-			if (templateName === 'uw-csd' || templateName === 'uw-probation' ||
-				templateName === 'uw-userspacenoindex' || templateName === 'uw-userpage') {
+			if (templateName === 'uw-userpage') {
 				text += "|3=''" + reason + "''";
 			} else {
 				text += "|2=''" + reason + "''";


### PR DESCRIPTION
Remove checks for `uw-csd`, `uw-probation` and `uw-userspacenoindex` in `getWarningWikitext`, as they are not included as available user warnings. Note that `uw-userpage` correctly takes `reason` as parameter 3 ([and the code still generates well!](https://test.wikipedia.org/wiki/User_talk:~2024-7582)), unlike most other single-use templates (and unlike what the default documentation states), so this one stays in place.