### PR TITLE
eslint: switch to camelcase, part 1

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -164,7 +164,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	Twinkle.batchdelete.pages = {};
 
 	const statelem = new Morebits.Status('Grabbing list of pages');
-	const wikipedia_api = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
+	const wikipediaApi = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
 		pages = pages.filter((page) => !page.missing && page.imagerepository !== 'shared');
@@ -236,8 +236,8 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 
 	}), statelem);
 
-	wikipedia_api.params = { form: form, Window: Window };
-	wikipedia_api.post();
+	wikipediaApi.params = { form: form, Window: Window };
+	wikipediaApi.post();
 };
 
 Twinkle.batchdelete.generateNewPageList = function(form) {
@@ -310,7 +310,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				return;
 			}
 
-			const wikipedia_api = new Morebits.wiki.Api('Getting list of subpages of ' + pageName, {
+			const wikipediaApi = new Morebits.wiki.Api('Getting list of subpages of ' + pageName, {
 				action: 'query',
 				prop: 'revisions|info|imageinfo',
 				generator: 'allpages',
@@ -365,8 +365,8 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			}), null /* statusElement */, (() => {
 				subpageLister.workerFailure();
 			}));
-			wikipedia_api.params = { pageNameFull: pageName }; // Used in onSuccess()
-			wikipedia_api.post();
+			wikipediaApi.params = { pageNameFull: pageName }; // Used in onSuccess()
+			wikipediaApi.post();
 
 		}, () => {
 			// List 'em on the interface
@@ -443,15 +443,15 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 			pageDeleter: pageDeleter
 		};
 
-		const wikipedia_page = new Morebits.wiki.Page(pageName, 'Deleting page ' + pageName);
-		wikipedia_page.setCallbackParameters(params);
+		const wikipediaPage = new Morebits.wiki.Page(pageName, 'Deleting page ' + pageName);
+		wikipediaPage.setCallbackParameters(params);
 		if (input.delete_page) {
-			wikipedia_page.setEditSummary(input.reason);
-			wikipedia_page.setChangeTags(Twinkle.changeTags);
-			wikipedia_page.suppressProtectWarning();
-			wikipedia_page.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
+			wikipediaPage.setEditSummary(input.reason);
+			wikipediaPage.setChangeTags(Twinkle.changeTags);
+			wikipediaPage.suppressProtectWarning();
+			wikipediaPage.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
 		} else {
-			Twinkle.batchdelete.callbacks.doExtras(wikipedia_page);
+			Twinkle.batchdelete.callbacks.doExtras(wikipediaPage);
 		}
 	}, () => {
 		if (input.delete_subpages && input.subpages) {
@@ -471,12 +471,12 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 					pageDeleter: subpageDeleter
 				};
 
-				const wikipedia_page = new Morebits.wiki.Page(pageName, 'Deleting subpage ' + pageName);
-				wikipedia_page.setCallbackParameters(params);
-				wikipedia_page.setEditSummary(input.reason);
-				wikipedia_page.setChangeTags(Twinkle.changeTags);
-				wikipedia_page.suppressProtectWarning();
-				wikipedia_page.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
+				const wikipediaPage = new Morebits.wiki.Page(pageName, 'Deleting subpage ' + pageName);
+				wikipediaPage.setCallbackParameters(params);
+				wikipediaPage.setEditSummary(input.reason);
+				wikipediaPage.setChangeTags(Twinkle.changeTags);
+				wikipediaPage.suppressProtectWarning();
+				wikipediaPage.deletePage(Twinkle.batchdelete.callbacks.doExtras, pageDeleter.workerFailure);
 			});
 		}
 	});
@@ -492,7 +492,7 @@ Twinkle.batchdelete.callbacks = {
 		// succeeded by now
 		params.pageDeleter.workerSuccess(thingWithParameters);
 
-		let query, wikipedia_api;
+		let query, wikipediaApi;
 
 		if (params.unlink_page) {
 			Twinkle.batchdelete.unlinkCache = {};
@@ -505,9 +505,9 @@ Twinkle.batchdelete.callbacks = {
 				bllimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			};
-			wikipedia_api = new Morebits.wiki.Api('Grabbing backlinks', query, Twinkle.batchdelete.callbacks.unlinkBacklinksMain);
-			wikipedia_api.params = params;
-			wikipedia_api.post();
+			wikipediaApi = new Morebits.wiki.Api('Grabbing backlinks', query, Twinkle.batchdelete.callbacks.unlinkBacklinksMain);
+			wikipediaApi.params = params;
+			wikipediaApi.post();
 		}
 
 		if (params.unlink_file) {
@@ -518,9 +518,9 @@ Twinkle.batchdelete.callbacks = {
 				iulimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			};
-			wikipedia_api = new Morebits.wiki.Api('Grabbing file links', query, Twinkle.batchdelete.callbacks.unlinkImageInstancesMain);
-			wikipedia_api.params = params;
-			wikipedia_api.post();
+			wikipediaApi = new Morebits.wiki.Api('Grabbing file links', query, Twinkle.batchdelete.callbacks.unlinkImageInstancesMain);
+			wikipediaApi.params = params;
+			wikipediaApi.post();
 		}
 
 		if (params.delete_page) {
@@ -532,9 +532,9 @@ Twinkle.batchdelete.callbacks = {
 					rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 					format: 'json'
 				};
-				wikipedia_api = new Morebits.wiki.Api('Grabbing redirects', query, Twinkle.batchdelete.callbacks.deleteRedirectsMain);
-				wikipedia_api.params = params;
-				wikipedia_api.post();
+				wikipediaApi = new Morebits.wiki.Api('Grabbing redirects', query, Twinkle.batchdelete.callbacks.deleteRedirectsMain);
+				wikipediaApi.params = params;
+				wikipediaApi.post();
 			}
 			if (params.delete_talk) {
 				const pageTitle = mw.Title.newFromText(params.page);
@@ -545,10 +545,10 @@ Twinkle.batchdelete.callbacks = {
 						titles: pageTitle.toText(),
 						format: 'json'
 					};
-					wikipedia_api = new Morebits.wiki.Api('Checking whether talk page exists', query, Twinkle.batchdelete.callbacks.deleteTalk);
-					wikipedia_api.params = params;
-					wikipedia_api.params.talkPage = pageTitle.toText();
-					wikipedia_api.post();
+					wikipediaApi = new Morebits.wiki.Api('Checking whether talk page exists', query, Twinkle.batchdelete.callbacks.deleteTalk);
+					wikipediaApi.params = params;
+					wikipediaApi.params.talkPage = pageTitle.toText();
+					wikipediaApi.post();
 				}
 			}
 		}
@@ -565,10 +565,10 @@ Twinkle.batchdelete.callbacks = {
 		redirectDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		redirectDeleter.setPageList(pages);
 		redirectDeleter.run((pageName) => {
-			const wikipedia_page = new Morebits.wiki.Page(pageName, 'Deleting ' + pageName);
-			wikipedia_page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page [[' + apiobj.params.page + ']]');
-			wikipedia_page.setChangeTags(Twinkle.changeTags);
-			wikipedia_page.deletePage(redirectDeleter.workerSuccess, redirectDeleter.workerFailure);
+			const wikipediaPage = new Morebits.wiki.Page(pageName, 'Deleting ' + pageName);
+			wikipediaPage.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page [[' + apiobj.params.page + ']]');
+			wikipediaPage.setChangeTags(Twinkle.changeTags);
+			wikipediaPage.deletePage(redirectDeleter.workerSuccess, redirectDeleter.workerFailure);
 		});
 	},
 	deleteTalk: function(apiobj) {
@@ -596,12 +596,12 @@ Twinkle.batchdelete.callbacks = {
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run((pageName) => {
-			const wikipedia_page = new Morebits.wiki.Page(pageName, 'Unlinking on ' + pageName);
+			const wikipediaPage = new Morebits.wiki.Page(pageName, 'Unlinking on ' + pageName);
 			const params = $.extend({}, apiobj.params);
 			params.title = pageName;
 			params.unlinker = unlinker;
-			wikipedia_page.setCallbackParameters(params);
-			wikipedia_page.load(Twinkle.batchdelete.callbacks.unlinkBacklinks);
+			wikipediaPage.setCallbackParameters(params);
+			wikipediaPage.load(Twinkle.batchdelete.callbacks.unlinkBacklinks);
 		});
 	},
 	unlinkBacklinks: function(pageobj) {
@@ -618,12 +618,12 @@ Twinkle.batchdelete.callbacks = {
 		} else {
 			text = pageobj.getPageText();
 		}
-		const old_text = text;
+		const oldText = text;
 		const wikiPage = new Morebits.wikitext.Page(text);
 		text = wikiPage.removeLink(params.page).getText();
 
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
-		if (text === old_text) {
+		if (text === oldText) {
 			// Nothing to do, return
 			params.unlinker.workerSuccess(pageobj);
 			return;
@@ -647,12 +647,12 @@ Twinkle.batchdelete.callbacks = {
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run((pageName) => {
-			const wikipedia_page = new Morebits.wiki.Page(pageName, 'Removing file usages on ' + pageName);
+			const wikipediaPage = new Morebits.wiki.Page(pageName, 'Removing file usages on ' + pageName);
 			const params = $.extend({}, apiobj.params);
 			params.title = pageName;
 			params.unlinker = unlinker;
-			wikipedia_page.setCallbackParameters(params);
-			wikipedia_page.load(Twinkle.batchdelete.callbacks.unlinkImageInstances);
+			wikipediaPage.setCallbackParameters(params);
+			wikipediaPage.load(Twinkle.batchdelete.callbacks.unlinkImageInstances);
 		});
 	},
 	unlinkImageInstances: function(pageobj) {
@@ -670,12 +670,12 @@ Twinkle.batchdelete.callbacks = {
 		} else {
 			text = pageobj.getPageText();
 		}
-		const old_text = text;
+		const oldText = text;
 		const wikiPage = new Morebits.wikitext.Page(text);
 		text = wikiPage.commentOutImage(image, 'Commented out because image was deleted').getText();
 
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
-		if (text === old_text) {
+		if (text === oldText) {
 			pageobj.getStatusElement().error('failed to unlink image ' + image + ' from ' + pageobj.getPageName());
 			params.unlinker.workerFailure(pageobj);
 			return;

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -173,7 +173,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 	const statelem = new Morebits.Status('Grabbing list of pages');
 
-	const wikipedia_api = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
+	const wikipediaApi = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		const pages = (response.query && response.query.pages) || [];
 		const list = [];
@@ -245,7 +245,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 	}), statelem);
 
-	wikipedia_api.post();
+	wikipediaApi.post();
 };
 
 Twinkle.batchprotect.currentProtectCounter = 0;
@@ -287,13 +287,13 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 			titles: pageName,
 			format: 'json'
 		};
-		const wikipedia_api = new Morebits.wiki.Api('Checking if page ' + pageName + ' exists', query,
+		const wikipediaApi = new Morebits.wiki.Api('Checking if page ' + pageName + ' exists', query,
 			Twinkle.batchprotect.callbacks.main, null, batchOperation.workerFailure);
-		wikipedia_api.params = $.extend({
+		wikipediaApi.params = $.extend({
 			page: pageName,
 			batchOperation: batchOperation
 		}, input);
-		wikipedia_api.post();
+		wikipediaApi.post();
 	});
 };
 

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -61,7 +61,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		format: 'json'
 	};
 	const statelem = new Morebits.Status('Grabbing list of pages');
-	const wikipedia_api = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
+	const wikipediaApi = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
 		pages = pages.filter((page) => page.missing);
@@ -108,8 +108,8 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		Morebits.QuickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
 
 	}), statelem);
-	wikipedia_api.params = { form: form, Window: Window };
-	wikipedia_api.post();
+	wikipediaApi.params = { form: form, Window: Window };
+	wikipediaApi.post();
 };
 
 Twinkle.batchundelete.callback.evaluate = function(event) {
@@ -146,13 +146,13 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 			pageUndeleter: pageUndeleter
 		};
 
-		const wikipedia_page = new Morebits.wiki.Page(pageName, 'Undeleting page ' + pageName);
-		wikipedia_page.setCallbackParameters(params);
-		wikipedia_page.setEditSummary(input.reason);
-		wikipedia_page.setChangeTags(Twinkle.changeTags);
-		wikipedia_page.suppressProtectWarning();
-		wikipedia_page.setMaxRetries(3); // temporary increase from 2 to make batchundelete more likely to succeed [[phab:T222402]] #613
-		wikipedia_page.undeletePage(Twinkle.batchundelete.callbacks.doExtras, pageUndeleter.workerFailure);
+		const wikipediaPage = new Morebits.wiki.Page(pageName, 'Undeleting page ' + pageName);
+		wikipediaPage.setCallbackParameters(params);
+		wikipediaPage.setEditSummary(input.reason);
+		wikipediaPage.setChangeTags(Twinkle.changeTags);
+		wikipediaPage.suppressProtectWarning();
+		wikipediaPage.setMaxRetries(3); // temporary increase from 2 to make batchundelete more likely to succeed [[phab:T222402]] #613
+		wikipediaPage.undeletePage(Twinkle.batchundelete.callbacks.doExtras, pageUndeleter.workerFailure);
 	});
 };
 
@@ -166,7 +166,7 @@ Twinkle.batchundelete.callbacks = {
 		// succeeded by now
 		params.pageUndeleter.workerSuccess(thingWithParameters);
 
-		let query, wikipedia_api;
+		let query, wikipediaApi;
 
 		if (params.undel_talk) {
 			const talkpagename = new mw.Title(params.page).getTalkPage().getPrefixedText();
@@ -179,10 +179,10 @@ Twinkle.batchundelete.callbacks = {
 					titles: talkpagename,
 					format: 'json'
 				};
-				wikipedia_api = new Morebits.wiki.Api('Checking talk page for deleted revisions', query, Twinkle.batchundelete.callbacks.undeleteTalk);
-				wikipedia_api.params = params;
-				wikipedia_api.params.talkPage = talkpagename;
-				wikipedia_api.post();
+				wikipediaApi = new Morebits.wiki.Api('Checking talk page for deleted revisions', query, Twinkle.batchundelete.callbacks.undeleteTalk);
+				wikipediaApi.params = params;
+				wikipediaApi.params.talkPage = talkpagename;
+				wikipediaApi.post();
 			}
 		}
 	},

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -308,7 +308,7 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 };
 
 Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction(e) {
-	let field_preset, field_template_options, field_block_options;
+	let fieldPreset, fieldTemplateOptions, fieldBlockOptions;
 	const $form = $(e.target.form);
 	// Make ifs shorter
 	const blockBox = $form.find('[name=actiontype][value=block]').is(':checked');
@@ -355,8 +355,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	Twinkle.block.callback.saveFieldset($('[name=field_template_options]'));
 
 	if (blockBox) {
-		field_preset = new Morebits.QuickForm.Element({ type: 'field', label: 'Preset', name: 'field_preset' });
-		field_preset.append({
+		fieldPreset = new Morebits.QuickForm.Element({ type: 'field', label: 'Preset', name: 'field_preset' });
+		fieldPreset.append({
 			type: 'select',
 			name: 'preset',
 			label: 'Choose a preset:',
@@ -364,10 +364,10 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			list: Twinkle.block.callback.filtered_block_groups(blockGroup)
 		});
 
-		field_block_options = new Morebits.QuickForm.Element({ type: 'field', label: 'Block options', name: 'field_block_options' });
-		field_block_options.append({ type: 'div', name: 'currentblock', label: ' ' });
-		field_block_options.append({ type: 'div', name: 'hasblocklog', label: ' ' });
-		field_block_options.append({
+		fieldBlockOptions = new Morebits.QuickForm.Element({ type: 'field', label: 'Block options', name: 'field_block_options' });
+		fieldBlockOptions.append({ type: 'div', name: 'currentblock', label: ' ' });
+		fieldBlockOptions.append({ type: 'div', name: 'hasblocklog', label: ' ' });
+		fieldBlockOptions.append({
 			type: 'select',
 			name: 'expiry_preset',
 			label: 'Expiry:',
@@ -393,7 +393,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				{ label: '3 years', value: '3 years' }
 			]
 		});
-		field_block_options.append({
+		fieldBlockOptions.append({
 			type: 'input',
 			name: 'expiry',
 			label: 'Custom expiry',
@@ -402,7 +402,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		});
 
 		if (partialBox) { // Partial block
-			field_block_options.append({
+			fieldBlockOptions.append({
 				type: 'select',
 				multiple: true,
 				name: 'pagerestrictions',
@@ -410,7 +410,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				value: '',
 				tooltip: '10 page max.'
 			});
-			const ns = field_block_options.append({
+			const ns = fieldBlockOptions.append({
 				type: 'select',
 				multiple: true,
 				name: 'namespacerestrictions',
@@ -471,12 +471,12 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			value: '1'
 		});
 
-		field_block_options.append({
+		fieldBlockOptions.append({
 			type: 'checkbox',
 			name: 'blockoptions',
 			list: blockoptions
 		});
-		field_block_options.append({
+		fieldBlockOptions.append({
 			type: 'textarea',
 			label: 'Reason (for block log):',
 			name: 'reason',
@@ -484,14 +484,14 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			value: Twinkle.block.field_block_options.reason
 		});
 
-		field_block_options.append({
+		fieldBlockOptions.append({
 			type: 'div',
 			name: 'filerlog_label',
 			label: 'See also:',
 			style: 'display:inline-block;font-style:normal !important',
 			tooltip: 'Insert a "see also" message to indicate whether the filter log or deleted contributions played a role in the decision to block.'
 		});
-		field_block_options.append({
+		fieldBlockOptions.append({
 			type: 'checkbox',
 			name: 'filter_see_also',
 			event: Twinkle.block.callback.toggle_see_alsos,
@@ -504,7 +504,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				}
 			]
 		});
-		field_block_options.append({
+		fieldBlockOptions.append({
 			type: 'checkbox',
 			name: 'deleted_see_also',
 			event: Twinkle.block.callback.toggle_see_alsos,
@@ -520,7 +520,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 		// Yet-another-logevents-doesn't-handle-ranges-well
 		if (blockedUserName === relevantUserName) {
-			field_block_options.append({ type: 'hidden', name: 'reblock', value: '1' });
+			fieldBlockOptions.append({ type: 'hidden', name: 'reblock', value: '1' });
 		}
 	}
 
@@ -544,8 +544,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		event: Twinkle.block.callback.toggle_ds_reason
 	};
 	if (templateBox) {
-		field_template_options = new Morebits.QuickForm.Element({ type: 'field', label: 'Template options', name: 'field_template_options' });
-		field_template_options.append({
+		fieldTemplateOptions = new Morebits.QuickForm.Element({ type: 'field', label: 'Template options', name: 'field_template_options' });
+		fieldTemplateOptions.append({
 			type: 'select',
 			name: 'template',
 			label: 'Choose talk page template:',
@@ -555,9 +555,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		});
 
 		// Only visible for aeblock and aepblock, toggled in change_template
-		field_template_options.append(dsSelectSettings);
+		fieldTemplateOptions.append(dsSelectSettings);
 
-		field_template_options.append({
+		fieldTemplateOptions.append({
 			type: 'input',
 			name: 'article',
 			label: 'Linked page',
@@ -566,7 +566,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		});
 
 		// Only visible if partial and not blocking
-		field_template_options.append({
+		fieldTemplateOptions.append({
 			type: 'input',
 			name: 'area',
 			label: 'Area blocked from',
@@ -575,7 +575,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		});
 
 		if (!blockBox) {
-			field_template_options.append({
+			fieldTemplateOptions.append({
 				type: 'input',
 				name: 'template_expiry',
 				label: 'Period of blocking:',
@@ -583,7 +583,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				tooltip: 'The period the blocking is due for, for example 24 hours, 2 weeks, indefinite etc...'
 			});
 		}
-		field_template_options.append({
+		fieldTemplateOptions.append({
 			type: 'input',
 			name: 'block_reason',
 			label: '"You have been blocked for ..."',
@@ -592,7 +592,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		});
 
 		if (blockBox) {
-			field_template_options.append({
+			fieldTemplateOptions.append({
 				type: 'checkbox',
 				name: 'blank_duration',
 				list: [
@@ -604,7 +604,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				]
 			});
 		} else {
-			field_template_options.append({
+			fieldTemplateOptions.append({
 				type: 'checkbox',
 				list: [
 					{
@@ -634,23 +634,23 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			Twinkle.block.callback.preview($form[0]);
 		});
 		$previewlink.css({cursor: 'pointer'});
-		field_template_options.append({ type: 'div', id: 'blockpreview', label: [ $previewlink[0] ] });
-		field_template_options.append({ type: 'div', id: 'twinkleblock-previewbox', style: 'display: none' });
-	} else if (field_preset) {
+		fieldTemplateOptions.append({ type: 'div', id: 'blockpreview', label: [ $previewlink[0] ] });
+		fieldTemplateOptions.append({ type: 'div', id: 'twinkleblock-previewbox', style: 'display: none' });
+	} else if (fieldPreset) {
 		// Only visible for arbitration enforcement, toggled in change_preset
-		field_preset.append(dsSelectSettings);
+		fieldPreset.append(dsSelectSettings);
 	}
 
 	let oldfield;
-	if (field_preset) {
+	if (fieldPreset) {
 		oldfield = $form.find('fieldset[name="field_preset"]')[0];
-		oldfield.parentNode.replaceChild(field_preset.render(), oldfield);
+		oldfield.parentNode.replaceChild(fieldPreset.render(), oldfield);
 	} else {
 		$form.find('fieldset[name="field_preset"]').hide();
 	}
-	if (field_block_options) {
+	if (fieldBlockOptions) {
 		oldfield = $form.find('fieldset[name="field_block_options"]')[0];
-		oldfield.parentNode.replaceChild(field_block_options.render(), oldfield);
+		oldfield.parentNode.replaceChild(fieldBlockOptions.render(), oldfield);
 		$form.find('fieldset[name="field_64"]').show();
 
 		$form.find('[name=pagerestrictions]').select2({
@@ -732,9 +732,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		$form.find('[name=namespacerestrictions]').val(null).trigger('change');
 	}
 
-	if (field_template_options) {
+	if (fieldTemplateOptions) {
 		oldfield = $form.find('fieldset[name="field_template_options"]')[0];
-		oldfield.parentNode.replaceChild(field_template_options.render(), oldfield);
+		oldfield.parentNode.replaceChild(fieldTemplateOptions.render(), oldfield);
 		e.target.form.root.previewer = new Morebits.wiki.Preview($(e.target.form.root).find('#twinkleblock-previewbox').last()[0]);
 	} else {
 		$form.find('fieldset[name="field_template_options"]').hide();
@@ -1467,7 +1467,7 @@ Twinkle.block.blockGroupsPartial = [
 	}
 ];
 
-Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilteredBlockGroups(group, show_template) {
+Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilteredBlockGroups(group, showTemplate) {
 	return $.map(group, (blockGroup) => {
 		const list = $.map(blockGroup.list, (blockPreset) => {
 			switch (blockPreset.value) {
@@ -1514,10 +1514,10 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 				allowedUserType = true;
 			}
 
-			if (!(blockSettings.templateName && show_template) && allowedUserType) {
+			if (!(blockSettings.templateName && showTemplate) && allowedUserType) {
 				const templateName = blockSettings.templateName || blockPreset.value;
 				return {
-					label: (show_template ? '{{' + templateName + '}}: ' : '') + blockPreset.label,
+					label: (showTemplate ? '{{' + templateName + '}}: ' : '') + blockPreset.label,
 					value: blockPreset.value,
 					data: [{
 						name: 'template-name',
@@ -1943,9 +1943,9 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Actions complete, loading user talk page in a few seconds';
 
-	const wikipedia_page = new Morebits.wiki.Page(userTalkPage, 'User talk page modification');
-	wikipedia_page.setCallbackParameters(params);
-	wikipedia_page.load(Twinkle.block.callback.main);
+	const wikipediaPage = new Morebits.wiki.Page(userTalkPage, 'User talk page modification');
+	wikipediaPage.setCallbackParameters(params);
+	wikipediaPage.load(Twinkle.block.callback.main);
 };
 
 Twinkle.block.combineFormDataAndFieldTemplateOptions = function(formData, messageData, reason, disabletalk, noemail, nocreate) {

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1553,9 +1553,9 @@ Twinkle.config.save = function twinkleconfigSave(e) {
 	Morebits.Status.init(document.getElementById('twinkle-config-content'));
 
 	const userjs = mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user] + ':' + mw.config.get('wgUserName') + '/twinkleoptions.js';
-	const wikipedia_page = new Morebits.wiki.Page(userjs, 'Saving preferences to ' + userjs);
-	wikipedia_page.setCallbackParameters(e.target);
-	wikipedia_page.load(Twinkle.config.writePrefs);
+	const wikipediaPage = new Morebits.wiki.Page(userjs, 'Saving preferences to ' + userjs);
+	wikipediaPage.setCallbackParameters(e.target);
+	wikipediaPage.load(Twinkle.config.writePrefs);
 
 	return false;
 };

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -52,7 +52,7 @@ Twinkle.deprod.callback = function() {
 	};
 
 	const statelem = new Morebits.Status('Grabbing list of pages');
-	const wikipedia_api = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
+	const wikipediaApi = new Morebits.wiki.Api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		const pages = (response.query && response.query.pages) || [];
 		const list = [];
@@ -112,8 +112,8 @@ Twinkle.deprod.callback = function() {
 		Morebits.QuickForm.getElements(rendered, 'pages').forEach(Twinkle.generateBatchPageLinks);
 	}), statelem);
 
-	wikipedia_api.params = { form: form, Window: Window };
-	wikipedia_api.post();
+	wikipediaApi.params = { form: form, Window: Window };
+	wikipediaApi.post();
 };
 
 var callback_commit = function(event) {
@@ -134,9 +134,9 @@ var callback_commit = function(event) {
 				rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			};
-			let wikipedia_api = new Morebits.wiki.Api('Grabbing redirects', query, callback_deleteRedirects);
-			wikipedia_api.params = params;
-			wikipedia_api.post();
+			let wikipediaApi = new Morebits.wiki.Api('Grabbing redirects', query, callback_deleteRedirects);
+			wikipediaApi.params = params;
+			wikipediaApi.post();
 
 			const pageTitle = mw.Title.newFromText(pageName);
 			// Don't delete user talk pages, limiting this to Talk: pages since only article and user pages appear in deprod
@@ -147,10 +147,10 @@ var callback_commit = function(event) {
 					titles: pageTitle.toText(),
 					format: 'json'
 				};
-				wikipedia_api = new Morebits.wiki.Api('Checking whether ' + pageName + ' has a talk page', query,
+				wikipediaApi = new Morebits.wiki.Api('Checking whether ' + pageName + ' has a talk page', query,
 					callback_deleteTalk);
-				wikipedia_api.params = params;
-				wikipedia_api.post();
+				wikipediaApi.params = params;
+				wikipediaApi.post();
 			}
 
 			var page = new Morebits.wiki.Page(pageName, 'Deleting page ' + pageName);


### PR DESCRIPTION
**Why**
* fix eslint warnings
* standardize appearance of variables in this repo (is currently a mix of snake_case and camelCase)

**What**
* Rename some variables from snake_case to camelCase.

I did this in a semi-automated fashion. I used the F2 button in VS Code, which renames a variable. This should be less risky than doing it manually, but could still be prone to bugs 1) if it's a global variable, 2) if a variable of the same name already exists, etc.

If this deploy goes well and isn't buggy, I'll do the conversion to camelcase in more files in follow up patches.