### PR TITLE
block: add checkbox for related TAs to seeAlsos

### DIFF
--- a/src/modules/twinkleblock.js
+++ b/src/modules/twinkleblock.js
@@ -1579,13 +1579,13 @@ Twinkle.block.callback.change_expiry = function twinkleblockCallbackChangeExpiry
 
 Twinkle.block.seeAlsos = [];
 Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSeeAlso() {
-	function joinEnum(e) {
+	const joinEnum = function(e) {
 		if (e.length >= 3) {
 			return e.slice(0, -1).join(', ') + ' and ' + e[e.length - 1];
 		} else {
 			return e.join(' and ');
 		}
-	}
+	};
 	const reason = this.form.reason.value.replace(
 		new RegExp('( <!--|;) see also ' + joinEnum(Twinkle.block.seeAlsos) + '( -->)?'), ''
 	);


### PR DESCRIPTION
Exactly what it says on the tin. Shows up only for temporary accounts.
<img width="789" height="227" alt="image" src="https://github.com/user-attachments/assets/88532e27-5cab-448d-b02e-775935fe74ea" />