### PR TITLE
Support recipient-level optout for Twinkle notices

### DIFF
--- a/src/modules/twinkleprod.js
+++ b/src/modules/twinkleprod.js
@@ -347,7 +347,7 @@ Twinkle.prod.callbacks = {
 		return def;
 	},
 
-	notifyAuthor: function twinkleprodNotifyAuthor() {
+	notifyAuthor: async function twinkleprodNotifyAuthor() {
 		const def = $.Deferred();
 
 		if (!params.blp && !params.usertalk) {
@@ -359,6 +359,11 @@ Twinkle.prod.callbacks = {
 			Morebits.Status.info('Notifying creator', 'You (' + params.initialContrib + ') created this page; skipping user notification');
 			return def.resolve();
 		}
+
+		if (await Twinkle.hasUserOptedOutOfNotice(params.initialContrib, ['prod'])) {
+			return def.resolve();
+		}
+
 		// [[Template:Proposed deletion notify]] supports File namespace
 		let notifyTemplate;
 		if (params.blp) {

--- a/src/modules/twinklespeedy.js
+++ b/src/modules/twinklespeedy.js
@@ -1329,7 +1329,7 @@ Twinkle.speedy.callbacks = {
 		api.post();
 	},
 
-	noteToCreator: function(pageobj) {
+	noteToCreator: async function(pageobj) {
 		const params = pageobj.getCallbackParameters();
 		let initialContrib = pageobj.getCreator();
 
@@ -1354,7 +1354,8 @@ Twinkle.speedy.callbacks = {
 			initialContrib = null;
 		}
 
-		if (initialContrib) {
+		// TODO: allow opting out of specific CSD criteria
+		if (initialContrib && !await Twinkle.hasUserOptedOutOfNotice(initialContrib, ['csd'])) {
 			const usertalkpage = new Morebits.wiki.Page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 			let notifytext, i, editsummary;
 

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -896,7 +896,7 @@ Twinkle.xfd.callbacks = {
 	 * @param {string} [actionName] Alternative description of the action
 	 * being undertaken. Required if not notifying a user talk page.
 	 */
-	notifyUser: function(params, notifyTarget, noLog, actionName) {
+	notifyUser: async function(params, notifyTarget, noLog, actionName) {
 		// Ensure items with User talk or no namespace prefix both end
 		// up at user talkspace as expected, but retain the
 		// prefix-less username for addToLog
@@ -911,6 +911,10 @@ Twinkle.xfd.callbacks = {
 
 				// if we thought we would notify someone but didn't,
 				// then jump to logging.
+				Twinkle.xfd.callbacks.addToLog(params, null);
+				return;
+			}
+			if (await Twinkle.hasUserOptedOutOfNotice(usernameOrTarget, ['xfd', params.venue])) {
 				Twinkle.xfd.callbacks.addToLog(params, null);
 				return;
 			}


### PR DESCRIPTION
Allows users to opt out from CSD/PROD/XFD notices by placing {{Twinkle optout}} on their talk page. The template creates an invisible external link to `https://optout.twinkle` with a `types` query param being the list of opted-out notice types. Opting out of specific CSD criteria notices is left for later, but opting out from specific XfD venues is supported. See https://en.wikipedia.org/wiki/Template:Twinkle_optout for usage details.

In Twinkle, we use a prop=extlinks API call to check for external links to that domain and parse the `types` parameter. An external link is used because it's the only way to create metadata that can be modified in wikitext and also accessed via the API.

This is a popular request, the most recent version being https://en.wikipedia.org/wiki/Wikipedia:Village_pump_(technical)#Mute_feature_not_working.