### PR TITLE
morebits: invoke event callback on input event instead of keyup

### DIFF
--- a/src/morebits.js
+++ b/src/morebits.js
@@ -695,7 +695,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				}
 			});
 			if (data.event) {
-				subnode.addEventListener('keyup', data.event, false);
+				subnode.addEventListener('input', data.event, false);
 			}
 
 			childContainer = subnode;
@@ -815,7 +815,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				subnode.setAttribute('required', 'disabled');
 			}
 			if (data.event) {
-				subnode.addEventListener('keyup', data.event, false);
+				subnode.addEventListener('input', data.event, false);
 			}
 			node.style.marginRight = '3px';
 			break;


### PR DESCRIPTION
In addition to keypresses, the input event also gets fired when the field value is changed via paste or drag-drop.

Closes #2050