### PR TITLE
Make linter pass without warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,25 +30,25 @@
 
 		// non-default rules we do like
 		"no-nested-ternary": "error",
-		
+
 		// rules we should probably fix someday
-		"camelcase": ["warn", {"properties": "never"}],
-		"mediawiki/class-doc": "warn",
-		"new-cap": "warn",
-		"no-jquery/no-done-fail": "warn",
-		"no-jquery/no-each-util": "warn",
-		"no-jquery/no-extend": "warn",
-		"no-jquery/no-grep": "warn",
-		"no-jquery/no-in-array": "warn",
-		"no-jquery/no-map-util": "warn",
-		"no-jquery/no-parse-html-literal": "warn",
-		"no-jquery/no-sizzle": "warn",
-		"no-loop-func": "warn",
-		"no-new": "warn",
-		"no-script-url": "warn",
-		"no-unused-expressions": "warn",
-		"no-use-before-define": "warn",
-		"no-var": "warn",
-		"unicorn/prefer-string-slice": "warn"
+		"camelcase": ["off", {"properties": "never"}],
+		"mediawiki/class-doc": "off",
+		"new-cap": "off",
+		"no-jquery/no-done-fail": "off",
+		"no-jquery/no-each-util": "off",
+		"no-jquery/no-extend": "off",
+		"no-jquery/no-grep": "off",
+		"no-jquery/no-in-array": "off",
+		"no-jquery/no-map-util": "off",
+		"no-jquery/no-parse-html-literal": "off",
+		"no-jquery/no-sizzle": "off",
+		"no-loop-func": "off",
+		"no-new": "off",
+		"no-script-url": "off",
+		"no-unused-expressions": "off",
+		"no-use-before-define": "off",
+		"no-var": "off",
+		"unicorn/prefer-string-slice": "off"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"deploy": "node scripts/deploy.js",
 		"deploy:cd": "node scripts/deploy.js -y",
 		"lint:fix": "eslint . --fix",
-		"lint": "eslint .",
+		"lint": "eslint . --max-warnings=0",
 		"start": "node scripts/dev-server.js",
 		"test": "jest"
 	},

--- a/src/modules/twinklewarn.js
+++ b/src/modules/twinklewarn.js
@@ -1798,6 +1798,9 @@ Twinkle.warn.callbacks = {
 		}
 		return [latest, history];
 	},
+
+	// False positive
+	// eslint-disable-next-line jsdoc/require-returns-check
 	/**
 	 * Main loop for deciding what the level should increment to. Most of
 	 * this is really just error catching and updating the subsequent data.

--- a/src/morebits.js
+++ b/src/morebits.js
@@ -228,8 +228,8 @@ Morebits.createHtml = function(input) {
 /**
  * Converts wikilinks to HTML anchor tags.
  *
- * @param text
- * @return {*}
+ * @param {string} text
+ * @return {string}
  */
 Morebits.createHtml.renderWikilinks = function (text) {
 	const ub = new Morebits.unbinder(text);
@@ -1444,8 +1444,8 @@ Morebits.string = {
 	 * @param {string} end
 	 * @param {(string[]|string)} [skiplist]
 	 * @return {string[]}
-	 * @throws If the `start` and `end` strings aren't of the same length.
-	 * @throws If `skiplist` isn't an array or string
+	 * @throws {Error} If the `start` and `end` strings aren't of the same length.
+	 * @throws {Error} If `skiplist` isn't an array or string
 	 */
 	splitWeightedByKeys: function(str, start, end, skiplist) {
 		if (start.length !== end.length) {
@@ -1584,7 +1584,7 @@ Morebits.array = {
 	 *
 	 * @param {Array} arr
 	 * @return {Array} A copy of the array with duplicates removed.
-	 * @throws When provided a non-array.
+	 * @throws {Error} When provided a non-array.
 	 */
 	uniq: function(arr) {
 		if (!Array.isArray(arr)) {
@@ -1599,7 +1599,7 @@ Morebits.array = {
 	 * @param {Array} arr
 	 * @return {Array} A copy of the array with the first instance of each value
 	 * removed; subsequent instances of those values (duplicates) remain.
-	 * @throws When provided a non-array.
+	 * @throws {Error} When provided a non-array.
 	 */
 	dups: function(arr) {
 		if (!Array.isArray(arr)) {
@@ -1614,7 +1614,7 @@ Morebits.array = {
 	 * @param {Array} arr
 	 * @param {number} size - Size of each chunk (except the last, which could be different).
 	 * @return {Array[]} An array containing the smaller, chunked arrays.
-	 * @throws When provided a non-array.
+	 * @throws {Error} When provided a non-array.
 	 */
 	chunk: function(arr, size) {
 		if (!Array.isArray(arr)) {
@@ -1750,7 +1750,7 @@ Morebits.unbinder.prototype = {
 	 *
 	 * @param {string} prefix
 	 * @param {string} postfix
-	 * @throws If either `prefix` or `postfix` is missing.
+	 * @throws {Error} If either `prefix` or `postfix` is missing.
 	 */
 	unbind: function UnbinderUnbind(prefix, postfix) {
 		if (!prefix || !postfix) {
@@ -1959,7 +1959,7 @@ Morebits.date.prototype = {
 	 *
 	 * @param {number} number - Should be an integer.
 	 * @param {string} unit
-	 * @throws If invalid or unsupported unit is given.
+	 * @throws {Error} If invalid or unsupported unit is given.
 	 * @return {Morebits.date}
 	 */
 	add: function(number, unit) {
@@ -1989,7 +1989,7 @@ Morebits.date.prototype = {
 	 *
 	 * @param {number} number - Should be an integer.
 	 * @param {string} unit
-	 * @throws If invalid or unsupported unit is given.
+	 * @throws {Error} If invalid or unsupported unit is given.
 	 * @return {Morebits.date}
 	 */
 	subtract: function(number, unit) {
@@ -3792,7 +3792,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 * or require checking protection or watched status, maintain the query
 	 * in one place. Used for {@link Morebits.wiki.page#deletePage|delete},
 	 * {@link Morebits.wiki.page#undeletePage|undelete},
-	 * {@link* Morebits.wiki.page#protect|protect},
+	 * {@link Morebits.wiki.page#protect|protect},
 	 * {@link Morebits.wiki.page#stabilize|stabilize},
 	 * and {@link Morebits.wiki.page#move|move}
 	 * (basically, just not {@link Morebits.wiki.page#load|load}).
@@ -5211,7 +5211,7 @@ Morebits.status = function Status(text, stat, type) {
  *
  * @memberof Morebits.status
  * @param {HTMLElement} root - Usually a div element.
- * @throws If `root` is not an `HTMLElement`.
+ * @throws {Error} If `root` is not an `HTMLElement`.
  */
 Morebits.status.init = function(root) {
 	if (!(root instanceof Element)) {
@@ -5229,7 +5229,7 @@ Morebits.status.root = null;
 /**
  * @memberof Morebits.status
  * @param {Function} handler - Function to execute on error.
- * @throws When `handler` is not a function.
+ * @throws {Error} When `handler` is not a function.
  */
 Morebits.status.onError = function(handler) {
 	if (typeof handler === 'function') {
@@ -5419,8 +5419,8 @@ Morebits.htmlNode = function (type, content, color) {
  * (`window.addCheckboxClickHandlers`) has some restrictions, and doesn't work
  * with checkboxes inside a sortable table, so let's build our own.
  *
- * @param jQuerySelector
- * @param jQueryContext
+ * @param {jQuery} jQuerySelector
+ * @param {jQuery} jQueryContext
  */
 Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
 	let lastCheckbox = null;

--- a/src/twinkle.js
+++ b/src/twinkle.js
@@ -274,7 +274,7 @@ Twinkle.addPortlet = function() {
 /**
  * Builds a portlet menu if it doesn't exist yet, and adds a portlet link. This function runs at the top of every Twinkle module, ensuring that the first module to be loaded adds the portlet, and that every module can add a link to itself to the portlet.
  *
- * @param task Either a URL for the portlet link or a function to execute.
+ * @param {string|Function} task Either a URL for the portlet link or a function to execute.
  */
 Twinkle.addPortletLink = function(task, text, id, tooltip) {
 	// Create a portlet to hold all the portlet links (if not created already). And get the portletId.

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -3,16 +3,16 @@
 		"wikimedia/server"
 	],
 	"env": {
-		"jest": true
+		"jest": true,
+		// Runs in node environment, but a fake browser env is created via JSDOM
+		"browser": true,
+		"jquery": true
 	},
 	"globals": {
 		"assert": "readonly",
-		"document": "readonly",
-		"jQuery": "readonly",
 		"Morebits": "readonly",
 		"mw": "readonly",
-		"Twinkle": "readonly",
-		"window": "readonly"
+		"Twinkle": "readonly"
 	},
 	"root": true,
 	"rules": {

--- a/tests/morebits.quickForm.js
+++ b/tests/morebits.quickForm.js
@@ -3,7 +3,8 @@
 /**
  * Simple helper to render a quickform element
  *
- * @param data
+ * @param {Object} data
+ * @return {HTMLElement}
  */
 function renderElement(data) {
 	return new Morebits.QuickForm.Element(data).render();


### PR DESCRIPTION
`npm run lint` currently raises over 800 warnings, which makes it hard to find any newly introduced errors, or even newly introduced warnings. I doubt anyone is paying attention to warnings when there are so many of them.

While we should probably fix these rule violations some day, for now I think it's better to set them to `off` instead of `warn`. I fixed the jsdoc lint rules not mentioned in the conf file which were also raising warnings.