### PR TITLE
fix workflows running twice

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Linter
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   lint:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,6 +1,10 @@
 name: Unit tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   lint:


### PR DESCRIPTION
Why
- when people with Twinkle write access write a branch to the Twinkle repo, then use it in a PR, it causes the PR to run the workflows "lint" and "unit test" twice each.

What
- fix this bug. "lint" and "unit test" will now only run one time each