### PR TITLE
Add {{uw-gender}}

### DIFF
--- a/src/modules/twinklewarn.js
+++ b/src/modules/twinklewarn.js
@@ -1138,6 +1138,11 @@ Twinkle.warn.messages = {
 			label: 'Not communicating in English',
 			summary: 'Notice: Not communicating in English'
 		},
+		'uw-gender': {
+			label: 'Misgendering BLPs',
+			summary: 'Notice: Please read the Manual of Style section on gender identity',
+			suppressArticleInSummary: true // non-standard summary wording, so postfixing article title doesn't make sense
+		},
 		'uw-hasty': {
 			label: 'Hasty addition of speedy deletion tags',
 			summary: 'Notice: Allow creators time to improve their articles before tagging them for deletion'


### PR DESCRIPTION
Added new template {{uw-gender}} to gentle warn users about misgendering BLP subjects.

Summary wording chosen to avoid the word "misgendering", which might feel accusatory or controversial to some editors, so a more neutral suggestion to read MOS:GENDERID is used instead.