### PR TITLE
speedy: remove X3 criterion

### DIFF
--- a/src/modules/twinkleconfig.js
+++ b/src/modules/twinkleconfig.js
@@ -33,8 +33,7 @@ Twinkle.config.commonSets = {
 		g1: 'G1', g2: 'G2', g3: 'G3', g4: 'G4', g5: 'G5', g6: 'G6', g7: 'G7', g8: 'G8', g10: 'G10', g11: 'G11', g12: 'G12', g13: 'G13', g14: 'G14', g15: 'G15',
 		r2: 'R2', r3: 'R3', r4: 'R4',
 		t5: 'T5',
-		u1: 'U1', u2: 'U2', u6: 'U6', u7: 'U7',
-		x3: 'X3'
+		u1: 'U1', u2: 'U2', u6: 'U6', u7: 'U7'
 	},
 	csdCriteriaNotification: {
 		db: 'Custom rationale ({{db}})',
@@ -43,8 +42,7 @@ Twinkle.config.commonSets = {
 		f1: 'F1', f2: 'F2', f3: 'F3', f7: 'F7', f9: 'F9',
 		g1: 'G1', g2: 'G2', g3: 'G3', g4: 'G4', g5: 'G5 ("general sanction violation" only)', g6: 'G6 ("copy-paste move" only)', g10: 'G10', g11: 'G11', g12: 'G12', g13: 'G13', g14: 'G14', g15: 'G15',
 		r2: 'R2', r3: 'R3', r4: 'R4',
-		u6: 'U6', u7: 'U7',
-		x3: 'X3'
+		u6: 'U6', u7: 'U7'
 	},
 	csdAndImageDeletionCriteria: {
 		db: 'Custom rationale ({{db}})',
@@ -54,8 +52,7 @@ Twinkle.config.commonSets = {
 		g1: 'G1', g2: 'G2', g3: 'G3', g4: 'G4', g5: 'G5', g6: 'G6', g7: 'G7', g8: 'G8', g10: 'G10', g11: 'G11', g12: 'G12', g13: 'G13', g14: 'G14', g15: 'G15',
 		r2: 'R2', r3: 'R3', r4: 'R4',
 		t5: 'T5',
-		u1: 'U1', u2: 'U2', u6: 'U6', u7: 'U7',
-		x3: 'X3'
+		u1: 'U1', u2: 'U2', u6: 'U6', u7: 'U7'
 	},
 	namespacesNoSpecial: {
 		0: 'Article',

--- a/src/modules/twinklespeedy.js
+++ b/src/modules/twinklespeedy.js
@@ -755,13 +755,6 @@ Twinkle.speedy.data = [
 		code: 'g8',
 		db: 'timedtext',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.'
-	},
-	{
-		list: 'redirectList',
-		label: 'X3: Redirects with no space before a parenthetical disambiguation',
-		code: 'x3',
-		db: 'x3',
-		tooltip: 'This excludes terms that can plausibly be searched for without spaces, or if the redirect contains substantive page history (e.g. from a merge).'
 	}
 ];
 

--- a/tests/__snapshots__/twinkleconfig.test.js.snap
+++ b/tests/__snapshots__/twinkleconfig.test.js.snap
@@ -40,7 +40,6 @@ exports[`modules/twinkleconfig Twinkle.config global variables Should match snap
   "u2": "U2",
   "u6": "U6",
   "u7": "U7",
-  "x3": "X3",
 }
 `;
 
@@ -84,7 +83,6 @@ exports[`modules/twinkleconfig Twinkle.config global variables Should match snap
   "u2",
   "u6",
   "u7",
-  "x3",
 ]
 `;
 
@@ -121,7 +119,6 @@ exports[`modules/twinkleconfig Twinkle.config global variables Should match snap
   "r4": "R4",
   "u6": "U6",
   "u7": "U7",
-  "x3": "X3",
 }
 `;
 
@@ -158,7 +155,6 @@ exports[`modules/twinkleconfig Twinkle.config global variables Should match snap
   "r4",
   "u6",
   "u7",
-  "x3",
 ]
 `;
 
@@ -206,7 +202,6 @@ exports[`modules/twinkleconfig Twinkle.config global variables Should match snap
   "u2": "U2",
   "u6": "U6",
   "u7": "U7",
-  "x3": "X3",
 }
 `;
 
@@ -254,6 +249,5 @@ exports[`modules/twinkleconfig Twinkle.config global variables Should match snap
   "u2",
   "u6",
   "u7",
-  "x3",
 ]
 `;

--- a/tests/__snapshots__/twinklespeedy.test.js.snap
+++ b/tests/__snapshots__/twinklespeedy.test.js.snap
@@ -670,11 +670,6 @@ exports[`modules/twinklespeedy Twinkle.speedy global variables Should match snap
     "tooltip": "This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.",
     "value": "redirnone",
   },
-  {
-    "label": "X3: Redirects with no space before a parenthetical disambiguation",
-    "tooltip": "This excludes terms that can plausibly be searched for without spaces, or if the redirect contains substantive page history (e.g. from a merge).",
-    "value": "x3",
-  },
 ]
 `;
 
@@ -754,7 +749,6 @@ exports[`modules/twinklespeedy Twinkle.speedy global variables Should match snap
   "userreq": "u1",
   "vandalism": "g3",
   "web": "a7",
-  "x3": "x3",
   "xfd": "g6",
 }
 `;


### PR DESCRIPTION
Repealed as of November 2025. See https://en.wikipedia.org/wiki/Wikipedia_talk:Speedy_deletion#RFC:_Time_to_promote_or_repeal_WP:X3?

Closes #2285