### PR TITLE
arv: Remove colon causing multi-colon escape lint errors when reporting to AIV

### DIFF
--- a/src/modules/twinklearv.js
+++ b/src/modules/twinklearv.js
@@ -673,7 +673,7 @@ Twinkle.arv.callback.getAivReasonWikitext = function(input) {
 
 	if (input.page !== '') {
 		// Allow links to redirects, files, and categories
-		text = 'On {{No redirect|:' + input.page + '}}';
+		text = 'On {{No redirect|' + input.page + '}}';
 		if (input.badid !== '') {
 			text += ' ({{diff|' + input.page + '|' + input.badid + '|' + input.goodid + '|diff}})';
 		}


### PR DESCRIPTION
When a user specifies a page in the "Primary linked page" field, the code adds an extra : unnecessarily which {{No redirect}} will filter out and link to the page anyway (but still causes a lint error), this leads to multi-colon escape lint errors being reported across AIV's transclusions (which is around 200 pages or so).

See also [here](https://en.wikipedia.org/wiki/Wikipedia_talk:Linter#No_redirect) where it was reported on WT:Linter.