### PR TITLE
morebits: remove message i18n

### DIFF
--- a/src/morebits.js
+++ b/src/morebits.js
@@ -40,56 +40,6 @@ const Morebits = {};
 window.Morebits = Morebits; // allow global access
 
 /**
- * i18n support for strings in Morebits
- */
-Morebits.i18n = {
-	parser: null,
-	/**
-	 * Set an i18n library to use with Morebits.
-	 * Examples:
-	 * Use jquery-i18n:
-	 * Morebits.i18n.setParser({ get: $.i18n });
-	 * Use banana-i18n or orange-i18n:
-	 * var banana = new Banana('en');
-	 * Morebits.i18n.setParser({ get: banana.i18n });
-	 *
-	 * @param {Object} parser
-	 */
-	setParser: function(parser) {
-		if (!parser || typeof parser.get !== 'function') {
-			throw new Error('Morebits.i18n: parser must implement get()');
-		}
-		Morebits.i18n.parser = parser;
-	},
-	/**
-	 * @private
-	 * @return {string}
-	 */
-	getMessage: function () {
-		const args = Array.prototype.slice.call(arguments); // array of size `n`
-		// 1st arg: message name
-		// 2nd to (n-1)th arg: message parameters
-		// nth arg: legacy English fallback
-		const msgName = args[0];
-		const fallback = args[args.length - 1];
-		if (!Morebits.i18n.parser) {
-			return fallback;
-		}
-		// i18n libraries are generally invoked with variable number of arguments
-		// as msg(msgName, ...parameters)
-		const i18nMessage = Morebits.i18n.parser.get.apply(null, args.slice(0, -1));
-		// if no i18n message exists, i18n libraries generally give back the message name
-		if (i18nMessage === msgName) {
-			return fallback;
-		}
-		return i18nMessage;
-	}
-};
-
-// shortcut
-const msg = Morebits.i18n.getMessage;
-
-/**
  * Wiki-specific configurations for Morebits
  */
 Morebits.l10n = {
@@ -943,7 +893,7 @@ Morebits.QuickForm.Element.generateTooltip = function QuickFormElementGenerateTo
 	const tooltipButton = node.appendChild(document.createElement('span'));
 	tooltipButton.className = 'morebits-tooltipButton';
 	tooltipButton.title = data.tooltip; // Provides the content for jQuery UI
-	tooltipButton.appendChild(document.createTextNode(msg('tooltip-mark', '?')));
+	tooltipButton.appendChild(document.createTextNode('?'));
 	$(tooltipButton).tooltip({
 		position: { my: 'left top', at: 'center bottom', collision: 'flipfit' },
 		// Deprecated in UI 1.12, but MW stuck on 1.9.2 indefinitely; see #398 and T71386
@@ -1850,28 +1800,28 @@ Morebits.Date = function() {
  */
 Morebits.Date.localeData = {
 	// message names here correspond to MediaWiki message names
-	months: [msg('january', 'January'), msg('february', 'February'), msg('march', 'March'),
-		msg('april', 'April'), msg('may_long', 'May'), msg('june', 'June'),
-		msg('july', 'July'), msg('august', 'August'), msg('september', 'September'),
-		msg('october', 'October'), msg('november', 'November'), msg('december', 'December')],
-	monthsShort: [msg('jan', 'Jan'), msg('feb', 'Feb'), msg('mar', 'Mar'),
-		msg('apr', 'Apr'), msg('may', 'May'), msg('jun', 'Jun'),
-		msg('jul', 'Jul'), msg('aug', 'Aug'), msg('sep', 'Sep'),
-		msg('oct', 'Oct'), msg('nov', 'Nov'), msg('dec', 'Dec')],
-	days: [msg('sunday', 'Sunday'), msg('monday', 'Monday'), msg('tuesday', 'Tuesday'),
-		msg('wednesday', 'Wednesday'), msg('thursday', 'Thursday'), msg('friday', 'Friday'),
-		msg('saturday', 'Saturday')],
-	daysShort: [msg('sun', 'Sun'), msg('mon', 'Mon'), msg('tue', 'Tue'),
-		msg('wed', 'Wed'), msg('thu', 'Thu'), msg('fri', 'Fri'),
-		msg('sat', 'Sat')],
+	months: ['January', 'February', 'March',
+		'April', 'May', 'June',
+		'July', 'August', 'September',
+		'October', 'November', 'December'],
+	monthsShort: ['Jan', 'Feb', 'Mar',
+		'Apr', 'May', 'Jun',
+		'Jul', 'Aug', 'Sep',
+		'Oct', 'Nov', 'Dec'],
+	days: ['Sunday', 'Monday', 'Tuesday',
+		'Wednesday', 'Thursday', 'Friday',
+		'Saturday'],
+	daysShort: ['Sun', 'Mon', 'Tue',
+		'Wed', 'Thu', 'Fri',
+		'Sat'],
 
 	relativeTimes: {
-		thisDay: msg('relative-today', '[Today at] h:mm A'),
-		prevDay: msg('relative-prevday', '[Yesterday at] h:mm A'),
-		nextDay: msg('relative-nextday', '[Tomorrow at] h:mm A'),
-		thisWeek: msg('relative-thisweek', 'dddd [at] h:mm A'),
-		pastWeek: msg('relative-pastweek', '[Last] dddd [at] h:mm A'),
-		other: msg('relative-other', 'YYYY-MM-DD')
+		thisDay: '[Today at] h:mm A',
+		prevDay: '[Yesterday at] h:mm A',
+		nextDay: '[Tomorrow at] h:mm A',
+		thisWeek: 'dddd [at] h:mm A',
+		pastWeek: '[Last] dddd [at] h:mm A',
+		other: 'YYYY-MM-DD'
 	}
 };
 
@@ -2056,7 +2006,7 @@ Morebits.Date.prototype = {
 		};
 		const h24 = udate.getHours(), m = udate.getMinutes(), s = udate.getSeconds(), ms = udate.getMilliseconds();
 		const D = udate.getDate(), M = udate.getMonth() + 1, Y = udate.getFullYear();
-		const h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? msg('period-pm', 'PM') : msg('period-am', 'AM');
+		const h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? 'PM' : 'AM';
 		const replacementMap = {
 			HH: pad(h24), H: h24, hh: pad(h12), h: h12, A: amOrPm,
 			mm: pad(m), m: m,
@@ -2405,7 +2355,7 @@ Morebits.wiki.Api.prototype = {
 					// as the first argument to the callback (for legacy code)
 					this.onSuccess.call(this.parent, this);
 				} else {
-					this.statelem.info(msg('done', 'done'));
+					this.statelem.info('done');
 				}
 
 				Morebits.wiki.actionCompleted();
@@ -2417,7 +2367,7 @@ Morebits.wiki.Api.prototype = {
 			function onAPIfailure(jqXHR, statusText, errorThrown) {
 				this.statusText = statusText;
 				this.errorThrown = errorThrown; // frequently undefined
-				this.errorText = msg('api-error', statusText, jqXHR.statusText, statusText + ' "' + jqXHR.statusText + '" occurred while contacting the API.');
+				this.errorText = statusText + ' "' + jqXHR.statusText + '" occurred while contacting the API.';
 				return this.returnError();
 			}
 
@@ -2426,7 +2376,7 @@ Morebits.wiki.Api.prototype = {
 
 	returnError: function(callerAjaxParameters) {
 		if (this.errorCode === 'badtoken' && !this.badtokenRetry) {
-			this.statelem.warn(msg('invalid-token-retrying', 'Invalid token. Getting a new token and retrying...'));
+			this.statelem.warn('Invalid token. Getting a new token and retrying...');
 			this.badtokenRetry = true;
 			// Get a new CSRF token and retry. If the original action needs a different
 			// type of action than CSRF, we do one pointless retry before bailing out
@@ -2517,7 +2467,7 @@ Morebits.wiki.Api.setApiUserAgent = function(ua) {
  * @return {string} MediaWiki CSRF token.
  */
 Morebits.wiki.Api.getToken = function() {
-	const tokenApi = new Morebits.wiki.Api(msg('getting-token', 'Getting token'), {
+	const tokenApi = new Morebits.wiki.Api('Getting token', {
 		action: 'query',
 		meta: 'tokens',
 		type: 'csrf',
@@ -2576,7 +2526,7 @@ Morebits.wiki.Api.getToken = function() {
 Morebits.wiki.Page = function(pageName, status) {
 
 	if (!status) {
-		status = msg('opening-page', pageName, 'Opening page "' + pageName + '"');
+		status = 'Opening page "' + pageName + '"';
 	}
 
 	/**
@@ -2749,7 +2699,7 @@ Morebits.wiki.Page = function(pageName, status) {
 			ctx.loadQuery.inprop += '|protection';
 		}
 
-		ctx.loadApi = new Morebits.wiki.Api(msg('retrieving-page', 'Retrieving page...'), ctx.loadQuery, fnLoadSuccess, ctx.statusElement, ctx.onLoadFailure);
+		ctx.loadApi = new Morebits.wiki.Api('Retrieving page...', ctx.loadQuery, fnLoadSuccess, ctx.statusElement, ctx.onLoadFailure);
 		ctx.loadApi.setParent(this);
 		ctx.loadApi.post();
 	};
@@ -2796,16 +2746,12 @@ Morebits.wiki.Page = function(pageName, status) {
 		if (ctx.fullyProtected && !ctx.suppressProtectWarning &&
 			!confirm(
 				ctx.fullyProtected === 'infinity' ?
-					msg('protected-indef-edit-warning', ctx.pageName,
-						'You are about to make an edit to the fully protected page "' + ctx.pageName + '" (protected indefinitely).  \n\nClick OK to proceed with the edit, or Cancel to skip this edit.'
-					) :
-					msg('protected-edit-warning', ctx.pageName, ctx.fullyProtected,
-						'You are about to make an edit to the fully protected page "' + ctx.pageName +
+					'You are about to make an edit to the fully protected page "' + ctx.pageName + '" (protected indefinitely).  \n\nClick OK to proceed with the edit, or Cancel to skip this edit.' :
+					'You are about to make an edit to the fully protected page "' + ctx.pageName +
 					'" (protection expiring ' + new Morebits.Date(ctx.fullyProtected).calendar('utc') + ' (UTC)).  \n\nClick OK to proceed with the edit, or Cancel to skip this edit.'
-					)
 			)
 		) {
-			ctx.statusElement.error(msg('protected-aborted', 'Edit to fully protected page was aborted.'));
+			ctx.statusElement.error('Edit to fully protected page was aborted.');
 			ctx.onSaveFailure(this);
 			return;
 		}
@@ -2896,7 +2842,7 @@ Morebits.wiki.Page = function(pageName, status) {
 			query.redirect = true;
 		}
 
-		ctx.saveApi = new Morebits.wiki.Api(msg('saving-page', 'Saving page...'), query, fnSaveSuccess, ctx.statusElement, fnSaveError);
+		ctx.saveApi = new Morebits.wiki.Api('Saving page...', query, fnSaveSuccess, ctx.statusElement, fnSaveError);
 		ctx.saveApi.setParent(this);
 		ctx.saveApi.post();
 	};
@@ -3467,7 +3413,7 @@ Morebits.wiki.Page = function(pageName, status) {
 			query.redirects = ''; // follow all redirects
 		}
 
-		ctx.lookupCreationApi = new Morebits.wiki.Api(msg('getting-creator', 'Retrieving page creation information'), query, fnLookupCreationSuccess, ctx.statusElement, ctx.onLookupCreationFailure);
+		ctx.lookupCreationApi = new Morebits.wiki.Api('Retrieving page creation information', query, fnLookupCreationSuccess, ctx.statusElement, ctx.onLookupCreationFailure);
 		ctx.lookupCreationApi.setParent(this);
 		ctx.lookupCreationApi.post();
 	};
@@ -3517,7 +3463,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		} else {
 			const query = fnNeedTokenInfoQuery('move');
 
-			ctx.moveApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), query, fnProcessMove, ctx.statusElement, ctx.onMoveFailure);
+			ctx.moveApi = new Morebits.wiki.Api('retrieving token...', query, fnProcessMove, ctx.statusElement, ctx.onMoveFailure);
 			ctx.moveApi.setParent(this);
 			ctx.moveApi.post();
 		}
@@ -3556,7 +3502,7 @@ Morebits.wiki.Page = function(pageName, status) {
 				format: 'json'
 			};
 
-			ctx.patrolApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), patrolQuery, fnProcessPatrol);
+			ctx.patrolApi = new Morebits.wiki.Api('retrieving token...', patrolQuery, fnProcessPatrol);
 			ctx.patrolApi.setParent(this);
 			ctx.patrolApi.post();
 		}
@@ -3595,7 +3541,7 @@ Morebits.wiki.Page = function(pageName, status) {
 			} else {
 				const query = fnNeedTokenInfoQuery('triage');
 
-				ctx.triageApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), query, fnProcessTriageList);
+				ctx.triageApi = new Morebits.wiki.Api('retrieving token...', query, fnProcessTriageList);
 				ctx.triageApi.setParent(this);
 				ctx.triageApi.post();
 			}
@@ -3622,7 +3568,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		} else {
 			const query = fnNeedTokenInfoQuery('delete');
 
-			ctx.deleteApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), query, fnProcessDelete, ctx.statusElement, ctx.onDeleteFailure);
+			ctx.deleteApi = new Morebits.wiki.Api('retrieving token...', query, fnProcessDelete, ctx.statusElement, ctx.onDeleteFailure);
 			ctx.deleteApi.setParent(this);
 			ctx.deleteApi.post();
 		}
@@ -3647,7 +3593,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		} else {
 			const query = fnNeedTokenInfoQuery('undelete');
 
-			ctx.undeleteApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), query, fnProcessUndelete, ctx.statusElement, ctx.onUndeleteFailure);
+			ctx.undeleteApi = new Morebits.wiki.Api('retrieving token...', query, fnProcessUndelete, ctx.statusElement, ctx.onUndeleteFailure);
 			ctx.undeleteApi.setParent(this);
 			ctx.undeleteApi.post();
 		}
@@ -3678,7 +3624,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		// protection levels from the server
 		const query = fnNeedTokenInfoQuery('protect');
 
-		ctx.protectApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), query, fnProcessProtect, ctx.statusElement, ctx.onProtectFailure);
+		ctx.protectApi = new Morebits.wiki.Api('retrieving token...', query, fnProcessProtect, ctx.statusElement, ctx.onProtectFailure);
 		ctx.protectApi.setParent(this);
 		ctx.protectApi.post();
 	};
@@ -3713,7 +3659,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		} else {
 			const query = fnNeedTokenInfoQuery('stabilize');
 
-			ctx.stabilizeApi = new Morebits.wiki.Api(msg('getting-token', 'retrieving token...'), query, fnProcessStabilize, ctx.statusElement, ctx.onStabilizeFailure);
+			ctx.stabilizeApi = new Morebits.wiki.Api('retrieving token...', query, fnProcessStabilize, ctx.statusElement, ctx.onStabilizeFailure);
 			ctx.stabilizeApi.setParent(this);
 			ctx.stabilizeApi.post();
 		}
@@ -3835,7 +3781,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		}
 		ctx.csrfToken = response.tokens.csrftoken;
 		if (!ctx.csrfToken) {
-			ctx.statusElement.error(msg('token-fetch-fail', 'Failed to retrieve edit token.'));
+			ctx.statusElement.error('Failed to retrieve edit token.');
 			ctx.onLoadFailure(this);
 			return;
 		}
@@ -3907,7 +3853,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		if (page) {
 			// check for invalid titles
 			if (page.invalid) {
-				ctx.statusElement.error(msg('invalid-title', ctx.pageName, 'The page title is invalid: ' + ctx.pageName));
+				ctx.statusElement.error('The page title is invalid: ' + ctx.pageName);
 				onFailure(this);
 				return false; // abort
 			}
@@ -3920,20 +3866,20 @@ Morebits.wiki.Page = function(pageName, status) {
 				const origNs = new mw.Title(ctx.pageName).namespace;
 				const newNs = new mw.Title(resolvedName).namespace;
 				if (origNs !== newNs && !ctx.followCrossNsRedirect) {
-					ctx.statusElement.error(msg('cross-redirect-abort', ctx.pageName, resolvedName, ctx.pageName + ' is a cross-namespace redirect to ' + resolvedName + ', aborted'));
+					ctx.statusElement.error(ctx.pageName + ' is a cross-namespace redirect to ' + resolvedName + ', aborted');
 					onFailure(this);
 					return false;
 				}
 
 				// only notify user for redirects, not normalization
-				new Morebits.Status('Note', msg('redirected', ctx.pageName, resolvedName, 'Redirected from ' + ctx.pageName + ' to ' + resolvedName));
+				new Morebits.Status('Note', 'Redirected from ' + ctx.pageName + ' to ' + resolvedName);
 			}
 
 			ctx.pageName = resolvedName; // update to redirect target or normalized name
 
 		} else {
 			// could be a circular redirect or other problem
-			ctx.statusElement.error(msg('redirect-resolution-fail', ctx.pageName, 'Could not resolve redirects for: ' + ctx.pageName));
+			ctx.statusElement.error('Could not resolve redirects for: ' + ctx.pageName);
 			onFailure(this);
 
 			// force error to stay on the screen
@@ -4010,7 +3956,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		if (response.edit.captcha) {
 			ctx.statusElement.error('Could not save the page because the wiki server wanted you to fill out a CAPTCHA.');
 		} else {
-			ctx.statusElement.error(msg('api-error-unknown', 'Unknown error received from API while saving page'));
+			ctx.statusElement.error('Unknown error received from API while saving page');
 		}
 
 		// force error to stay on the screen
@@ -4032,10 +3978,10 @@ Morebits.wiki.Page = function(pageName, status) {
 				titles: ctx.pageName // redirects are already resolved
 			};
 
-			const purgeApi = new Morebits.wiki.Api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, (() => {
+			const purgeApi = new Morebits.wiki.Api('Edit conflict detected, purging server cache', purgeQuery, (() => {
 				--Morebits.wiki.numberOfActionsLeft; // allow for normal completion if retry succeeds
 
-				ctx.statusElement.info(msg('editconflict-retrying', 'Edit conflict detected, reapplying edit'));
+				ctx.statusElement.info('Edit conflict detected, reapplying edit');
 				if (fnCanUseMwUserToken('edit')) {
 					ctx.saveApi.post(); // necessarily append, prepend, or newSection, so this should work as desired
 				} else {
@@ -4048,7 +3994,7 @@ Morebits.wiki.Page = function(pageName, status) {
 		} else if ((errorCode === null || errorCode === undefined) && ctx.retries++ < ctx.maxRetries) {
 
 			// the error might be transient, so try again
-			ctx.statusElement.info(msg('save-failed-retrying', 2, 'Save failed, retrying in 2 seconds ...'));
+			ctx.statusElement.info('Save failed, retrying in 2 seconds ...');
 			--Morebits.wiki.numberOfActionsLeft; // allow for normal completion if retry succeeds
 
 			// wait for sometime for client to regain connectivity
@@ -4298,7 +4244,7 @@ Morebits.wiki.Page = function(pageName, status) {
 			query.noredirect = 'true';
 		}
 
-		ctx.moveProcessApi = new Morebits.wiki.Api(msg('moving-page', 'moving page...'), query, ctx.onMoveSuccess, ctx.statusElement, ctx.onMoveFailure);
+		ctx.moveProcessApi = new Morebits.wiki.Api('moving page...', query, ctx.onMoveSuccess, ctx.statusElement, ctx.onMoveFailure);
 		ctx.moveProcessApi.setParent(this);
 		ctx.moveProcessApi.post();
 	};
@@ -5506,7 +5452,7 @@ Morebits.BatchOperation = function(currentAction) {
 		},
 
 		// internal counters, etc.
-		statusElement: new Morebits.Status(currentAction || msg('batch-starting', 'Performing batch operation')),
+		statusElement: new Morebits.Status(currentAction || 'Performing batch operation'),
 		worker: null, // function that executes for each item in pageList
 		postFinish: null, // function that executes when the whole batch has been processed
 		countStarted: 0,
@@ -5573,7 +5519,7 @@ Morebits.BatchOperation = function(currentAction) {
 
 		const total = ctx.pageList.length;
 		if (!total) {
-			ctx.statusElement.info(msg('batch-no-pages', 'no pages specified'));
+			ctx.statusElement.info('no pages specified');
 			ctx.running = false;
 			if (ctx.postFinish) {
 				ctx.postFinish();
@@ -5608,10 +5554,10 @@ Morebits.BatchOperation = function(currentAction) {
 				if (arg.getPageName || arg.pageName || (arg.query && arg.query.title)) {
 					// we know the page title - display a relevant message
 					const pageName = arg.getPageName ? arg.getPageName() : arg.pageName || arg.query.title;
-					statelem.info(msg('batch-done-page', pageName, 'completed ([[' + pageName + ']])'));
+					statelem.info('completed ([[' + pageName + ']])');
 				} else {
 					// we don't know the page title - just display a generic message
-					statelem.info(msg('done', 'done'));
+					statelem.info('done');
 				}
 			} else {
 				// remove the status line automatically produced by Morebits.wiki.*
@@ -5619,7 +5565,7 @@ Morebits.BatchOperation = function(currentAction) {
 			}
 
 		} else if (typeof arg === 'string' && ctx.options.preserveIndividualStatusLines) {
-			new Morebits.Status(arg, msg('batch-done-page', arg, 'completed ([[' + arg + ']])'));
+			new Morebits.Status(arg, 'completed ([[' + arg + ']])');
 		}
 
 		ctx.countFinishedSuccess++;
@@ -5654,7 +5600,7 @@ Morebits.BatchOperation = function(currentAction) {
 		const total = ctx.pageList.length;
 		if (ctx.countFinished < total) {
 			const progress = Math.round(100 * ctx.countFinished / total);
-			ctx.statusElement.status(msg('percent', progress, progress + '%'));
+			ctx.statusElement.status(progress + '%');
 
 			// start a new chunk if we're close enough to the end of the previous chunk, and
 			// we haven't already started the next one
@@ -5663,8 +5609,7 @@ Morebits.BatchOperation = function(currentAction) {
 				fnStartNewChunk();
 			}
 		} else if (ctx.countFinished === total) {
-			const statusString = msg('batch-progress', ctx.countFinishedSuccess, ctx.countFinished, 'Done (' + ctx.countFinishedSuccess +
-				'/' + ctx.countFinished + ' actions completed successfully)');
+			const statusString = 'Done (' + ctx.countFinishedSuccess + '/' + ctx.countFinished + ' actions completed successfully)';
 			if (ctx.countFinishedSuccess < ctx.countFinished) {
 				ctx.statusElement.warn(statusString);
 			} else {
@@ -5969,7 +5914,7 @@ Morebits.SimpleWindow.prototype = {
 			} else if (value.textContent) {
 				button.textContent = value.textContent;
 			} else {
-				button.textContent = msg('submit', 'Submit');
+				button.textContent = 'Submit';
 			}
 
 			button.className = value.className || 'submitButtonProxy';
@@ -6019,7 +5964,7 @@ Morebits.SimpleWindow.prototype = {
 		const $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
 		if (this.hasFooterLinks) {
 			const bullet = document.createElement('span');
-			bullet.textContent = msg('bullet-separator', ' \u2022 '); // U+2022 BULLET
+			bullet.textContent = ' \u2022 '; // U+2022 BULLET
 			if (prep) {
 				$footerlinks.prepend(bullet);
 			} else {


### PR DESCRIPTION
This has never really been used anywhere in the intended way. For example, on [Bangla Wikipedia](https://bn.wikipedia.org/wiki/MediaWiki:Gadget-morebits.js), they have modified the defaults inline, which defeats the point. The intended usage was to define messages in a JSON object, load them into an i18n lib like jquery.i18n and attach it to morebits via Morebits.i18n.setParser(). The [Chinese Wikipedia](https://zh.wikipedia.org/wiki/MediaWiki:Gadget-morebits.js) skips Morebits.i18n altogether in favour of defining messages inline.

The only usage is in Twinkle-core which anyway has its own copy of morebits. At this point, continuing to maintain this system feels like technical debt that also impedes readability of code where messages are used.