### PR TITLE
morebits: remove SimpleWindow focus() method

### DIFF
--- a/src/morebits.js
+++ b/src/morebits.js
@@ -5734,16 +5734,6 @@ Morebits.SimpleWindow.prototype = {
 	scriptName: null,
 
 	/**
-	 * Focuses the dialog. This might work, or on the contrary, it might not.
-	 *
-	 * @return {Morebits.SimpleWindow}
-	 */
-	focus: function() {
-		$(this.content).dialog('moveToTop');
-		return this;
-	},
-
-	/**
 	 * Closes the dialog. If this is set as an event handler, it will stop the event
 	 * from doing anything more.
 	 *


### PR DESCRIPTION
Not used anywhere in Twinkle or in any other morebits-using script on enwiki. The function doc suggests it might not be reliable ("This might work, or on the contrary, it might not").

This was used internally in the pre-jQuery UI version (prior to bc64fc341d1), and has been unused since then.