### PR TITLE
morebits: port tooltips from jQuery UI to plain JS

### DIFF
--- a/gadget.txt
+++ b/gadget.txt
@@ -1,4 +1,4 @@
 * Twinkle [ResourceLoader |dependencies=ext.gadget.morebits, ext.gadget.select2, mediawiki.api, mediawiki.language |rights=autoconfirmed |type=general |peers=Twinkle-pagestyles] |Twinkle.js |Twinkle.css |twinklearv.js |twinklewarn.js |twinkleblock.js |twinklewelcome.js |twinkletalkback.js |twinklespeedy.js |twinkleprod.js |twinklexfd.js |twinkleimage.js |twinkleprotect.js |twinkletag.js |twinklediff.js |twinkleunlink.js |twinklerollback.js |twinkledeprod.js |twinklebatchdelete.js |twinklebatchprotect.js |twinklebatchundelete.js |twinkleconfig.js
-* morebits [ResourceLoader |dependencies=mediawiki.user, mediawiki.util, mediawiki.Title, jquery.ui |hidden] |morebits.js |morebits.css
+* morebits [ResourceLoader |dependencies=mediawiki.user, mediawiki.util, mediawiki.Title |hidden] |morebits.js |morebits.css
 * Twinkle-pagestyles [hidden |skins=vector, vector-2022] |Twinkle-pagestyles.css
 * select2 [ResourceLoader |hidden] |select2.min.js |select2.min.css

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -17,7 +17,7 @@ const server = http.createServer(async (request, response) => {
 	const jsFiles = ['src/morebits.js', 'src/twinkle.js'].concat(moduleFiles.map(f => 'src/modules/' + f));
 	const cssFiles = ['src/morebits.css', 'src/twinkle.css'];
 
-	let jsCode = `mw.loader.using(['jquery.ui', 'ext.gadget.select2']).then(function () {\n`;
+	let jsCode = `mw.loader.using(['ext.gadget.select2']).then(function () {\n`;
 
 	if (process.argv[2] !== '--no-sysop') {
 		// Pretend to be a sysop, if not one already - enables testing of sysop modules by non-sysops

--- a/src/morebits.css
+++ b/src/morebits.css
@@ -172,12 +172,24 @@ form.quickform .morebits-tooltipButton {
 }
 
 .morebits-ui-tooltip {
+	position: absolute;
+	z-index: 1005;
 	padding: 4px 6px 4px 6px;
+	max-width: 300px;
+	transition: opacity 600ms ease;
+	opacity: 0;
+	visibility: hidden;
+	pointer-events: none;
 	/* stylelint-disable-next-line declaration-property-unit-disallowed-list */ /* FIXME */
 	font-size: 13px;
 	background: var(--background-color-neutral-subtle, #f8f9fa);
-	border-color: var(--border-color-base, #a2ab91);
+	border: 2px solid var(--border-color-base, #a2ab91);
 	box-shadow: 0 0 5px #a2ab91;
+}
+
+.morebits-ui-tooltip.visible {
+	opacity: 1;
+	visibility: visible;
 }
 
 /* Scrollbox styles, for use within Morebits.SimpleWindow */


### PR DESCRIPTION
_(PR stacked on #2304 and #2309, which should be merged first_)

----

Implement tooltips from scratch to avoid dependency on jQuery UI. No discernible difference compared to the previous implementation.

Closes #2300.