### PR TITLE
block: rewrite user type options for more modularity + adjust some

### DIFF
--- a/src/modules/twinkleblock.js
+++ b/src/modules/twinkleblock.js
@@ -1180,7 +1180,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for using user and/or article pages as a [[WP:NOTMYSPACE|blog, web host, social networking site or forum]]'
 	},
 	'uw-sockblock': {
-		userTypes: ['ta', 'named'],
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		reason: 'Abusing [[WP:Sock puppetry|multiple accounts]]',

--- a/src/modules/twinkleblock.js
+++ b/src/modules/twinkleblock.js
@@ -836,9 +836,6 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
  *   autoblock: <autoblock any IP addresses used (for registered users only)>
  *   disabletalk: <disable user from editing their own talk page while blocked>
  *   expiry: <string - expiry timestamp, can include relative times like "5 months", "2 weeks" etc>
- *   forIPsOnly: <show block option in the interface only if the relevant user is an IP>
- *   forTempAccountsOnly: <show block option in the interface only if the relevant user is a temporary account>
- *   forRegisteredOnly: <show block option in the interface only if the relevant user is a temporary account or regular account>
  *   label: <string - label for the option of the dropdown in the interface (keep brief)>
  *   noemail: prevent the user from sending email through Special:Emailuser
  *   pageParam: <set if the associated block template accepts a page parameter>
@@ -854,22 +851,23 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
  *   templateName: <string - name of template to use (instead of key name), entry will be omitted from the Templates list.
  *                  (e.g. use another template but with different block options)>
  *   useInitialOptions: <when preset is chosen, only change given block options, leave others as they were>
+ *   userTypes: <show block option in the interface if the relevant user is an IP, a temporary account, or a regular account>
  *
  * WARNING: 'anononly' and 'allowusertalk' are enabled by default.
  *   To disable, set 'hardblock' and 'disabletalk', respectively
  */
 Twinkle.block.blockPresetsInfo = {
 	anonblock: {
+		userTypes: ['ip'],
 		expiry: '31 hours',
-		forIPsOnly: true,
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{anonblock}}',
 		sig: '~~~~'
 	},
 	'anonblock - school': {
+		userTypes: ['ip'],
 		expiry: '36 hours',
-		forIPsOnly: true,
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{anonblock}} <!-- Likely a school based on behavioral evidence -->',
@@ -877,8 +875,8 @@ Twinkle.block.blockPresetsInfo = {
 		sig: '~~~~'
 	},
 	'blocked proxy': {
+		userTypes: ['ip'],
 		expiry: '1 year',
-		forIPsOnly: true,
 		nocreate: true,
 		nonstandard: true,
 		hardblock: true,
@@ -886,37 +884,38 @@ Twinkle.block.blockPresetsInfo = {
 		sig: null
 	},
 	'CheckUser block': {
+		userTypes: ['ip'],
 		expiry: '1 week',
-		forIPsOnly: true,
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{CheckUser block}}',
 		sig: '~~~~'
 	},
 	'checkuserblock-account': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{checkuserblock-account}}',
 		sig: '~~~~'
 	},
 	'checkuserblock-wide': {
-		forIPsOnly: true,
+		userTypes: ['ip'],
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{checkuserblock-wide}}',
 		sig: '~~~~'
 	},
 	colocationwebhost: {
+		userTypes: ['ip'],
 		expiry: '1 year',
-		forIPsOnly: true,
 		nonstandard: true,
 		reason: '{{colocationwebhost}}',
 		sig: null
 	},
 	oversightblock: {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
 		nocreate: true,
@@ -925,42 +924,43 @@ Twinkle.block.blockPresetsInfo = {
 		sig: '~~~~'
 	},
 	'school block': {
-		forIPsOnly: true,
+		userTypes: ['ip'],
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{school block}}',
 		sig: '~~~~'
 	},
 	spamblacklistblock: {
-		forIPsOnly: true,
+		userTypes: ['ip'],
 		expiry: '1 month',
 		disabletalk: true,
 		nocreate: true,
 		reason: '{{spamblacklistblock}} <!-- editor only attempts to add blacklisted links, see [[Special:Log/spamblacklist]] -->'
 	},
 	rangeblock: {
+		userTypes: ['ip'],
 		reason: '{{rangeblock}}',
 		nocreate: true,
 		nonstandard: true,
-		forIPsOnly: true,
 		sig: '~~~~'
 	},
 	tor: {
+		userTypes: ['ip'],
 		expiry: '1 year',
-		forIPsOnly: true,
 		nonstandard: true,
 		reason: '{{Tor}}',
 		sig: null
 	},
 	webhostblock: {
+		userTypes: ['ip'],
 		expiry: '1 year',
-		forIPsOnly: true,
 		nonstandard: true,
 		reason: '{{webhostblock}}',
 		sig: null
 	},
 	// uw-prefixed
 	'uw-3block': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '24 hours',
 		nocreate: true,
@@ -969,9 +969,9 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for violation of the [[WP:3RR|three-revert rule]]'
 	},
 	'uw-ablock': {
+		userTypes: ['ip'],
 		autoblock: true,
 		expiry: '31 hours',
-		forIPsOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reasonParam: true,
@@ -979,6 +979,7 @@ Twinkle.block.blockPresetsInfo = {
 		suppressArticleInSummary: true
 	},
 	'uw-adblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		pageParam: true,
@@ -986,6 +987,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for [[WP:SOAP|advertising or self-promotion]]'
 	},
 	'uw-aeblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		pageParam: true,
@@ -994,6 +996,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for violating an [[WP:Arbitration|arbitration decision]]'
 	},
 	'uw-bioblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		pageParam: true,
@@ -1001,9 +1004,9 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for violations of Wikipedia\'s [[WP:BLP|biographies of living persons policy]]'
 	},
 	'uw-block': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: '24 hours',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reasonParam: true,
@@ -1011,9 +1014,9 @@ Twinkle.block.blockPresetsInfo = {
 		suppressArticleInSummary: true
 	},
 	'uw-blockindef': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reasonParam: true,
@@ -1021,6 +1024,7 @@ Twinkle.block.blockPresetsInfo = {
 		suppressArticleInSummary: true
 	},
 	'uw-blocknotalk': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		disabletalk: true,
 		nocreate: true,
@@ -1030,32 +1034,33 @@ Twinkle.block.blockPresetsInfo = {
 		suppressArticleInSummary: true
 	},
 	'uw-botblock': {
-		forRegisteredOnly: true,
+		userTypes: ['ta', 'named'],
 		pageParam: true,
 		reason: 'Running a [[WP:BOT|bot script]] without [[WP:BRFA|approval]]',
 		summary: 'You have been blocked from editing because it appears you are running a [[WP:BOT|bot script]] without [[WP:BRFA|approval]]'
 	},
 	'uw-botublock': {
+		userTypes: ['named'],
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		reason: '{{uw-botublock}} <!-- Username implies a bot, soft block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] indicates this is a [[WP:BOT|bot]] account, which is currently not approved'
 	},
 	'uw-botuhblock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '{{uw-botuhblock}} <!-- Username implies a bot, hard block -->',
 		summary: 'You have been indefinitely blocked from editing because your username is a blatant violation of the [[WP:U|username policy]]'
 	},
 	'uw-causeblock': {
+		userTypes: ['named'],
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		reason: '{{uw-causeblock}} <!-- Username represents a non-profit, soft block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] gives the impression that the account represents a group, organization or website'
 	},
 	'uw-compblock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
 		forRegisteredOnly: true,
@@ -1064,6 +1069,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been indefinitely blocked from editing because it is believed that your [[WP:SECURE|account has been compromised]]'
 	},
 	'uw-copyrightblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
 		nocreate: true,
@@ -1072,6 +1078,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for continued [[WP:COPYVIO|copyright infringement]]'
 	},
 	'uw-dblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		reason: 'Persistent removal of content',
@@ -1079,18 +1086,21 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for continued [[WP:VAND|removal of material]]'
 	},
 	'uw-disruptblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		reason: '[[WP:Disruptive editing|Disruptive editing]]',
 		summary: 'You have been blocked from editing for [[WP:DE|disruptive editing]]'
 	},
 	'uw-efblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		reason: 'Repeatedly triggering the [[WP:Edit filter|Edit filter]]',
 		summary: 'You have been blocked from editing for disruptive edits that repeatedly triggered the [[WP:EF|edit filter]]'
 	},
 	'uw-ewblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '24 hours',
 		nocreate: true,
@@ -1099,6 +1109,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing to prevent further [[WP:DE|disruption]] caused by your engagement in an [[WP:EW|edit war]]'
 	},
 	'uw-hblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		pageParam: true,
@@ -1106,13 +1117,14 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for attempting to [[WP:HARASS|harass]] other users'
 	},
 	'uw-ipevadeblock': {
-		forIPsOnly: true,
+		userTypes: ['ip'],
 		expiry: '1 week',
 		nocreate: true,
 		reason: '[[WP:Blocking policy#Evasion of blocks|Block evasion]]',
 		summary: 'Your IP address has been blocked from editing because it has been used to [[WP:EVADE|evade a previous block]]'
 	},
 	'uw-lblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
 		nocreate: true,
@@ -1120,14 +1132,15 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for making [[WP:NLT|legal threats or taking legal action]]'
 	},
 	'uw-nothereblock': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
 		nocreate: true,
 		reason: 'Clearly [[WP:NOTHERE|not here to build an encyclopedia]]',
-		forRegisteredOnly: true,
 		summary: 'You have been indefinitely blocked from editing because it appears that you are not here to [[WP:NOTHERE|build an encyclopedia]]'
 	},
 	'uw-npblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		pageParam: true,
@@ -1135,6 +1148,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for creating [[WP:PN|nonsense pages]]'
 	},
 	'uw-pablock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '31 hours',
 		nocreate: true,
@@ -1142,21 +1156,23 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for making [[WP:NPA|personal attacks]] toward other users'
 	},
 	'uw-sblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		reason: 'Using Wikipedia for [[WP:SPAM|spam]] purposes',
 		summary: 'You have been blocked from editing for using Wikipedia for [[WP:SPAM|spam]] purposes'
 	},
 	'uw-soablock': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reason: '[[WP:Spam|Spam]] / [[WP:NOTADVERTISING|advertising]]-only account',
 		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam, advertising, or promotion]]'
 	},
 	'uw-socialmediablock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: true,
 		pageParam: true,
@@ -1164,35 +1180,37 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for using user and/or article pages as a [[WP:NOTMYSPACE|blog, web host, social networking site or forum]]'
 	},
 	'uw-sockblock': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
-		forRegisteredOnly: true,
 		nocreate: true,
 		reason: 'Abusing [[WP:Sock puppetry|multiple accounts]]',
 		summary: 'You have been blocked from editing for abusing [[WP:SOCK|multiple accounts]]'
 	},
 	'uw-softerblock': {
+		userTypes: ['named'],
 		expiry: 'infinity',
 		forRegisteredOnly: true,
 		reason: '{{uw-softerblock}} <!-- Promotional username, soft block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] gives the impression that the account represents a group, organization or website'
 	},
 	'uw-spamublock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '{{uw-spamublock}} <!-- Promotional username, promotional edits -->',
 		summary: 'You have been indefinitely blocked from editing because your account is being used only for [[WP:SPAM|spam or advertising]] and your username is a violation of the [[WP:U|username policy]]'
 	},
 	'uw-spoablock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '[[WP:SOCK|Sock puppetry]]',
 		summary: 'This account has been blocked as a [[WP:SOCK|sock puppet]] created to violate Wikipedia policy'
 	},
 	'uw-talkrevoked': {
+		userTypes: ['ip', 'ta', 'named'],
 		disabletalk: true,
 		reason: 'Revoking talk page access: inappropriate use of user talk page while blocked',
 		prependReason: true,
@@ -1200,27 +1218,28 @@ Twinkle.block.blockPresetsInfo = {
 		useInitialOptions: true
 	},
 	'uw-tempevadeblock': {
+		userTypes: ['ta'],
 		autoblock: true,
 		expiry: 'infinity',
-		forTempAccountsOnly: true,
 		nocreate: true,
 		reason: '[[WP:Blocking policy#Evasion of blocks|Block evasion]]',
 		summary: 'Your temporary account has been blocked from editing because it has been used to [[WP:EVADE|evade a previous block]]'
 	},
 	'uw-ublock': {
+		userTypes: ['named'],
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		reason: '{{uw-ublock}} <!-- Username violation, soft block -->',
 		reasonParam: true,
 		summary: 'You have been indefinitely blocked from editing because your username is a violation of the [[WP:U|username policy]]'
 	},
 	'uw-ublock-double': {
+		userTypes: ['named'],
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		reason: '{{uw-ublock-double}} <!-- Username closely resembles another user, soft block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] is too similar to the username of another Wikipedia user'
 	},
 	'uw-ucblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '31 hours',
 		nocreate: true,
@@ -1229,47 +1248,48 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing for persistent addition of [[WP:INTREF|unsourced content]]'
 	},
 	'uw-uhblock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '{{uw-uhblock}} <!-- Username violation, hard block -->',
 		reasonParam: true,
 		summary: 'You have been indefinitely blocked from editing because your username is a blatant violation of the [[WP:U|username policy]]'
 	},
 	'uw-ublock-wellknown': {
+		userTypes: ['named'],
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		reason: '{{uw-ublock-wellknown}} <!-- Username represents a well-known person, soft block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] matches the name of a well-known living individual'
 	},
 	'uw-uhblock-double': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '{{uw-uhblock-double}} <!-- Attempted impersonation of another user, hard block -->',
 		summary: 'You have been indefinitely blocked from editing because your [[WP:U|username]] appears to impersonate another established Wikipedia user'
 	},
 	'uw-upeblock': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reason: '[[WP:PAID|Undisclosed paid editing]] in violation of the WMF [[WP:TOU|Terms of Use]]',
 		summary: 'You have been indefinitely blocked from editing because your account is being used in violation of [[WP:PAID|Wikipedia policy on undisclosed paid advocacy]]'
 	},
 	'uw-vaublock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reason: '{{uw-vaublock}} <!-- Username violation, vandalism-only account -->',
 		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:DISRUPTONLY|used only for vandalism]] and your username is a blatant violation of the [[WP:U|username policy]]'
 	},
 	'uw-vblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '31 hours',
 		nocreate: true,
@@ -1278,17 +1298,17 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been blocked from editing to prevent further [[WP:VAND|vandalism]]'
 	},
 	'uw-voablock': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
 		reason: '[[WP:DISRUPTONLY|Vandalism-only account]]',
 		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:DISRUPTONLY|used only for vandalism]]'
 	},
 	'zombie proxy': {
+		userTypes: ['ip'],
 		expiry: '1 month',
-		forIPsOnly: true,
 		nocreate: true,
 		nonstandard: true,
 		reason: '{{zombie proxy}}',
@@ -1297,6 +1317,7 @@ Twinkle.block.blockPresetsInfo = {
 
 	// Begin partial block templates, accessed in Twinkle.block.blockGroupsPartial
 	'uw-acpblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '48 hours',
 		nocreate: true,
@@ -1306,9 +1327,9 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been [[WP:PB|blocked from creating accounts]] for misusing [[WP:SOCK|multiple accounts]]'
 	},
 	'uw-acpblockindef': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: false,
 		reasonParam: true,
@@ -1316,6 +1337,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been indefinitely [[WP:PB|blocked from creating accounts]] for misusing [[WP:SOCK|multiple accounts]]'
 	},
 	'uw-aepblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		nocreate: false,
 		pageParam: false,
@@ -1324,9 +1346,9 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been [[WP:PB|partially blocked]] from editing for violating an [[WP:Arbitration|arbitration decision]]'
 	},
 	'uw-epblock': {
+		userTypes: ['named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: false,
 		noemail: true,
 		pageParam: false,
@@ -1335,6 +1357,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been [[WP:PB|blocked from emailing]] other editors for [[WP:Harassment|harassment]]'
 	},
 	'uw-ewpblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '24 hours',
 		nocreate: false,
@@ -1344,6 +1367,7 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been [[WP:PB|partially blocked]] from editing certain areas of the encyclopedia to prevent further [[WP:DE|disruption]] due to [[WP:EW|edit warring]]'
 	},
 	'uw-pblock': {
+		userTypes: ['ip', 'ta', 'named'],
 		autoblock: true,
 		expiry: '24 hours',
 		nocreate: false,
@@ -1352,9 +1376,9 @@ Twinkle.block.blockPresetsInfo = {
 		summary: 'You have been [[WP:PB|partially blocked]] from certain areas of the encyclopedia'
 	},
 	'uw-pblockindef': {
+		userTypes: ['ta', 'named'],
 		autoblock: true,
 		expiry: 'infinity',
-		forRegisteredOnly: true,
 		nocreate: false,
 		pageParam: false,
 		reasonParam: true,
@@ -1516,17 +1540,16 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 			const blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
 
 			let allowedUserType;
-			// for regular users and temporary accounts
-			if (blockSettings.forRegisteredOnly) {
-				allowedUserType = Twinkle.block.isRegistered;
+
+			// for regular users
+			if (Twinkle.block.isRegistered && !mw.util.isTemporaryUser(mw.config.get('wgRelevantUserName'))) {
+				allowedUserType = blockSettings.userTypes.includes('named');
 			// for temporary accounts
-			} else if (blockSettings.forTempAccountsOnly) {
-				allowedUserType = mw.util.isTemporaryUser(mw.config.get('wgRelevantUserName'));
+			} else if (Twinkle.block.isRegistered) {
+				allowedUserType = blockSettings.userTypes.includes('ta');
 			// for IPs
-			} else if (blockSettings.forIPsOnly) {
-				allowedUserType = !Twinkle.block.isRegistered;
 			} else {
-				allowedUserType = true;
+				allowedUserType = blockSettings.userTypes.includes('ip');
 			}
 
 			if (!(blockSettings.templateName && showTemplate) && allowedUserType) {


### PR DESCRIPTION
Replaced the `forIPsOnly`, `forTempAccountsOnly` and `forRegisteredOnly` by a single `userTypes` array that can take `'ip'`, `'ta'` and `'named'` as values, to cover more options without multiplying variables. Allowed me to also fix a few that couldn't be treated previously (such as username blocks not showing for TAs anymore). Tested on test.wikipedia.org, block options menu works exactly as intended.