### PR TITLE
styles: simplify and move ombox CSS from morebits.css to twinkle.css

### DIFF
--- a/src/modules/twinkleconfig.js
+++ b/src/modules/twinkleconfig.js
@@ -929,14 +929,18 @@ Twinkle.config.init = function twinkleconfigInit() {
 		// let user know about possible conflict with skin js/common.js file
 		// (settings in that file will still work, but they will be overwritten by twinkleoptions.js settings)
 		if (window.TwinkleConfig || window.FriendlyConfig) {
-			const contentnotice = document.createElement('p');
-			contentnotice.innerHTML = '<table class="plainlinks morebits-ombox morebits-ombox-content"><tr><td class="morebits-mbox-image">' +
-				'<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/3/38/Imbox_content.png" /></td>' +
-				'<td class="morebits-mbox-text"><p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
-				'<p>To do this, you can <a href="' + mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/' + mw.config.get('skin') +
-				'.js', { action: 'edit' }) + '" target="_blank"><b>edit your personal skin javascript file</b></a> or <a href="' +
-				mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/common.js', { action: 'edit'}) + '" target="_blank"><b>your common.js file</b></a>, removing all lines of code that refer to <code>TwinkleConfig</code> and <code>FriendlyConfig</code>.</p>' +
-				'</td></tr></table>';
+			const contentnotice = document.createElement('div');
+			contentnotice.className = 'plainlinks twinkle-ombox';
+			contentnotice.innerHTML =
+				'<div>' +
+					'<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/3/38/Imbox_content.png" />' +
+				'</div>' +
+				'<div>' +
+					'<p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
+					'<p>To do this, you can <a href="' + mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/' + mw.config.get('skin') +
+					'.js', { action: 'edit' }) + '" target="_blank"><b>edit your personal skin javascript file</b></a> or <a href="' +
+					mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/common.js', { action: 'edit'}) + '" target="_blank"><b>your common.js file</b></a>, removing all lines of code that refer to <code>TwinkleConfig</code> and <code>FriendlyConfig</code>.</p>' +
+				'</div>';
 			contentdiv.appendChild(contentnotice);
 		}
 

--- a/src/morebits.css
+++ b/src/morebits.css
@@ -366,33 +366,6 @@ div.morebits-usertext {
 	z-index: 701;
 }
 
-/* For styling message/warning boxes. Cannot use MediaWiki ombox class because it will be deprecated soon. */
-table.morebits-ombox {
-	margin: 4px 10%;
-	border-collapse: collapse;
-	border: 1px solid #a2a9b1;
-	background: var(--background-color-neutral-subtle, #f8f9fa);
-	color: inherit;
-	box-sizing: border-box;
-}
-
-table.morebits-ombox-content {
-	border: 1px solid #f28500;
-}
-
-td.morebits-mbox-image {
-	border: 0;
-	padding: 2px 0 2px 0.9em;
-	text-align: center;
-}
-
-th.morebits-mbox-text,
-td.morebits-mbox-text {
-	border: 0;
-	padding: 0.25em 0.9em;
-	width: 100%;
-}
-
 /* Override select2 silliness */
 .select2-morebits,
 .select2-morebits .select2-results,

--- a/src/twinkle.css
+++ b/src/twinkle.css
@@ -92,6 +92,18 @@ html {
 	color: var(--color-subtle, #54595d);
 }
 
+/* Flexbox gap not supported by old Safari versions. Rendering without gap is okay. */
+/* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+.twinkle-ombox {
+	display: flex;
+	align-items: center;
+	gap: 0.9em;
+	padding-left: 0.9em;
+	margin: 4px 10%;
+	background: var(--background-color-neutral-subtle, #f8f9fa);
+	border: 1px solid #f28500;
+}
+
 @media screen {
 	html.skin-theme-clientpref-night #twinkle-config-headerbox {
 		background: #532b18;


### PR DESCRIPTION
This doesn't belong in morebits.css as the only usage is in twinkleconfig.js. Also, we don't need to match on-wiki ombox styling exactly. This allows simplifying the CSS quite a bit and switching the table with a flex box.