### PR TITLE
morebits: focus on first form element after SimpleWindow display()

### DIFF
--- a/src/morebits.js
+++ b/src/morebits.js
@@ -5821,7 +5821,8 @@ Morebits.SimpleWindow.prototype = {
 			this.$dialog.find('.quickform').addClass('has-scrollbox');
 		}
 		this.$dialog.appendTo(document.body);
-		this.$dialog[0].focus();
+		// Put focus on the first form element or link in the dialog
+		this.$dialog.find('input, select, textarea, a').first().trigger('focus');
 		return this;
 	},
 


### PR DESCRIPTION
Focusing on a form element allows hitting return to submit the form. Some dialogs (eg. unlink, d-batch) don't have form elements immediately when dialog opens, so also allow `<a>` to be focused by default, since we want something in the dialog to be in focus (to allow it to pop to front, and to allow Esc to close the dialog).

For parity with jQuery UI.