### PR TITLE
morebits: focus on dialog if there are no form elements

### DIFF
--- a/src/morebits.js
+++ b/src/morebits.js
@@ -5821,8 +5821,10 @@ Morebits.SimpleWindow.prototype = {
 			this.$dialog.find('.quickform').addClass('has-scrollbox');
 		}
 		this.$dialog.appendTo(document.body);
-		// Put focus on the first form element or link in the dialog
-		this.$dialog.find('input, select, textarea, a').first().trigger('focus');
+		// Put focus on the first form element in the dialog, or on dialog itself.
+		const $firstField = this.$dialog.find('input, select, textarea').first();
+		const $firstFieldOrDialog = $firstField.length ? $firstField : this.$dialog;
+		$firstFieldOrDialog.trigger('focus');
 		return this;
 	},
 


### PR DESCRIPTION
In some cases, there may be no form elements or links. Focus on the first form element if present, else focus on the dialog.

Reported on https://en.wikipedia.org/wiki/User_talk:SD0001#Change_in_morebits_causes_successive_dialogs_to_appear_behind. Also for parity with jQuery UI.