### PR TITLE
arv: don't auto-subscribe to sections on AIV/SPI/AN3

### DIFF
--- a/src/modules/twinklearv.js
+++ b/src/modules/twinklearv.js
@@ -525,6 +525,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					aivPage.setEditSummary('Reporting [[Special:Contributions/' + input.uid + '|' + input.uid + ']].');
 					aivPage.setChangeTags(Twinkle.changeTags);
 					aivPage.setAppendText(Twinkle.arv.callback.buildAivReport(input));
+					aivPage.setDiscussionToolsAutoSubscribe(false);
 					aivPage.append();
 				});
 			});
@@ -561,6 +562,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 
 				// Blank newline per [[Special:Permalink/996949310#Spacing]]; see also [[WP:LISTGAP]] and [[WP:INDENTGAP]]
 				uaaPage.setPageText(text + '\n' + reason + '\n*');
+				uaaPage.setDiscussionToolsAutoSubscribe(false);
 				uaaPage.save();
 			});
 			break;
@@ -592,6 +594,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			spiPage.setChangeTags(Twinkle.changeTags);
 			spiPage.setAppendText(reportData.wikitext);
 			spiPage.setWatchlist(Twinkle.getPref('spiWatchReport'));
+			spiPage.setDiscussionToolsAutoSubscribe(false);
 			spiPage.append();
 
 			Morebits.wiki.removeCheckpoint(); // all page updates have been started
@@ -622,6 +625,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 				an3Page.setEditSummary('Adding new report for [[Special:Contributions/' + data.uid + '|' + data.uid + ']].');
 				an3Page.setChangeTags(Twinkle.changeTags);
 				an3Page.setAppendText(data.reportWikitext);
+				an3Page.setDiscussionToolsAutoSubscribe(false);
 				an3Page.append();
 
 				// notify user


### PR DESCRIPTION
Use the discussiontoolsautosubscribe API parameter to prevent auto-subscribing to AIV/SPI/AN3 report sections when adding an entry in them. Reported on [WT:Twinkle#Auto-subscribing to AIV](https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Auto-subscribing_to_AIV).