### PR TITLE
dev-server: use localhost, not 127.0.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ First, familiarize yourself with the code; most likely, the changes you want are
 
 Manually testing your patch (such as by running Twinkle on localhost using `npm start`, loading it in your testwiki common.js, then clicking around and testing the module that you modified) is required. Please do not submit untested code. Twinkle has 40,000 users, so it is important to keep bugs out of production.
 
-Once you have made your changes, run `npm start`. This launches a webserver listening on `http://127.0.0.1:5500`. So, to load the local version of Twinkle on-wiki, you need to run `mw.loader.load('http://127.0.0.1:5500')` in your browser console. A more permanent solution would be to add that line in your [common.js page](https://en.wikipedia.org/wiki/Special:MyPage/common.js), since code entered in the console does not persist on page navigation.
+Once you have made your changes, run `npm start`. This launches a webserver listening on `http://localhost:5500`. So, to load the local version of Twinkle on-wiki, you need to run `mw.loader.load('http://localhost:5500')` in your browser console. A more permanent solution would be to add that line in your [common.js page](https://en.wikipedia.org/wiki/Special:MyPage/common.js), since code entered in the console does not persist on page navigation.
 
 You can also test your code by simply pasting it into the browser console, but that's not recommended.
 

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -42,7 +42,7 @@ const server = http.createServer(async (request, response) => {
 	response.end(jsCode, 'utf-8');
 });
 
-const hostname = '127.0.0.1';
+const hostname = 'localhost';
 const port = process.env.PORT || '5500';
 const GADGET_NAME = 'Twinkle';
 


### PR DESCRIPTION
Why
- Wikimedia's new CSP policy blocks 127.0.0.1 but allows localhost

What
- update CONTRIBUTING.md
- update dev-server.js