### PR TITLE
xfd: add "desired outcome" dropdown

### DIFF
--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -302,7 +302,6 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 	form.previewer.closePreview();
 
-	let outcome;
 	switch (value) {
 		case 'afd':
 			work_area = new Morebits.QuickForm.Element({
@@ -318,31 +317,32 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				style: 'margin-bottom: 5px; margin-top: -5px;'
 			});
 
-			outcome = work_area.append({
+			work_area.append({
 				type: 'select',
 				name: 'outcome',
-				label: 'Desired outcome:'
-			});
-
-			outcome.append({
-				type: 'option',
-				label: 'Delete',
-				value: 'deletion'
-			});
-			outcome.append({
-				type: 'option',
-				label: 'Merge',
-				value: 'merging'
-			});
-			outcome.append({
-				type: 'option',
-				label: 'Redirect',
-				value: 'redirecting'
-			});
-			outcome.append({
-				type: 'option',
-				label: 'Draftify',
-				value: 'draftification'
+				label: 'Desired outcome:',
+				list: [
+					{
+						type: 'option',
+						label: 'Delete',
+						value: 'deletion'
+					},
+					{
+						type: 'option',
+						label: 'Merge',
+						value: 'merging'
+					},
+					{
+						type: 'option',
+						label: 'Redirect',
+						value: 'redirecting'
+					},
+					{
+						type: 'option',
+						label: 'Draftify',
+						value: 'draftification'
+					}
+				]
 			});
 
 			work_area.append({
@@ -1209,19 +1209,19 @@ Twinkle.xfd.callbacks = {
 
 			let noIncludeStart = '';
 			let noIncludeEnd = '';
-			if ( params.noinclude ) {
+			if (params.noinclude) {
 				noIncludeStart = '<noinclude>';
 				noIncludeEnd = '</noinclude>';
 			}
 
 			let outcome = '';
-			if ( params.outcome !== 'deletion' ) {
+			if (params.outcome !== 'deletion') {
 				outcome = '|outcome=' + params.outcome;
 			}
 
 			let templateAndParams = '';
 			const isFirstNomination = params.number === '';
-			if ( isFirstNomination ) {
+			if (isFirstNomination) {
 				templateAndParams = 'subst:afd|help=off' + outcome;
 			} else {
 				templateAndParams = 'subst:afdx|' + params.number + '|help=off' + outcome;

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -345,18 +345,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				name: 'xfdcat',
 				label: 'Choose what category this nomination belongs in:',
 				list: [
-					{ label: 'Unknown', value: '?', selected: true },
-					{ label: 'Media and music', value: 'M' },
-					{ label: 'Organisation, corporation, or product', value: 'O' },
-					{ label: 'Biographical', value: 'B' },
-					{ label: 'Society topics', value: 'S' },
-					{ label: 'Web or internet', value: 'W' },
-					{ label: 'Games or sports', value: 'G' },
-					{ label: 'Science and technology', value: 'T' },
-					{ label: 'Fiction and the arts', value: 'F' },
-					{ label: 'Places and transportation', value: 'P' },
-					{ label: 'Indiscernible or unclassifiable topic', value: 'I' },
-					{ label: 'Debate not yet sorted', value: 'U' }
+					{ type: 'option', label: 'Unknown', value: '?', selected: true },
+					{ type: 'option', label: 'Media and music', value: 'M' },
+					{ type: 'option', label: 'Organisation, corporation, or product', value: 'O' },
+					{ type: 'option', label: 'Biographical', value: 'B' },
+					{ type: 'option', label: 'Society topics', value: 'S' },
+					{ type: 'option', label: 'Web or internet', value: 'W' },
+					{ type: 'option', label: 'Games or sports', value: 'G' },
+					{ type: 'option', label: 'Science and technology', value: 'T' },
+					{ type: 'option', label: 'Fiction and the arts', value: 'F' },
+					{ type: 'option', label: 'Places and transportation', value: 'P' },
+					{ type: 'option', label: 'Indiscernible or unclassifiable topic', value: 'I' },
+					{ type: 'option', label: 'Debate not yet sorted', value: 'U' }
 				]
 			});
 

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -302,6 +302,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 	form.previewer.closePreview();
 
+	let outcome;
 	switch (value) {
 		case 'afd':
 			work_area = new Morebits.QuickForm.Element({
@@ -315,6 +316,33 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: '', // Added later by Twinkle.makeFindSourcesDiv()
 				id: 'twinkle-xfd-findsources',
 				style: 'margin-bottom: 5px; margin-top: -5px;'
+			});
+
+			outcome = work_area.append({
+				type: 'select',
+				name: 'outcome',
+				label: 'Desired outcome:'
+			});
+
+			outcome.append({
+				type: 'option',
+				label: 'Delete',
+				value: 'deletion'
+			});
+			outcome.append({
+				type: 'option',
+				label: 'Merge',
+				value: 'merging'
+			});
+			outcome.append({
+				type: 'option',
+				label: 'Redirect',
+				value: 'redirecting'
+			});
+			outcome.append({
+				type: 'option',
+				label: 'Draftify',
+				value: 'draftification'
 			});
 
 			work_area.append({
@@ -1179,8 +1207,27 @@ Twinkle.xfd.callbacks = {
 				Twinkle.xfd.callbacks.addToLog(params, null);
 			}
 
-			params.tagText = (params.noinclude ? '<noinclude>{{' : '{{') + (params.number === '' ? 'subst:afd|help=off' : 'subst:afdx|' +
-					params.number + '|help=off') + (params.noinclude ? '}}</noinclude>\n' : '}}\n');
+			let noIncludeStart = '';
+			let noIncludeEnd = '';
+			if ( params.noinclude ) {
+				noIncludeStart = '<noinclude>';
+				noIncludeEnd = '</noinclude>';
+			}
+
+			let outcome = '';
+			if ( params.outcome !== 'deletion' ) {
+				outcome = '|outcome=' + params.outcome;
+			}
+
+			let templateAndParams = '';
+			const isFirstNomination = params.number === '';
+			if ( isFirstNomination ) {
+				templateAndParams = 'subst:afd|help=off' + outcome;
+			} else {
+				templateAndParams = 'subst:afdx|' + params.number + '|help=off' + outcome;
+			}
+
+			params.tagText = noIncludeStart + '{{' + templateAndParams + '}}' + noIncludeEnd + '\n';
 
 			if (pageobj.canEdit()) {
 			// Remove some tags that should always be removed on AfD.

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -322,22 +322,10 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				name: 'outcome',
 				label: 'Desired outcome:',
 				list: [
-					{
-						label: 'Delete',
-						value: 'deletion'
-					},
-					{
-						label: 'Merge',
-						value: 'merging'
-					},
-					{
-						label: 'Redirect',
-						value: 'redirecting'
-					},
-					{
-						label: 'Draftify',
-						value: 'draftification'
-					}
+					{ label: 'Delete', value: 'deletion' },
+					{ label: 'Merge', value: 'merging' },
+					{ label: 'Redirect', value: 'redirecting' },
+					{ label: 'Draftify', value: 'draftification' }
 				]
 			});
 
@@ -357,18 +345,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				name: 'xfdcat',
 				label: 'Choose what category this nomination belongs in:',
 				list: [
-					{ type: 'option', label: 'Unknown', value: '?', selected: true },
-					{ type: 'option', label: 'Media and music', value: 'M' },
-					{ type: 'option', label: 'Organisation, corporation, or product', value: 'O' },
-					{ type: 'option', label: 'Biographical', value: 'B' },
-					{ type: 'option', label: 'Society topics', value: 'S' },
-					{ type: 'option', label: 'Web or internet', value: 'W' },
-					{ type: 'option', label: 'Games or sports', value: 'G' },
-					{ type: 'option', label: 'Science and technology', value: 'T' },
-					{ type: 'option', label: 'Fiction and the arts', value: 'F' },
-					{ type: 'option', label: 'Places and transportation', value: 'P' },
-					{ type: 'option', label: 'Indiscernible or unclassifiable topic', value: 'I' },
-					{ type: 'option', label: 'Debate not yet sorted', value: 'U' }
+					{ label: 'Unknown', value: '?', selected: true },
+					{ label: 'Media and music', value: 'M' },
+					{ label: 'Organisation, corporation, or product', value: 'O' },
+					{ label: 'Biographical', value: 'B' },
+					{ label: 'Society topics', value: 'S' },
+					{ label: 'Web or internet', value: 'W' },
+					{ label: 'Games or sports', value: 'G' },
+					{ label: 'Science and technology', value: 'T' },
+					{ label: 'Fiction and the arts', value: 'F' },
+					{ label: 'Places and transportation', value: 'P' },
+					{ label: 'Indiscernible or unclassifiable topic', value: 'I' },
+					{ label: 'Debate not yet sorted', value: 'U' }
 				]
 			});
 

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -323,22 +323,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Desired outcome:',
 				list: [
 					{
-						type: 'option',
 						label: 'Delete',
 						value: 'deletion'
 					},
 					{
-						type: 'option',
 						label: 'Merge',
 						value: 'merging'
 					},
 					{
-						type: 'option',
 						label: 'Redirect',
 						value: 'redirecting'
 					},
 					{
-						type: 'option',
 						label: 'Draftify',
 						value: 'draftification'
 					}


### PR DESCRIPTION
<img width="681" height="406" alt="2026-04-11_022709" src="https://github.com/user-attachments/assets/fed79654-a3fb-4487-9f30-18df5c4e6bed" />

Why
- a recent RFC decided to bring the merging process into the AFD process

What
- add dropdown called "Desired outcome:" with options Delete, Merge, Redirect, and Draftify
- add |outcome= to tagging wikicode when merge, redirect, or draftify are selected
- refactor tagging wikicode to not use ternaries (more readable)

Note that Twinkle uses {{subst:Afd}} and {{subst:Afdx}}, not {{subst:Article for deletion/dated}} directly. Those two templates will need to be modified with template editor edit requests. That doesn't need to hold up this patch though.

Example wikicode outputted by this patch:

Delete:
- `{{subst:afd|help=off}}\n`
- `{{subst:afdx|18th|help=off}}\n`

Merge:
- `{{subst:afd|help=off|outcome=merging}}\n`
- `{{subst:afdx|18th|help=off|outcome=merging}}\n`

If you want the params in a different order, let me know.

Related #2335