### PR TITLE
morebits: deprecate methods added to HTMLFormElement prototype

### DIFF
--- a/src/modules/twinklespeedy.js
+++ b/src/modules/twinklespeedy.js
@@ -2140,7 +2140,8 @@ Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParamete
  * @return {Array}
  */
 Twinkle.speedy.resolveCsdValues = function twinklespeedyResolveCsdValues(e) {
-	const values = (e.target.form ? e.target.form : e.target).getChecked('csd');
+	const form = e.target.form ? e.target.form : e.target;
+	const values = Morebits.QuickForm.getChecked(form, 'csd');
 	if (values.length === 0) {
 		alert('Please select a criterion!');
 		return null;

--- a/src/modules/twinkletag.js
+++ b/src/modules/twinkletag.js
@@ -363,7 +363,7 @@ let $allCheckboxDivs, $allHeaders;
 Twinkle.tag.updateSortOrder = function(e) {
 	const form = e.target.form;
 	const sortorder = e.target.value;
-	Twinkle.tag.checkedTags = form.getChecked('tags');
+	Twinkle.tag.checkedTags = Morebits.QuickForm.getChecked(form, 'tags');
 
 	const container = new Morebits.QuickForm.Element({ type: 'fragment' });
 
@@ -382,7 +382,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		container.append({ type: 'header', id: 'tagHeader0', label: 'Tags already present' });
 		const subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
 		const checkboxes = [];
-		const unCheckedTags = e.target.form.getUnchecked('existingTags');
+		const unCheckedTags = Morebits.QuickForm.getUnchecked(e.target.form, 'existingTags');
 		Twinkle.tag.alreadyPresentTags.forEach((tag) => {
 			const checkbox =
 				{
@@ -2035,7 +2035,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 	// [array two]] devoid of context.
 	switch (Twinkle.tag.mode) {
 		case 'article':
-			params.tagsToRemove = form.getUnchecked('existingTags'); // not in `input`
+			params.tagsToRemove = Morebits.QuickForm.getUnchecked(form, 'existingTags'); // not in `input`
 			params.tagsToRemain = params.existingTags || []; // container not created if none present
 
 			if ((params.tags.includes('Merge')) || (params.tags.includes('Merge from')) ||

--- a/src/morebits.js
+++ b/src/morebits.js
@@ -1133,56 +1133,25 @@ Morebits.QuickForm.setElementTooltipVisibility = function QuickFormSetElementToo
 };
 
 /**
- * @external HTMLFormElement
- */
-/**
- * Get checked items in the form.
+ * Get checked items in a form.
  *
- * @method external:HTMLFormElement.getChecked
+ * @memberof Morebits.QuickForm
+ * @param {HTMLFormElement} form
  * @param {string} name - Find checked property of elements (i.e. a checkbox
  * or a radiobutton) with the given name, or select options that have selected
  * set to true (don't try to mix selects with radio/checkboxes).
- * @param {string} [type] - Optionally specify either radio or checkbox (for
- * the event that both checkboxes and radiobuttons have the same name).
  * @return {string[]} - Contains the values of elements with the given name
  * checked property set to true.
  */
-HTMLFormElement.prototype.getChecked = function(name, type) {
-	const elements = this.elements[name];
-	if (!elements) {
-		return [];
-	}
+Morebits.QuickForm.getChecked = function QuickFormGetChecked(form, name) {
+	const elements = form.elements[name] || [];
 	const return_array = [];
-	let i;
-	if (elements instanceof HTMLSelectElement) {
-		const options = elements.options;
-		for (i = 0; i < options.length; ++i) {
-			if (options[i].selected) {
-				if (options[i].values) {
-					return_array.push(options[i].values);
-				} else {
-					return_array.push(options[i].value);
-				}
-
-			}
-		}
-	} else if (elements instanceof HTMLInputElement) {
-		if (type && elements.type !== type) {
-			return [];
-		} else if (elements.checked) {
-			return [ elements.value ];
-		}
-	} else {
-		for (i = 0; i < elements.length; ++i) {
-			if (elements[i].checked) {
-				if (type && elements[i].type !== type) {
-					continue;
-				}
-				if (elements[i].values) {
-					return_array.push(elements[i].values);
-				} else {
-					return_array.push(elements[i].value);
-				}
+	for (let i = 0; i < elements.length; ++i) {
+		if (elements[i].checked) {
+			if (elements[i].values) {
+				return_array.push(elements[i].values);
+			} else {
+				return_array.push(elements[i].value);
 			}
 		}
 	}
@@ -1190,57 +1159,56 @@ HTMLFormElement.prototype.getChecked = function(name, type) {
 };
 
 /**
- * Does the same as {@link HTMLFormElement.getChecked|getChecked}, but with unchecked elements.
+ * Does the same as {@link Morebits.QuickForm.getChecked|getChecked}, but with unchecked elements.
  *
- * @method external:HTMLFormElement.getUnchecked
+ * @memberof Morebits.QuickForm
+ * @param {HTMLFormElement} form
  * @param {string} name - Find checked property of elements (i.e. a checkbox
  * or a radiobutton) with the given name, or select options that have selected
  * set to true (don't try to mix selects with radio/checkboxes).
- * @param {string} [type] - Optionally specify either radio or checkbox (for
- * the event that both checkboxes and radiobuttons have the same name).
  * @return {string[]} - Contains the values of elements with the given name
  * checked property set to true.
  */
-HTMLFormElement.prototype.getUnchecked = function(name, type) {
-	const elements = this.elements[name];
-	if (!elements) {
-		return [];
-	}
+Morebits.QuickForm.getUnchecked = function QuickFormGetUnchecked(form, name) {
+	const elements = form.elements[name] || [];
 	const return_array = [];
-	let i;
-	if (elements instanceof HTMLSelectElement) {
-		const options = elements.options;
-		for (i = 0; i < options.length; ++i) {
-			if (!options[i].selected) {
-				if (options[i].values) {
-					return_array.push(options[i].values);
-				} else {
-					return_array.push(options[i].value);
-				}
-
-			}
-		}
-	} else if (elements instanceof HTMLInputElement) {
-		if (type && elements.type !== type) {
-			return [];
-		} else if (!elements.checked) {
-			return [ elements.value ];
-		}
-	} else {
-		for (i = 0; i < elements.length; ++i) {
-			if (!elements[i].checked) {
-				if (type && elements[i].type !== type) {
-					continue;
-				}
-				if (elements[i].values) {
-					return_array.push(elements[i].values);
-				} else {
-					return_array.push(elements[i].value);
-				}
+	for (let i = 0; i < elements.length; ++i) {
+		if (!elements[i].checked) {
+			if (elements[i].values) {
+				return_array.push(elements[i].values);
+			} else {
+				return_array.push(elements[i].value);
 			}
 		}
 	}
 	return return_array;
+};
+
+/**
+ * @external HTMLFormElement
+ */
+/**
+ * Get checked items in the form.
+ *
+ * @deprecated since April 2026. Use {@link Morebits.QuickForm.getChecked} instead.
+ * @method external:HTMLFormElement.getChecked
+ * @param {string} name
+ * @return {string[]}
+ */
+HTMLFormElement.prototype.getChecked = function(name) {
+	return Morebits.QuickForm.getChecked(this, name);
+};
+
+/**
+ * Get unchecked items in the form.
+ *
+ * @deprecated since April 2026. Use {@link Morebits.QuickForm.getUnchecked} instead.
+ * @method external:HTMLFormElement.getUnchecked
+ * @param {string} name
+ * @return {string[]}
+ */
+HTMLFormElement.prototype.getUnchecked = function(name) {
+	return Morebits.QuickForm.getUnchecked(this, name);
 };
 
 /**


### PR DESCRIPTION
morebits: deprecate and simplify methods added to HTMLFormElement prototype

Add `getChecked` and `getUnchecked` methods to `Morebits.QuickForm` and deprecate them from `HTMLFormElement` prototype. Update usage in modules accordingly.

Remove functionality which is not used in Twinkle or any enwiki user scripts:
* Getting checked/unchecked values from select fields and single checkboxes.
* The `type` parameter.

Closes #910