### PR TITLE
eslint: add rules for no space inside parentheses

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,6 @@
 	},
 	"rules": {
 		// default rules we don't like
-		"array-bracket-spacing": "off",
-		"computed-property-spacing": "off",
 		"es-x/no-array-prototype-includes": "off",
 		"es-x/no-promise-prototype-finally": "off",
 		"indent": "off",
@@ -25,9 +23,13 @@
 		"no-jquery/no-global-selector": "off",
 		"no-shadow": "off",
 		"object-curly-spacing": "off",
-		"space-before-function-paren": "off",
-		"space-in-parens": "off",
-		"template-curly-spacing": "off",
+
+		// enforce no spaces in parens
+		"array-bracket-spacing": ["error", "never"],
+		"computed-property-spacing": ["error", "never"],
+		"space-before-function-paren": ["error", "never"],
+		"space-in-parens": ["error", "never"],
+		"template-curly-spacing": ["error", "never"],
 
 		// non-default rules we do like
 		"no-nested-ternary": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
 		"no-shadow": "off",
 		"object-curly-spacing": "off",
 
-		// enforce no spaces in parens
+		// enforce no spaces in parens (https://github.com/wikimedia-gadgets/twinkle/issues/1827)
 		"array-bracket-spacing": ["error", "never"],
 		"computed-property-spacing": ["error", "never"],
 		"space-before-function-paren": ["error", "never"],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -23,12 +23,12 @@ global.assert = assert;
 
 // Node.js assert doesn't support these functions unlike Qunit assert,
 // so temporarily monkey-patch them
-assert.true = function (arg, message) {
+assert.true = function(arg, message) {
 	if (arg !== true) {
 		throw new Error(message);
 	}
 };
-assert.false = function (arg, message) {
+assert.false = function(arg, message) {
 	if (arg !== false) {
 		throw new Error(message);
 	}

--- a/src/modules/twinklearv.js
+++ b/src/modules/twinklearv.js
@@ -28,7 +28,7 @@ Twinkle.arv = function twinklearv() {
 	}, 'ARV', 'tw-arv', 'Report ' + userType + ' to administrators');
 };
 
-Twinkle.arv.callback = function (uid, isIP) {
+Twinkle.arv.callback = function(uid, isIP) {
 	const Window = new Morebits.SimpleWindow(600, 500);
 	Window.setTitle('Advance Reporting and Vetting'); // Backronym
 	Window.setScriptName('Twinkle');
@@ -141,7 +141,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 	result.category.dispatchEvent(evt);
 };
 
-Twinkle.arv.callback.changeCategory = function (e) {
+Twinkle.arv.callback.changeCategory = function(e) {
 	const value = e.target.value;
 	const root = e.target.form;
 	const old_area = Morebits.QuickForm.getElements(root, 'work_area')[0];
@@ -714,7 +714,7 @@ Twinkle.arv.callback.getUsernameReportWikitext = function(input) {
 	if (input.arvtype.length <= 2) {
 		input.arvtype = input.arvtype.join(' and ');
 	} else {
-		input.arvtype = [ input.arvtype.slice(0, -1).join(', '), input.arvtype.slice(-1) ].join(' and ');
+		input.arvtype = [input.arvtype.slice(0, -1).join(', '), input.arvtype.slice(-1)].join(' and ');
 	}
 
 	// a or an?

--- a/src/modules/twinkleblock.js
+++ b/src/modules/twinkleblock.js
@@ -655,7 +655,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			Twinkle.block.callback.preview($form[0]);
 		});
 		$previewlink.css({cursor: 'pointer'});
-		fieldTemplateOptions.append({ type: 'div', id: 'blockpreview', label: [ $previewlink[0] ] });
+		fieldTemplateOptions.append({ type: 'div', id: 'blockpreview', label: [$previewlink[0]] });
 		fieldTemplateOptions.append({ type: 'div', id: 'twinkleblock-previewbox', style: 'display: none' });
 	} else if (fieldPreset) {
 		// Only visible for arbitration enforcement, toggled in change_preset
@@ -2022,7 +2022,7 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 		// Building the template, however, takes a fair bit of logic
 		if (params.partial) {
 			if (params.pagerestrictions.length || params.namespacerestrictions.length) {
-				const makeSentence = function (array) {
+				const makeSentence = function(array) {
 					if (array.length < 3) {
 						return array.join(' and ');
 					}

--- a/src/modules/twinkleconfig.js
+++ b/src/modules/twinkleconfig.js
@@ -82,9 +82,9 @@ Twinkle.config.commonSets = {
 	}
 };
 
-Twinkle.config.commonSets.csdCriteriaDisplayOrder = Object.keys( Twinkle.config.commonSets.csdCriteria );
-Twinkle.config.commonSets.csdCriteriaNotificationDisplayOrder = Object.keys( Twinkle.config.commonSets.csdCriteriaNotification );
-Twinkle.config.commonSets.csdAndImageDeletionCriteriaDisplayOrder = Object.keys( Twinkle.config.commonSets.csdAndImageDeletionCriteria );
+Twinkle.config.commonSets.csdCriteriaDisplayOrder = Object.keys(Twinkle.config.commonSets.csdCriteria);
+Twinkle.config.commonSets.csdCriteriaNotificationDisplayOrder = Object.keys(Twinkle.config.commonSets.csdCriteriaNotification);
+Twinkle.config.commonSets.csdAndImageDeletionCriteriaDisplayOrder = Object.keys(Twinkle.config.commonSets.csdAndImageDeletionCriteria);
 
 /**
  * Section entry format:

--- a/src/modules/twinklediff.js
+++ b/src/modules/twinklediff.js
@@ -47,7 +47,7 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 		action: 'query',
 		titles: mw.config.get('wgPageName'),
 		rvlimit: 1,
-		rvprop: [ 'ids', 'user' ],
+		rvprop: ['ids', 'user'],
 		rvstartid: mw.config.get('wgCurRevisionId') - 1, // i.e. not the current one
 		rvuser: user,
 		format: 'json'

--- a/src/modules/twinkleimage.js
+++ b/src/modules/twinkleimage.js
@@ -240,7 +240,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 		// No auto-notification, display what was going to be added.
 		const noteData = document.createElement('pre');
 		noteData.appendChild(document.createTextNode('{{subst:di-' + templatename + '-notice|1=' + mw.config.get('wgTitle') + '}} ~~~~'));
-		Morebits.Status.info('Notification', [ 'Following/similar data should be posted to the original uploader:', document.createElement('br'), noteData ]);
+		Morebits.Status.info('Notification', ['Following/similar data should be posted to the original uploader:', document.createElement('br'), noteData]);
 	}
 };
 
@@ -249,7 +249,7 @@ Twinkle.image.callbacks = {
 		let text = pageobj.getPageText();
 		const params = pageobj.getCallbackParameters();
 
-		text = Twinkle.removeMoveToCommonsTagsFromWikicode( text );
+		text = Twinkle.removeMoveToCommonsTagsFromWikicode(text);
 
 		let tag = '{{di-' + params.templatename + '|date={{subst:#time:j F Y}}';
 		switch (params.type) {

--- a/src/modules/twinkleprod.js
+++ b/src/modules/twinkleprod.js
@@ -450,18 +450,18 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	tm.add(cbs.checkPriors, []);
 	tm.add(cbs.fetchCreationInfo, []);
 	// tag the page once we're clear of the pre-requisites
-	tm.add(cbs.taggingPage, [ cbs.checkPriors, cbs.fetchCreationInfo ]);
+	tm.add(cbs.taggingPage, [cbs.checkPriors, cbs.fetchCreationInfo]);
 	// notify the author once we know who's the author, and also wait for the
 	// taggingPage() as we don't need to notify if tagging was not done, such as
 	// there was already a tag and the user chose not to endorse.
-	tm.add(cbs.notifyAuthor, [ cbs.fetchCreationInfo, cbs.taggingPage ]);
+	tm.add(cbs.notifyAuthor, [cbs.fetchCreationInfo, cbs.taggingPage]);
 	// oldProd needs to be added only if there wasn't one before, so need to wait
 	// for checkPriors() to finish. Also don't add oldProd if tagging itself was
 	// aborted or unsuccessful
-	tm.add(cbs.addOldProd, [ cbs.taggingPage, cbs.checkPriors ]);
+	tm.add(cbs.addOldProd, [cbs.taggingPage, cbs.checkPriors]);
 	// add to log only after notifying author so that the logging can be adjusted if
 	// notification wasn't successful. Also, don't run if tagging was not done.
-	tm.add(cbs.addToLog, [ cbs.notifyAuthor, cbs.taggingPage ]);
+	tm.add(cbs.addToLog, [cbs.notifyAuthor, cbs.taggingPage]);
 	// All set, go!
 	tm.execute().then(() => {
 		Morebits.Status.actionCompleted('Tagging complete');

--- a/src/modules/twinkleprotect.js
+++ b/src/modules/twinkleprotect.js
@@ -1521,13 +1521,13 @@ Twinkle.protect.callbacks = {
 			rppLink.appendChild(document.createTextNode('Wikipedia:Requests for page protection'));
 
 			if (tag) {
-				statusElement.error([ 'There is already a protection request for this page at ', rppLink, ', aborting.' ]);
+				statusElement.error(['There is already a protection request for this page at ', rppLink, ', aborting.']);
 				return;
 			}
 
 			let newtag = '=== [[:' + Morebits.pageNameNorm + ']] ===\n';
 			if (new RegExp('^' + mw.util.escapeRegExp(newtag).replace(/\s+/g, '\\s*'), 'm').test(text) || new RegExp('^' + mw.util.escapeRegExp(newtag).replace(/\s+/g, '\\s*'), 'm').test(text2)) {
-				statusElement.error([ 'There is already a protection request for this page at ', rppLink, ', aborting.' ]);
+				statusElement.error(['There is already a protection request for this page at ', rppLink, ', aborting.']);
 				return;
 			}
 			newtag += '* {{pagelinks|1=' + Morebits.pageNameNorm + '}}\n\n';
@@ -1590,7 +1590,7 @@ Twinkle.protect.callbacks = {
 					const linknode = document.createElement('a');
 					linknode.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing RPP'));
 					linknode.appendChild(document.createTextNode('How to fix RPP'));
-					statusElement.error([ 'Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode, '.' ]);
+					statusElement.error(['Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode, '.']);
 					return;
 				}
 				statusElement.status('Adding new request...');
@@ -1626,7 +1626,7 @@ Twinkle.protect.callbacks = {
 					const linknode2 = document.createElement('a');
 					linknode2.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing RPP'));
 					linknode2.appendChild(document.createTextNode('How to fix RPP'));
-					statusElement.error([ 'Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode2, '.' ]);
+					statusElement.error(['Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode2, '.']);
 					return;
 				}
 				statusElement.status('Adding new request...');

--- a/src/modules/twinklerollback.js
+++ b/src/modules/twinklerollback.js
@@ -407,7 +407,7 @@ Twinkle.rollback.revert = function revertPage(type, vandal, rev, page) {
 		inprop: 'watched',
 		intestactions: 'edit',
 		rvlimit: Twinkle.getPref('revertMaxRevisions'),
-		rvprop: [ 'ids', 'timestamp', 'user' ],
+		rvprop: ['ids', 'timestamp', 'user'],
 		curtimestamp: '',
 		meta: 'tokens',
 		type: 'csrf',
@@ -429,7 +429,7 @@ Twinkle.rollback.revertToRevision = function revertToRevision(oldrev) {
 		inprop: 'watched',
 		rvlimit: 1,
 		rvstartid: oldrev,
-		rvprop: [ 'ids', 'user' ],
+		rvprop: ['ids', 'user'],
 		curtimestamp: '',
 		meta: 'tokens',
 		type: 'csrf',
@@ -535,7 +535,7 @@ Twinkle.rollback.callbacks = {
 		const lastuser = top.user;
 
 		if (lastrevid < params.revid) {
-			Morebits.Status.error('Error', [ 'The most recent revision ID received from the server, ', Morebits.htmlNode('strong', lastrevid), ', is less than the ID of the displayed revision. This could indicate that the current revision has been deleted, the server is lagging, or that bad data has been received. Stopping revert.' ]);
+			Morebits.Status.error('Error', ['The most recent revision ID received from the server, ', Morebits.htmlNode('strong', lastrevid), ', is less than the ID of the displayed revision. This could indicate that the current revision has been deleted, the server is lagging, or that bad data has been received. Stopping revert.']);
 			return;
 		}
 
@@ -543,20 +543,20 @@ Twinkle.rollback.callbacks = {
 		let userNorm = params.user || Twinkle.rollback.hiddenName;
 		let index = 1;
 		if (params.revid !== lastrevid) {
-			Morebits.Status.warn('Warning', [ 'Latest revision ', Morebits.htmlNode('strong', lastrevid), ' doesn\'t equal our revision ', Morebits.htmlNode('strong', params.revid) ]);
+			Morebits.Status.warn('Warning', ['Latest revision ', Morebits.htmlNode('strong', lastrevid), ' doesn\'t equal our revision ', Morebits.htmlNode('strong', params.revid)]);
 			// Treat ipv6 users on same 64 block as the same
 			if (lastuser === params.user || (mw.util.isIPv6Address(params.user) && Morebits.ip.get64(lastuser) === Morebits.ip.get64(params.user))) {
 				switch (params.type) {
 					case 'vand':
 						var diffUser = lastuser !== params.user;
-						Morebits.Status.info('Info', [ 'Latest revision was ' + (diffUser ? '' : 'also ') + 'made by ', Morebits.htmlNode('strong', userNorm),
-							diffUser ? ', which is on the same /64 subnet' : '', '. As we assume vandalism, we will proceed to revert.' ]);
+						Morebits.Status.info('Info', ['Latest revision was ' + (diffUser ? '' : 'also ') + 'made by ', Morebits.htmlNode('strong', userNorm),
+							diffUser ? ', which is on the same /64 subnet' : '', '. As we assume vandalism, we will proceed to revert.']);
 						break;
 					case 'agf':
-						Morebits.Status.warn('Warning', [ 'Latest revision was made by ', Morebits.htmlNode('strong', userNorm), '. As we assume good faith, we will stop the revert, as the problem might have been fixed.' ]);
+						Morebits.Status.warn('Warning', ['Latest revision was made by ', Morebits.htmlNode('strong', userNorm), '. As we assume good faith, we will stop the revert, as the problem might have been fixed.']);
 						return;
 					default:
-						Morebits.Status.warn('Notice', [ 'Latest revision was made by ', Morebits.htmlNode('strong', userNorm), ', but we will stop the revert.' ]);
+						Morebits.Status.warn('Notice', ['Latest revision was made by ', Morebits.htmlNode('strong', userNorm), ', but we will stop the revert.']);
 						return;
 				}
 			} else if (params.type === 'vand' &&
@@ -564,10 +564,10 @@ Twinkle.rollback.callbacks = {
 					// Besides, none of the trusted bots are going to be revdel'd
 					Twinkle.rollback.trustedBots.includes(top.user) && revs.length > 1 &&
 					revs[1].revid === params.revid) {
-				Morebits.Status.info('Info', [ 'Latest revision was made by ', Morebits.htmlNode('strong', lastuser), ', a trusted bot, and the revision before was made by our vandal, so we will proceed with the revert.' ]);
+				Morebits.Status.info('Info', ['Latest revision was made by ', Morebits.htmlNode('strong', lastuser), ', a trusted bot, and the revision before was made by our vandal, so we will proceed with the revert.']);
 				index = 2;
 			} else {
-				Morebits.Status.error('Error', [ 'Latest revision was made by ', Morebits.htmlNode('strong', lastuser), ', so it might have already been reverted, we will stop the revert.']);
+				Morebits.Status.error('Error', ['Latest revision was made by ', Morebits.htmlNode('strong', lastuser), ', so it might have already been reverted, we will stop the revert.']);
 				return;
 			}
 
@@ -581,26 +581,26 @@ Twinkle.rollback.callbacks = {
 		if (Twinkle.rollback.trustedBots.includes(params.user)) {
 			switch (params.type) {
 				case 'vand':
-					Morebits.Status.info('Info', [ 'Vandalism revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. As this is a trusted bot, we assume you wanted to revert vandalism made by the previous user instead.' ]);
+					Morebits.Status.info('Info', ['Vandalism revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. As this is a trusted bot, we assume you wanted to revert vandalism made by the previous user instead.']);
 					index = 2;
 					params.user = revs[1].user;
 					params.userHidden = !!revs[1].userhidden;
 					break;
 				case 'agf':
-					Morebits.Status.warn('Notice', [ 'Good faith revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. This is a trusted bot and thus AGF rollback will not proceed.' ]);
+					Morebits.Status.warn('Notice', ['Good faith revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. This is a trusted bot and thus AGF rollback will not proceed.']);
 					return;
 				case 'norm':
 				/* falls through */
 				default:
 					var cont = confirm('Normal revert was chosen, but the most recent edit was made by a trusted bot (' + userNorm + '). Do you want to revert the revision before instead?');
 					if (cont) {
-						Morebits.Status.info('Info', [ 'Normal revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. This is a trusted bot, and per confirmation, we\'ll revert the previous revision instead.' ]);
+						Morebits.Status.info('Info', ['Normal revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. This is a trusted bot, and per confirmation, we\'ll revert the previous revision instead.']);
 						index = 2;
 						params.user = revs[1].user;
 						params.userHidden = !!revs[1].userhidden;
 						userNorm = params.user || Twinkle.rollback.hiddenName;
 					} else {
-						Morebits.Status.warn('Notice', [ 'Normal revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. This is a trusted bot, but per confirmation, revert on selected revision will proceed.' ]);
+						Morebits.Status.warn('Notice', ['Normal revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. This is a trusted bot, but per confirmation, revert on selected revision will proceed.']);
 					}
 					break;
 			}
@@ -626,7 +626,7 @@ Twinkle.rollback.callbacks = {
 		}
 
 		if (!found) {
-			statelem.error([ 'No previous revision found. Perhaps ', Morebits.htmlNode('strong', userNorm), ' is the only contributor, or they have made more than ' + mw.language.convertNumber(Twinkle.getPref('revertMaxRevisions')) + ' edits in a row.' ]);
+			statelem.error(['No previous revision found. Perhaps ', Morebits.htmlNode('strong', userNorm), ' is the only contributor, or they have made more than ' + mw.language.convertNumber(Twinkle.getPref('revertMaxRevisions')) + ' edits in a row.']);
 			return;
 		}
 
@@ -651,7 +651,7 @@ Twinkle.rollback.callbacks = {
 		params.gooduser = good_revision.user;
 		params.gooduserHidden = !!good_revision.userhidden;
 
-		statelem.status([ ' revision ', Morebits.htmlNode('strong', params.goodid), ' that was made ', Morebits.htmlNode('strong', mw.language.convertNumber(count)), ' revisions ago by ', Morebits.htmlNode('strong', params.gooduserHidden ? Twinkle.rollback.hiddenName : params.gooduser) ]);
+		statelem.status([' revision ', Morebits.htmlNode('strong', params.goodid), ' that was made ', Morebits.htmlNode('strong', mw.language.convertNumber(count)), ' revisions ago by ', Morebits.htmlNode('strong', params.gooduserHidden ? Twinkle.rollback.hiddenName : params.gooduser)]);
 
 		let summary, extra_summary;
 		switch (params.type) {
@@ -763,7 +763,7 @@ Twinkle.rollback.callbacks = {
 		wikipedia_api.post();
 
 	},
-	complete: function (apiobj) {
+	complete: function(apiobj) {
 		// TODO Most of this is copy-pasted from Morebits.wiki.Page#fnSaveSuccess. Unify it
 		const response = apiobj.getResponse();
 		const edit = response.edit;
@@ -777,7 +777,7 @@ Twinkle.rollback.callbacks = {
 			const params = apiobj.params;
 
 			if (params.notifyUser && !params.userHidden) { // notifyUser only from main, not from toRevision
-				Morebits.Status.info('Info', [ 'Opening user talk page edit form for user ', Morebits.htmlNode('strong', params.user) ]);
+				Morebits.Status.info('Info', ['Opening user talk page edit form for user ', Morebits.htmlNode('strong', params.user)]);
 
 				const url = mw.util.getUrl('User talk:' + params.user, {
 					action: 'edit',

--- a/src/modules/twinklespeedy.js
+++ b/src/modules/twinklespeedy.js
@@ -411,7 +411,7 @@ Twinkle.speedy.data = [
 		code: 'g1',
 		db: 'nonsense',
 		tooltip: 'This does not include poor writing, partisan screeds, obscene remarks, vandalism, fictional material, material not in English, poorly translated material, implausible theories, or hoaxes. In short, if you can understand it, G1 does not apply.',
-		hideInNamespaces: [ 2 ] // Not applicable in userspace
+		hideInNamespaces: [2] // Not applicable in userspace
 	},
 	{
 		list: 'generalList',
@@ -419,7 +419,7 @@ Twinkle.speedy.data = [
 		code: 'g2',
 		db: 'test',
 		tooltip: 'A page created to test editing or other Wikipedia functions. Pages in the User namespace are not included, nor are valid but unused or duplicate templates.',
-		hideInNamespaces: [ 2 ] // Not applicable in userspace
+		hideInNamespaces: [2] // Not applicable in userspace
 	},
 	{
 		list: 'generalList',
@@ -603,7 +603,7 @@ Twinkle.speedy.data = [
 		db: 'subpage',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true,
-		hideInNamespaces: [ 0, 6, 8 ] // hide in main, file, and mediawiki-spaces
+		hideInNamespaces: [0, 6, 8] // hide in main, file, and mediawiki-spaces
 	},
 	{
 		list: 'generalList',
@@ -711,7 +711,7 @@ Twinkle.speedy.data = [
 		code: 'r2',
 		db: 'rediruser',
 		tooltip: 'This does not include the pseudo-namespace shortcuts. If this was the result of a page move, consider waiting a day or two before deleting the redirect',
-		showInNamespaces: [ 0 ]
+		showInNamespaces: [0]
 	},
 	{
 		list: 'redirectList',
@@ -726,7 +726,7 @@ Twinkle.speedy.data = [
 		code: 'r4',
 		db: 'redircom',
 		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).',
-		showInNamespaces: [ 6 ]
+		showInNamespaces: [6]
 	},
 	{
 		list: 'redirectList',
@@ -756,7 +756,7 @@ Twinkle.speedy.data = [
 /**
  * Given a list name such as talkList, fileList, redirectList, etc, return the CSDs that should be in that list.
  */
-Twinkle.speedy.getCsdList = ( csdList ) => {
+Twinkle.speedy.getCsdList = (csdList) => {
 	const list = [];
 	for (const item of Twinkle.speedy.data) {
 		if (item.list === csdList) {
@@ -772,16 +772,16 @@ Twinkle.speedy.getCsdList = ( csdList ) => {
 	return list;
 };
 
-Twinkle.speedy.customRationale = Twinkle.speedy.getCsdList( 'customRationale' );
-Twinkle.speedy.talkList = Twinkle.speedy.getCsdList( 'talkList' );
-Twinkle.speedy.fileList = Twinkle.speedy.getCsdList( 'fileList' );
-Twinkle.speedy.articleList = Twinkle.speedy.getCsdList( 'articleList' );
-Twinkle.speedy.categoryList = Twinkle.speedy.getCsdList( 'categoryList' );
-Twinkle.speedy.templateList = Twinkle.speedy.getCsdList( 'templateList' );
-Twinkle.speedy.userList = Twinkle.speedy.getCsdList( 'userList' );
-Twinkle.speedy.generalList = Twinkle.speedy.getCsdList( 'generalList' );
-Twinkle.speedy.redirectList = Twinkle.speedy.getCsdList( 'redirectList' );
-Twinkle.speedy.timedTextList = Twinkle.speedy.getCsdList( 'timedTextList' );
+Twinkle.speedy.customRationale = Twinkle.speedy.getCsdList('customRationale');
+Twinkle.speedy.talkList = Twinkle.speedy.getCsdList('talkList');
+Twinkle.speedy.fileList = Twinkle.speedy.getCsdList('fileList');
+Twinkle.speedy.articleList = Twinkle.speedy.getCsdList('articleList');
+Twinkle.speedy.categoryList = Twinkle.speedy.getCsdList('categoryList');
+Twinkle.speedy.templateList = Twinkle.speedy.getCsdList('templateList');
+Twinkle.speedy.userList = Twinkle.speedy.getCsdList('userList');
+Twinkle.speedy.generalList = Twinkle.speedy.getCsdList('generalList');
+Twinkle.speedy.redirectList = Twinkle.speedy.getCsdList('redirectList');
+Twinkle.speedy.timedTextList = Twinkle.speedy.getCsdList('timedTextList');
 
 /**
  * Iterate over Twinkle.speedy.data. Turn `code: 'g8', db: 'redirnone',` into `redirnone: 'g8',`
@@ -895,7 +895,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 					name: 'redirects',
 					tooltip: 'This option deletes all incoming redirects in addition. Avoid this option for procedural (e.g. move/merge) deletions.',
 					checked: Twinkle.getPref('deleteRedirectsOnDelete'),
-					event: function (event) {
+					event: function(event) {
 						event.stopPropagation();
 					}
 				},
@@ -1127,7 +1127,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 	}
 };
 
-Twinkle.speedy.callback.priorDeletionCount = function () {
+Twinkle.speedy.callback.priorDeletionCount = function() {
 	const query = {
 		action: 'query',
 		format: 'json',
@@ -1519,7 +1519,7 @@ Twinkle.speedy.callbacks = {
 						Morebits.wiki.actionCompleted.redirect = null;
 						Twinkle.speedy.dialog.close();
 						Twinkle.unlink.callback('Removing links to deleted page ' + Morebits.pageNameNorm);
-					} );
+					});
 				$bigtext = $('<span>')
 					.text('To orphan backlinks')
 					.css({
@@ -1619,7 +1619,7 @@ Twinkle.speedy.callbacks = {
 				// Remove tags that become superfluous with this action
 				text = text.replace(/\{\{\s*([Uu]serspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, '');
 				if (mw.config.get('wgNamespaceNumber') === 6) {
-					text = Twinkle.removeMoveToCommonsTagsFromWikicode( text );
+					text = Twinkle.removeMoveToCommonsTagsFromWikicode(text);
 				}
 
 				if (params.requestsalt) {

--- a/src/modules/twinkletag.js
+++ b/src/modules/twinkletag.js
@@ -99,7 +99,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 				const searchString = this.value;
 				const searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
 
-				$allCheckboxDivs.find('label').each(function () {
+				$allCheckboxDivs.find('label').each(function() {
 					const labelText = this.textContent;
 					const searchHit = searchRegex.exec(labelText);
 					if (searchHit) {
@@ -247,7 +247,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 				form.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
 				const subdiv = form.append({ type: 'div', id: 'tagSubdiv' + i++ });
 				$.each(group, (subgroupName, subgroup) => {
-					subdiv.append({ type: 'div', label: [ Morebits.htmlNode('b', subgroupName) ] });
+					subdiv.append({ type: 'div', label: [Morebits.htmlNode('b', subgroupName)] });
 					subdiv.append({
 						type: 'checkbox',
 						name: 'tags',
@@ -368,7 +368,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	const container = new Morebits.QuickForm.Element({ type: 'fragment' });
 
 	// function to generate a checkbox, with appropriate subgroup if needed
-	const makeCheckbox = function (item) {
+	const makeCheckbox = function(item) {
 		const tag = item.tag, description = item.description;
 		const checkbox = { value: tag, label: '{{' + tag + '}}: ' + description };
 		if (Twinkle.tag.checkedTags.includes(tag)) {
@@ -429,7 +429,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 				doCategoryCheckboxes(subdiv, group);
 			} else {
 				$.each(group, (subgroupName, subgroup) => {
-					subdiv.append({ type: 'div', label: [ Morebits.htmlNode('b', subgroupName) ] });
+					subdiv.append({ type: 'div', label: [Morebits.htmlNode('b', subgroupName)] });
 					doCategoryCheckboxes(subdiv, subgroup);
 				});
 			}
@@ -533,11 +533,11 @@ const translationSubgroups = [
 ].concat(mw.config.get('wgNamespaceNumber') === 0 ? [
 	{
 		type: 'checkbox',
-		list: [ {
+		list: [{
 			name: 'translationPostAtPNT',
 			label: 'List this article at Wikipedia:Pages needing translation into English (PNT)',
 			checked: true
-		} ]
+		}]
 	},
 	{
 		name: 'translationComments',
@@ -1604,7 +1604,7 @@ Twinkle.tag.callbacks = {
 				const subgroupObj = Twinkle.tag.article.flatObject[tagName] &&
 					Twinkle.tag.article.flatObject[tagName].subgroup;
 				if (subgroupObj) {
-					const subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
+					const subgroups = Array.isArray(subgroupObj) ? subgroupObj : [subgroupObj];
 					subgroups.forEach((gr) => {
 						if (gr.parameter && (params[gr.name] || gr.required)) {
 							currentTag += '|' + gr.parameter + '=' + (params[gr.name] || '');
@@ -1904,7 +1904,7 @@ Twinkle.tag.callbacks = {
 			$.each(params.tags, (k, tag) => {
 				// when other commons-related tags are placed, remove "move to Commons" tag
 				if (['Keep local', 'Do not move to Commons'].includes(tag)) {
-					text = Twinkle.removeMoveToCommonsTagsFromWikicode( text );
+					text = Twinkle.removeMoveToCommonsTagsFromWikicode(text);
 				}
 
 				currentTag = tag;

--- a/src/modules/twinkletalkback.js
+++ b/src/modules/twinkletalkback.js
@@ -66,7 +66,7 @@ Twinkle.talkback.callback = function() {
 	});
 	previewlink.style.cursor = 'pointer';
 	previewlink.textContent = 'Preview';
-	form.append({ type: 'div', id: 'talkbackpreview', label: [ previewlink ] });
+	form.append({ type: 'div', id: 'talkbackpreview', label: [previewlink] });
 	form.append({ type: 'div', id: 'twinkletalkback-previewbox', style: 'display: none' });
 
 	form.append({ type: 'submit' });

--- a/src/modules/twinklewarn.js
+++ b/src/modules/twinklewarn.js
@@ -121,7 +121,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	});
 	previewlink.style.cursor = 'pointer';
 	previewlink.textContent = 'Preview';
-	more.append({ type: 'div', id: 'warningpreview', label: [ previewlink ] });
+	more.append({ type: 'div', id: 'warningpreview', label: [previewlink] });
 	more.append({ type: 'div', id: 'twinklewarn-previewbox', style: 'display: none' });
 
 	more.append({ type: 'submit', label: 'Submit' });

--- a/src/modules/twinklewelcome.js
+++ b/src/modules/twinklewelcome.js
@@ -162,7 +162,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 	});
 	previewlink.style.cursor = 'pointer';
 	previewlink.textContent = 'Preview';
-	form.append({ type: 'div', name: 'welcomepreview', label: [ previewlink ] });
+	form.append({ type: 'div', name: 'welcomepreview', label: [previewlink] });
 
 	form.append({ type: 'submit' });
 

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -143,7 +143,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	categories.append({
 		type: 'option',
 		label: 'TfD (Templates for discussion)',
-		selected: [ 10, 828 ].includes(namespace), // Template and module namespaces
+		selected: [10, 828].includes(namespace), // Template and module namespaces
 		value: 'tfd'
 	});
 	categories.append({
@@ -166,7 +166,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	categories.append({
 		type: 'option',
 		label: 'MfD (Miscellany for deletion)',
-		selected: ![ 0, 6, 10, 14, 828 ].includes(namespace) || Morebits.pageNameNorm.indexOf('Template:User ', 0) === 0,
+		selected: ![0, 6, 10, 14, 828].includes(namespace) || Morebits.pageNameNorm.indexOf('Template:User ', 0) === 0,
 		// Other namespaces, and userboxes in template namespace
 		value: 'mfd'
 	});
@@ -213,7 +213,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	});
 	previewlink.style.cursor = 'pointer';
 	previewlink.textContent = 'Preview';
-	form.append({ type: 'div', id: 'xfdpreview', label: [ previewlink ] });
+	form.append({ type: 'div', id: 'xfdpreview', label: [previewlink] });
 	form.append({ type: 'div', id: 'twinklexfd-previewbox', style: 'display: none' });
 
 	form.append({ type: 'submit' });
@@ -249,7 +249,7 @@ Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(ve
 			}
 			break;
 		case 'cfd':
-			if (![ 10, 14 ].includes(namespace)) {
+			if (![10, 14].includes(namespace)) {
 				text = 'CfD is only for categories and stub templates.';
 			}
 			break;
@@ -1246,7 +1246,7 @@ Twinkle.xfd.callbacks = {
 					const linknode = document.createElement('a');
 					linknode.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing AFD') + '?action=purge');
 					linknode.appendChild(document.createTextNode('How to fix AFD'));
-					statelem.error([ 'Could not find the target spot for the discussion. To fix this problem, please see ', linknode, '.' ]);
+					statelem.error(['Could not find the target spot for the discussion. To fix this problem, please see ', linknode, '.']);
 					return;
 				}
 			}
@@ -1293,7 +1293,7 @@ Twinkle.xfd.callbacks = {
 				if (watchModule) {
 					watch_query = {
 						action: 'watch',
-						titles: [ mw.config.get('wgPageName') ],
+						titles: [mw.config.get('wgPageName')],
 						token: mw.user.tokens.get('watchToken')
 					};
 					// Only add the expiry if page is unwatched or already temporarily watched
@@ -1654,7 +1654,7 @@ Twinkle.xfd.callbacks = {
 
 			params.tagText = '{{ffd|log=' + date + '|help=off}}\n';
 			if (pageobj.canEdit()) {
-				text = Twinkle.removeMoveToCommonsTagsFromWikicode( text );
+				text = Twinkle.removeMoveToCommonsTagsFromWikicode(text);
 
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Listed for discussion at [[:' + params.discussionpage + ']].');

--- a/src/morebits.js
+++ b/src/morebits.js
@@ -57,7 +57,7 @@ Morebits.l10n = {
 	 * @param {string} str
 	 * @return {number[] | null}
 	 */
-	signatureTimestampFormat: function (str) {
+	signatureTimestampFormat: function(str) {
 		// HH:mm, DD Month YYYY (UTC)
 		const rgx = /(\d{2}):(\d{2}), (\d{1,2}) (\w+) (\d{4}) \(UTC\)/;
 		const match = rgx.exec(str);
@@ -79,7 +79,7 @@ Morebits.l10n = {
  * @param {string} group - e.g. `sysop`, `extendedconfirmed`, etc.
  * @return {boolean}
  */
-Morebits.userIsInGroup = function (group) {
+Morebits.userIsInGroup = function(group) {
 	return mw.config.get('wgUserGroups').includes(group);
 };
 /**
@@ -143,7 +143,7 @@ Morebits.createHtml = function(input) {
 		return fragment;
 	}
 	if (!Array.isArray(input)) {
-		input = [ input ];
+		input = [input];
 	}
 	for (let i = 0; i < input.length; ++i) {
 		if (input[i] instanceof Node) {
@@ -163,7 +163,7 @@ Morebits.createHtml = function(input) {
  * @param {string} text
  * @return {string}
  */
-Morebits.createHtml.renderWikilinks = function (text) {
+Morebits.createHtml.renderWikilinks = function(text) {
 	const ub = new Morebits.Unbinder(text);
 	// Don't convert wikilinks within code tags as they're used for displaying wiki-code
 	ub.unbind('<code>', '</code>');
@@ -388,7 +388,7 @@ Morebits.QuickForm.Element.prototype.compute = function QuickFormElementCompute(
 		case 'fragment':
 			node = document.createDocumentFragment();
 			// fragments can't have any attributes, so just return it straight away
-			return [ node, node ];
+			return [node, node];
 		// Sometimes Twinkle uses fancy searchable "select" elements. This is powered by the third party library "select2". Activate it by creating a Morebits "select" element, then call `$('select[name=sub_group]').select2({});` or similar towards the end of your main code.
 		case 'select':
 			node = document.createElement('div');
@@ -526,7 +526,7 @@ Morebits.QuickForm.Element.prototype.compute = function QuickFormElementCompute(
 						let tmpgroup = current.subgroup;
 
 						if (!Array.isArray(tmpgroup)) {
-							tmpgroup = [ tmpgroup ];
+							tmpgroup = [tmpgroup];
 						}
 
 						var subgroupRaw = new Morebits.QuickForm.Element({
@@ -860,7 +860,7 @@ Morebits.QuickForm.Element.prototype.compute = function QuickFormElementCompute(
 	}
 	childContainer.setAttribute('id', data.id || id);
 
-	return [ node, childContainer ];
+	return [node, childContainer];
 };
 
 Morebits.QuickForm.$tooltip = null;
@@ -1170,7 +1170,7 @@ HTMLFormElement.prototype.getChecked = function(name, type) {
 		if (type && elements.type !== type) {
 			return [];
 		} else if (elements.checked) {
-			return [ elements.value ];
+			return [elements.value];
 		}
 	} else {
 		for (i = 0; i < elements.length; ++i) {
@@ -1224,7 +1224,7 @@ HTMLFormElement.prototype.getUnchecked = function(name, type) {
 		if (type && elements.type !== type) {
 			return [];
 		} else if (!elements.checked) {
-			return [ elements.value ];
+			return [elements.value];
 		}
 	} else {
 		for (i = 0; i < elements.length; ++i) {
@@ -1259,7 +1259,7 @@ Morebits.ip = {
 	 * @param {string} address - The IPv6 address, with or without CIDR.
 	 * @return {string}
 	 */
-	sanitizeIPv6: function (address) {
+	sanitizeIPv6: function(address) {
 		address = address.trim();
 		if (address === '') {
 			return null;
@@ -1312,7 +1312,7 @@ Morebits.ip = {
 	 * @param {string} ip
 	 * @return {boolean} - True if given a valid IP address range, false otherwise.
 	 */
-	isRange: function (ip) {
+	isRange: function(ip) {
 		return mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip);
 	},
 
@@ -1324,7 +1324,7 @@ Morebits.ip = {
 	 * @return {boolean} - True for valid ranges within the CIDR limits,
 	 * otherwise false (ranges outside the limit, single IPs, non-IPs).
 	 */
-	validCIDR: function (ip) {
+	validCIDR: function(ip) {
 		if (Morebits.ip.isRange(ip)) {
 			const subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
 			if (subnet) { // Should be redundant
@@ -1349,7 +1349,7 @@ Morebits.ip = {
 	 * @return {boolean|string} - False if not IPv6 or bigger than a 64,
 	 * otherwise the (sanitized) /64 address.
 	 */
-	get64: function (ipv6) {
+	get64: function(ipv6) {
 		if (!ipv6 || !mw.util.isIPv6Address(ipv6, true)) {
 			return false;
 		}
@@ -1412,7 +1412,7 @@ Morebits.string = {
 			if (skiplist === undefined) {
 				skiplist = [];
 			} else if (typeof skiplist === 'string') {
-				skiplist = [ skiplist ];
+				skiplist = [skiplist];
 			} else {
 				throw new Error('non-applicable skiplist parameter');
 			}
@@ -1575,7 +1575,7 @@ Morebits.array = {
 			throw new Error('A non-array object passed to Morebits.array.chunk');
 		}
 		if (typeof size !== 'number' || size <= 0) { // pretty impossible to do anything :)
-			return [ arr ]; // we return an array consisting of this array.
+			return [arr]; // we return an array consisting of this array.
 		}
 		const numChunks = Math.ceil(arr.length / size);
 		const result = new Array(numChunks);
@@ -3226,13 +3226,13 @@ Morebits.wiki.Page = function(pageName, status) {
 
 	// Delete-related setter
 	/** @param {boolean} flag */
-	this.setDeleteTalkPage = function (flag) {
+	this.setDeleteTalkPage = function(flag) {
 		ctx.deleteTalkPage = !!flag;
 	};
 
 	// Undelete-related setter
 	/** @param {boolean} flag */
-	this.setUndeleteTalkPage = function (flag) {
+	this.setUndeleteTalkPage = function(flag) {
 		ctx.undeleteTalkPage = !!flag;
 	};
 
@@ -3334,7 +3334,7 @@ Morebits.wiki.Page = function(pageName, status) {
 	 * unless it's being watched temporarily, in which case returns the
 	 * expiry string.
 	 */
-	this.getWatched = function () {
+	this.getWatched = function() {
 		return ctx.watched;
 	};
 
@@ -4016,7 +4016,7 @@ Morebits.wiki.Page = function(pageName, status) {
 					break;
 
 				case 'abusefilter-warning':
-					ctx.statusElement.error([ 'A warning was returned by the edit filter: "', errorData.abusefilter.description, '". If you wish to proceed with the edit, please carry it out again. This warning will not appear a second time.' ]);
+					ctx.statusElement.error(['A warning was returned by the edit filter: "', errorData.abusefilter.description, '". If you wish to proceed with the edit, please carry it out again. This warning will not appear a second time.']);
 					// We should provide the user with a way to automatically retry the action if they so choose -
 					// I can't see how to do this without creating a UI dependency on Morebits.wiki.Page though -- TTO
 					break;
@@ -4966,7 +4966,7 @@ Morebits.wikitext.Page.prototype = {
 	removeTemplate: function(template) {
 		const template_re_string = Morebits.pageNameRegex(template);
 		const links_re = new RegExp('\\{\\{(?:' + Morebits.namespaceRegex(10) + ':)?\\s*' + template_re_string + '\\s*[\\|(?:\\}\\})]');
-		const allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
+		const allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', ['{{{', '}}}']);
 		for (let i = 0; i < allTemplates.length; ++i) {
 			if (links_re.test(allTemplates[i])) {
 				this.text = this.text.replace(allTemplates[i], '');
@@ -5337,7 +5337,7 @@ Morebits.Status.printUserText = function(comments, message) {
  * @param {string} [color] - Font color.
  * @return {HTMLElement}
  */
-Morebits.htmlNode = function (type, content, color) {
+Morebits.htmlNode = function(type, content, color) {
 	const node = document.createElement(type);
 	if (color) {
 		node.style.color = color;
@@ -5354,7 +5354,7 @@ Morebits.htmlNode = function (type, content, color) {
  * @param {jQuery} jQuerySelector
  * @param {jQuery} jQueryContext
  */
-Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
+Morebits.checkboxShiftClickSupport = function(jQuerySelector, jQueryContext) {
 	let lastCheckbox = null;
 
 	function clickHandler(event) {

--- a/src/twinkle.js
+++ b/src/twinkle.js
@@ -63,16 +63,16 @@ Twinkle.defaultConfig = {
 
 	// Rollback
 	autoMenuAfterRollback: false,
-	openTalkPage: [ 'agf', 'norm', 'vand' ],
+	openTalkPage: ['agf', 'norm', 'vand'],
 	openTalkPageOnAutoRevert: false,
 	rollbackInPlace: false,
-	markRevertedPagesAsMinor: [ 'vand' ],
-	watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
+	markRevertedPagesAsMinor: ['vand'],
+	watchRevertedPages: ['agf', 'norm', 'vand', 'torev'],
 	watchRevertedExpiry: '1 month',
 	offerReasonOnNormalRevert: true,
 	confirmOnRollback: false,
 	confirmOnMobileRollback: true,
-	showRollbackLinks: [ 'diff', 'others' ],
+	showRollbackLinks: ['diff', 'others'],
 
 	// DI (twinkleimage)
 	notifyUserOnDeli: true,
@@ -93,15 +93,15 @@ Twinkle.defaultConfig = {
 
 	// CSD
 	speedySelectionStyle: 'buttonClick',
-	watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
+	watchSpeedyPages: ['g3', 'g5', 'g10', 'g11', 'g12'],
 	watchSpeedyExpiry: '1 month',
 	markSpeedyPagesAsPatrolled: false,
 	watchSpeedyUser: '1 month',
 
 	// these next two should probably be identical by default
-	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'g15', 'a1', 'a2', 'a3', 'a7', 'a9', 'a10', 'a11', 'c1', 'f1', 'f2', 'f3', 'f7', 'f9', 'r3', 'u6', 'u7' ],
-	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'g15', 'a1', 'a2', 'a3', 'a7', 'a9', 'a10', 'a11', 'c1', 'f1', 'f2', 'f3', 'f7', 'f9', 'r3', 'u6', 'u7' ],
-	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'g15', 'a1', 'a2', 'a3', 'a7', 'a9', 'a10', 'a11', 'c1', 'f1', 'f2', 'f3', 'f7', 'f9', 'r3', 'u6', 'u7' ],
+	welcomeUserOnSpeedyDeletionNotification: ['db', 'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'g15', 'a1', 'a2', 'a3', 'a7', 'a9', 'a10', 'a11', 'c1', 'f1', 'f2', 'f3', 'f7', 'f9', 'r3', 'u6', 'u7'],
+	notifyUserOnSpeedyDeletionNomination: ['db', 'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'g15', 'a1', 'a2', 'a3', 'a7', 'a9', 'a10', 'a11', 'c1', 'f1', 'f2', 'f3', 'f7', 'f9', 'r3', 'u6', 'u7'],
+	warnUserOnSpeedyDelete: ['db', 'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'g15', 'a1', 'a2', 'a3', 'a7', 'a9', 'a10', 'a11', 'c1', 'f1', 'f2', 'f3', 'f7', 'f9', 'r3', 'u6', 'u7'],
 	promptForSpeedyDeletionSummary: [],
 	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,
@@ -110,10 +110,10 @@ Twinkle.defaultConfig = {
 	speedyWindowWidth: 800,
 	logSpeedyNominations: false,
 	speedyLogPageName: 'CSD log',
-	noLogOnSpeedyNomination: [ 'u1' ],
+	noLogOnSpeedyNomination: ['u1'],
 
 	// Unlink
-	unlinkNamespaces: [ '0', '10', '100', '118' ],
+	unlinkNamespaces: ['0', '10', '100', '118'],
 
 	// Warn
 	defaultWarningGroup: '10',
@@ -344,12 +344,12 @@ Morebits.wiki.getCachedPage(`User:${mw.config.get('wgUserName')}/twinkleoptions.
 // Developers: you can import custom Twinkle modules here
 // For example, mw.loader.load(scriptpathbefore + "User:UncleDouggie/morebits-test.js" + scriptpathafter);
 
-Twinkle.load = function () {
+Twinkle.load = function() {
 	// Don't activate on special pages other than those listed here, so
 	// that others load faster, especially the watchlist.
-	let activeSpecialPageList = [ 'Block', 'Contributions', 'IPContributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+	let activeSpecialPageList = ['Block', 'Contributions', 'IPContributions', 'Recentchanges', 'Recentchangeslinked']; // wgRelevantUserName defined for non-sysops on Special:Block
 	if (Morebits.userIsSysop) {
-		activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
+		activeSpecialPageList = activeSpecialPageList.concat(['DeletedContributions', 'Prefixindex']);
 	}
 	if (mw.config.get('wgNamespaceNumber') === -1 &&
 		!activeSpecialPageList.includes(mw.config.get('wgCanonicalSpecialPageName'))) {
@@ -417,7 +417,7 @@ Twinkle.hatnoteRegex = 'short description|hatnote|main|correct title|dablink|dis
 /**
  * When performing rollbacks with [rollback] links, then visiting a user talk page, some data such as page name can be prefilled into Wel/AIV/Warn. Twinkle calls this a "prefill". This method gets a prefill, either from URL parameters (e.g. &vanarticle=Test) or from data previously stored using Twinkle.setPrefill()
  */
-Twinkle.getPrefill = function (key) {
+Twinkle.getPrefill = function(key) {
 	Twinkle.prefill = Twinkle.prefill || {};
 	if (!Object.prototype.hasOwnProperty.call(Twinkle.prefill, key)) {
 		Twinkle.prefill[key] = mw.util.getParamValue(key);
@@ -428,7 +428,7 @@ Twinkle.getPrefill = function (key) {
 /**
  * When performing rollbacks with [rollback] links, then visiting a user talk page, some data such as page name can be prefilled into Wel/AIV/Warn. Twinkle calls this a "prefill". This method sets a prefill. This data will be lost if the page is refreshed, unless it is added to the URL as a parameter.
  */
-Twinkle.setPrefill = function (key, value) {
+Twinkle.setPrefill = function(key, value) {
 	Twinkle.prefill = Twinkle.prefill || {};
 	Twinkle.prefill[key] = value;
 };
@@ -463,7 +463,7 @@ Twinkle.sortByNamespace = function(first, second) {
 /**
  * Used in batch listings to link to the page in question with >
  */
-Twinkle.generateArrowLinks = function (checkbox) {
+Twinkle.generateArrowLinks = function(checkbox) {
 	const link = Morebits.htmlNode('a', ' >');
 	link.setAttribute('class', 'tw-arrowpage-link');
 	link.setAttribute('href', mw.util.getUrl(checkbox.value));
@@ -474,7 +474,7 @@ Twinkle.generateArrowLinks = function (checkbox) {
 /**
  * Used in deprod and unlink listings to link the page title
  */
-Twinkle.generateBatchPageLinks = function (checkbox) {
+Twinkle.generateBatchPageLinks = function(checkbox) {
 	const $checkbox = $(checkbox);
 	const link = Morebits.htmlNode('a', $checkbox.val());
 	link.setAttribute('class', 'tw-batchpage-link');
@@ -486,7 +486,7 @@ Twinkle.generateBatchPageLinks = function (checkbox) {
 /**
  * remove "move to Commons" tag - deletion-tagged files cannot be moved to Commons
  */
-Twinkle.removeMoveToCommonsTagsFromWikicode = ( wikicode ) => wikicode.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)(?!( in))[^}]*\}\}/gi, '');
+Twinkle.removeMoveToCommonsTagsFromWikicode = (wikicode) => wikicode.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)(?!( in))[^}]*\}\}/gi, '');
 
 }());
 


### PR DESCRIPTION
I disagree with not putting space inside parentheses. I'd prefer to do space inside parentheses (MediaWiki style) because that is what my muscle memory is now after years of working on MediaWiki. But I was overruled in #1827

So let's be consistent and enforce no space inside parentheses. This provides efficiency in code review since CI will catch it instead of requiring reviewer bandwidth.

I imagine we used to have a rule that did this, but it was probably lost in the conversion to eslint-config-wikimedia.

- change eslint rules to:
```
		"array-bracket-spacing": ["error", "never"],
		"computed-property-spacing": ["error", "never"],
		"space-before-function-paren": ["error", "never"],
		"space-in-parens": ["error", "never"],
		"template-curly-spacing": ["error", "never"],
```
- autofix (`npm run lint:fix`)