### PR TITLE
xfd: add more logic to AFD "Draftify" option

### DIFF
--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -302,7 +302,6 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 	form.previewer.closePreview();
 
-	let outcome;
 	switch (value) {
 		case 'afd':
 			work_area = new Morebits.QuickForm.Element({
@@ -318,31 +317,32 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				style: 'margin-bottom: 5px; margin-top: -5px;'
 			});
 
-			outcome = work_area.append({
+			work_area.append({
 				type: 'select',
 				name: 'outcome',
-				label: 'Desired outcome:'
-			});
-
-			outcome.append({
-				type: 'option',
-				label: 'Delete',
-				value: 'deletion'
-			});
-			outcome.append({
-				type: 'option',
-				label: 'Merge',
-				value: 'merging'
-			});
-			outcome.append({
-				type: 'option',
-				label: 'Redirect',
-				value: 'redirecting'
-			});
-			outcome.append({
-				type: 'option',
-				label: 'Draftify',
-				value: 'draftification'
+				label: 'Desired outcome:',
+				list: [
+					{
+						type: 'option',
+						label: 'Delete',
+						value: 'deletion'
+					},
+					{
+						type: 'option',
+						label: 'Merge',
+						value: 'merging'
+					},
+					{
+						type: 'option',
+						label: 'Redirect',
+						value: 'redirecting'
+					},
+					{
+						type: 'option',
+						label: 'Draftify',
+						value: 'draftification'
+					}
+				]
 			});
 
 			work_area.append({
@@ -1209,19 +1209,19 @@ Twinkle.xfd.callbacks = {
 
 			let noIncludeStart = '';
 			let noIncludeEnd = '';
-			if ( params.noinclude ) {
+			if (params.noinclude) {
 				noIncludeStart = '<noinclude>';
 				noIncludeEnd = '</noinclude>';
 			}
 
 			let outcome = '';
-			if ( params.outcome !== 'deletion' ) {
+			if (params.outcome !== 'deletion') {
 				outcome = '|outcome=' + params.outcome;
 			}
 
 			let templateAndParams = '';
 			const isFirstNomination = params.number === '';
-			if ( isFirstNomination ) {
+			if (isFirstNomination) {
 				templateAndParams = 'subst:afd|help=off' + outcome;
 			} else {
 				templateAndParams = 'subst:afdx|' + params.number + '|help=off' + outcome;

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -321,6 +321,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				type: 'select',
 				name: 'outcome',
 				label: 'Desired outcome:',
+				event: Twinkle.xfd.callbacks.changeOutcome,
 				list: [
 					{
 						label: 'Delete',
@@ -774,6 +775,15 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 };
 
 Twinkle.xfd.callbacks = {
+	changeOutcome: function(outcome) {
+		const form = outcome.target.form;
+		const reasonBox = form.querySelector('textarea[name="reason"]');
+		if (outcome.target.value === 'draftification') {
+			reasonBox.value = "I propose '''draftifying''' because ";
+		} else {
+			reasonBox.value = '';
+		}
+	},
 	// Requires having the tag text (params.tagText) set ahead of time
 	autoEditRequest: function(pageobj, params) {
 		const talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
@@ -924,11 +934,12 @@ Twinkle.xfd.callbacks = {
 		// Ensure items with User talk or no namespace prefix both end
 		// up at user talkspace as expected, but retain the
 		// prefix-less username for addToLog
-		notifyTarget = mw.Title.newFromText(notifyTarget, 3);
+		const userTalkNamespace = 3;
+		notifyTarget = mw.Title.newFromText(notifyTarget, userTalkNamespace);
 		const targetNS = notifyTarget.getNamespaceId();
-		const usernameOrTarget = notifyTarget.getRelativeText(3);
+		const usernameOrTarget = notifyTarget.getRelativeText(userTalkNamespace);
 		notifyTarget = notifyTarget.toText();
-		if (targetNS === 3) {
+		if (targetNS === userTalkNamespace) {
 			// Disallow warning yourself
 			if (usernameOrTarget === mw.config.get('wgUserName')) {
 				Morebits.Status.warn('You (' + usernameOrTarget + ') created this page; skipping user notification');
@@ -943,11 +954,19 @@ Twinkle.xfd.callbacks = {
 			actionName = actionName || 'Notifying initial contributor (' + usernameOrTarget + ')';
 		}
 
+		// For grep: Afd notice, Mfd notice, Tfd notice, Cfd notice, Ffd notice, Rfd notice
 		let notifytext = '\n{{subst:' + params.venue + ' notice';
 		// Venue-specific parameters
 		switch (params.venue) {
 			case 'afd':
+				if (params.outcome !== 'deletion') {
+					notifytext += '|outcome=' + params.outcome;
+				}
+				// tell the template to add " (Xnd nomination)" to the XFD title, if needed
+				notifytext += params.numbering !== '' ? '|order=&#32;' + params.numbering : '';
+				break;
 			case 'mfd':
+				// tell the template to add " (Xnd nomination)" to the XFD title, if needed
 				notifytext += params.numbering !== '' ? '|order=&#32;' + params.numbering : '';
 				break;
 			case 'tfd':

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -302,6 +302,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 	form.previewer.closePreview();
 
+	let outcome;
 	switch (value) {
 		case 'afd':
 			work_area = new Morebits.QuickForm.Element({
@@ -315,6 +316,33 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: '', // Added later by Twinkle.makeFindSourcesDiv()
 				id: 'twinkle-xfd-findsources',
 				style: 'margin-bottom: 5px; margin-top: -5px;'
+			});
+
+			outcome = work_area.append({
+				type: 'select',
+				name: 'outcome',
+				label: 'Desired outcome:'
+			});
+
+			outcome.append({
+				type: 'option',
+				label: 'Delete',
+				value: 'deletion'
+			});
+			outcome.append({
+				type: 'option',
+				label: 'Merge',
+				value: 'merging'
+			});
+			outcome.append({
+				type: 'option',
+				label: 'Redirect',
+				value: 'redirecting'
+			});
+			outcome.append({
+				type: 'option',
+				label: 'Draftify',
+				value: 'draftification'
 			});
 
 			work_area.append({
@@ -1179,8 +1207,27 @@ Twinkle.xfd.callbacks = {
 				Twinkle.xfd.callbacks.addToLog(params, null);
 			}
 
-			params.tagText = (params.noinclude ? '<noinclude>{{' : '{{') + (params.number === '' ? 'subst:afd|help=off' : 'subst:afdx|' +
-					params.number + '|help=off') + (params.noinclude ? '}}</noinclude>\n' : '}}\n');
+			let noIncludeStart = '';
+			let noIncludeEnd = '';
+			if ( params.noinclude ) {
+				noIncludeStart = '<noinclude>';
+				noIncludeEnd = '</noinclude>';
+			}
+
+			let outcome = '';
+			if ( params.outcome !== 'deletion' ) {
+				outcome = '|outcome=' + params.outcome;
+			}
+
+			let templateAndParams = '';
+			const isFirstNomination = params.number === '';
+			if ( isFirstNomination ) {
+				templateAndParams = 'subst:afd|help=off' + outcome;
+			} else {
+				templateAndParams = 'subst:afdx|' + params.number + '|help=off' + outcome;
+			}
+
+			params.tagText = noIncludeStart + '{{' + templateAndParams + '}}' + noIncludeEnd + '\n';
 
 			if (pageobj.canEdit()) {
 			// Remove some tags that should always be removed on AfD.

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -323,22 +323,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Desired outcome:',
 				list: [
 					{
-						type: 'option',
 						label: 'Delete',
 						value: 'deletion'
 					},
 					{
-						type: 'option',
 						label: 'Merge',
 						value: 'merging'
 					},
 					{
-						type: 'option',
 						label: 'Redirect',
 						value: 'redirecting'
 					},
 					{
-						type: 'option',
 						label: 'Draftify',
 						value: 'draftification'
 					}

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -323,22 +323,10 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Desired outcome:',
 				event: Twinkle.xfd.callbacks.changeOutcome,
 				list: [
-					{
-						label: 'Delete',
-						value: 'deletion'
-					},
-					{
-						label: 'Merge',
-						value: 'merging'
-					},
-					{
-						label: 'Redirect',
-						value: 'redirecting'
-					},
-					{
-						label: 'Draftify',
-						value: 'draftification'
-					}
+					{ label: 'Delete', value: 'deletion' },
+					{ label: 'Merge', value: 'merging' },
+					{ label: 'Redirect', value: 'redirecting' },
+					{ label: 'Draftify', value: 'draftification' }
 				]
 			});
 
@@ -358,18 +346,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				name: 'xfdcat',
 				label: 'Choose what category this nomination belongs in:',
 				list: [
-					{ type: 'option', label: 'Unknown', value: '?', selected: true },
-					{ type: 'option', label: 'Media and music', value: 'M' },
-					{ type: 'option', label: 'Organisation, corporation, or product', value: 'O' },
-					{ type: 'option', label: 'Biographical', value: 'B' },
-					{ type: 'option', label: 'Society topics', value: 'S' },
-					{ type: 'option', label: 'Web or internet', value: 'W' },
-					{ type: 'option', label: 'Games or sports', value: 'G' },
-					{ type: 'option', label: 'Science and technology', value: 'T' },
-					{ type: 'option', label: 'Fiction and the arts', value: 'F' },
-					{ type: 'option', label: 'Places and transportation', value: 'P' },
-					{ type: 'option', label: 'Indiscernible or unclassifiable topic', value: 'I' },
-					{ type: 'option', label: 'Debate not yet sorted', value: 'U' }
+					{ label: 'Unknown', value: '?', selected: true },
+					{ label: 'Media and music', value: 'M' },
+					{ label: 'Organisation, corporation, or product', value: 'O' },
+					{ label: 'Biographical', value: 'B' },
+					{ label: 'Society topics', value: 'S' },
+					{ label: 'Web or internet', value: 'W' },
+					{ label: 'Games or sports', value: 'G' },
+					{ label: 'Science and technology', value: 'T' },
+					{ label: 'Fiction and the arts', value: 'F' },
+					{ label: 'Places and transportation', value: 'P' },
+					{ label: 'Indiscernible or unclassifiable topic', value: 'I' },
+					{ label: 'Debate not yet sorted', value: 'U' }
 				]
 			});
 

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -346,18 +346,18 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				name: 'xfdcat',
 				label: 'Choose what category this nomination belongs in:',
 				list: [
-					{ label: 'Unknown', value: '?', selected: true },
-					{ label: 'Media and music', value: 'M' },
-					{ label: 'Organisation, corporation, or product', value: 'O' },
-					{ label: 'Biographical', value: 'B' },
-					{ label: 'Society topics', value: 'S' },
-					{ label: 'Web or internet', value: 'W' },
-					{ label: 'Games or sports', value: 'G' },
-					{ label: 'Science and technology', value: 'T' },
-					{ label: 'Fiction and the arts', value: 'F' },
-					{ label: 'Places and transportation', value: 'P' },
-					{ label: 'Indiscernible or unclassifiable topic', value: 'I' },
-					{ label: 'Debate not yet sorted', value: 'U' }
+					{ type: 'option', label: 'Unknown', value: '?', selected: true },
+					{ type: 'option', label: 'Media and music', value: 'M' },
+					{ type: 'option', label: 'Organisation, corporation, or product', value: 'O' },
+					{ type: 'option', label: 'Biographical', value: 'B' },
+					{ type: 'option', label: 'Society topics', value: 'S' },
+					{ type: 'option', label: 'Web or internet', value: 'W' },
+					{ type: 'option', label: 'Games or sports', value: 'G' },
+					{ type: 'option', label: 'Science and technology', value: 'T' },
+					{ type: 'option', label: 'Fiction and the arts', value: 'F' },
+					{ type: 'option', label: 'Places and transportation', value: 'P' },
+					{ type: 'option', label: 'Indiscernible or unclassifiable topic', value: 'I' },
+					{ type: 'option', label: 'Debate not yet sorted', value: 'U' }
 				]
 			});
 


### PR DESCRIPTION
<img width="670" height="401" alt="2026-04-12_151425" src="https://github.com/user-attachments/assets/8ccbc702-937e-45af-b2da-ceace4a22ca4" />

This is a patch chain, and this patch is number 2. **Earlier patches need to merge first.** Then rebase this one to fix the "files changed" tab.

Why
- #2335

What
- add |outcome=draftification to {{Afd notify}} template that is left on user's talk page
- pre-fill some draftify text in the AFD reason textarea. the specific verbiage I chose was `I propose '''draftifying''' because `.
- changing away from the draftify outcome in the dropdown blanks the reason textarea
- refactor

Example text written to user talk:
- `{{subst:afd notice|1=NovemTest110}} ~~~~`
- `{{subst:afd notice|outcome=draftification|order=&#32; (2nd nomination)|1=NovemTest110}} ~~~~`