### PR TITLE
morebits: fix morebits-dialog z-index issue

### DIFF
--- a/src/morebits.css
+++ b/src/morebits.css
@@ -245,7 +245,9 @@ div.morebits-usertext {
 	overflow: hidden;
 	min-width: 150px;
 	min-height: 150px;
-	/* top, left, width, height, max-height, and z-index are set via JS */
+	/* z-index will be adjusted upwards by JS if there are multiple Twinkle dialogs open and a Twinkle dialog gets clicked on. */
+	z-index: 500;
+	/* top, left, width, height, and max-height are set via JS. */
 }
 
 .morebits-dialog-resizer {

--- a/src/morebits.css
+++ b/src/morebits.css
@@ -245,7 +245,7 @@ div.morebits-usertext {
 	overflow: hidden;
 	min-width: 150px;
 	min-height: 150px;
-	/* z-index will be adjusted upwards by JS if there are multiple Twinkle dialogs open and a Twinkle dialog gets clicked on. */
+	/* z-index will be adjusted upwards by JS if there are multiple dialogs open and a dialog gets clicked on. */
 	z-index: 500;
 	/* top, left, width, height, and max-height are set via JS. */
 }


### PR DESCRIPTION
Why
- `.morebits-dialog` should always be on top of things like the more menu, Twinkle menu, and user scripts

What
- add a default (and high) z-index of 500 to `.morebits-dialog` in morebits.css
- there's some JS code that sets the z-index to 500 + morebits dialog number (effective minimum is 501), which is why I chose 500 as the default

Fixes #2348