### PR TITLE
xfd: rmtr: handle WP:ANCHORSUBST

### DIFF
--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -2213,7 +2213,8 @@ Twinkle.xfd.callbacks = {
  * @return {string} pageWikitext
  */
 Twinkle.xfd.insertRMTR = function(pageWikitext, wikitextToInsert) {
-	const placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;
+	// [^\n]+ is for matching anchors, e.g. <span class="anchor" id="*"></span>
+	const placementRE = /\n{1,}(====[^\n]+Requests to revert undiscussed moves ?====)/i;
 	return pageWikitext.replace(placementRE, '\n' + wikitextToInsert + '\n\n$1');
 };
 

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -2213,8 +2213,8 @@ Twinkle.xfd.callbacks = {
  * @return {string} pageWikitext
  */
 Twinkle.xfd.insertRMTR = function(pageWikitext, wikitextToInsert) {
-	// [^\n]+ is for matching anchors, e.g. <span class="anchor" id="*"></span>
-	const placementRE = /\n{1,}(====[^\n]+Requests to revert undiscussed moves ?====)/i;
+	// [^\n]* is for matching anchors, e.g. <span class="anchor" id="*"></span>
+	const placementRE = /\n{1,}(====[^\n]*Requests to revert undiscussed moves ?====)/i;
 	return pageWikitext.replace(placementRE, '\n' + wikitextToInsert + '\n\n$1');
 };
 


### PR DESCRIPTION
Why
- folks want to change WP:RMTR to comply with WP:ANCHORSUBST, and Twinkle will currently break if they do that

What
- add `[^\n]*` to the RegEx that reads headings at RMTR. this is compatible with both the non-anchor style and the anchor style