### PR TITLE
Fix alignment with Twinkle menu

### DIFF
--- a/src/twinkle.css
+++ b/src/twinkle.css
@@ -106,7 +106,7 @@ html {
 
 #p-twinkle-dropdown {
 	display: flex;
-    min-width: 40px;
+	min-width: 40px;
 }
 
 @media screen {

--- a/src/twinkle.css
+++ b/src/twinkle.css
@@ -104,6 +104,11 @@ html {
 	border: 1px solid #f28500;
 }
 
+#p-twinkle-dropdown {
+	display: flex;
+    min-width: 40px;
+}
+
 @media screen {
 	html.skin-theme-clientpref-night #twinkle-config-headerbox {
 		background: #532b18;


### PR DESCRIPTION
We made some changes to Vector 2022's menu system so Twinkle's styles need to be updated to be compatible with it.

I already applied this on wiki but adding here for completeness https://en.wikipedia.org/w/index.php?title=MediaWiki%3AGadget-Twinkle.css&diff=1361137310&oldid=1339045356