### PR TITLE
Fix Parsoid section wrapper compatibility

### DIFF
--- a/src/modules/twinkletag.js
+++ b/src/modules/twinkletag.js
@@ -294,9 +294,12 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		if (Twinkle.tag.canRemove) {
 			// Look for existing maintenance tags in the lead section and put them in array
 
-			// All tags are HTML table elements that are direct children of .mw-parser-output,
+			// All tags are HTML table elements that are direct children of .mw-parser-output
+			// (legacy parser) or the first <section> child (Parsoid),
 			// except when they are within {{multiple issues}}
-			$('.mw-parser-output').children().each((i, e) => {
+			const $parserOutput = $('.mw-parser-output');
+			const $leadSection = $parserOutput.children('section[data-mw-section-id="0"]');
+			($leadSection.length ? $leadSection : $parserOutput).children().each((i, e) => {
 
 				// break out on encountering the first heading, which means we are no
 				// longer in the lead section

--- a/src/modules/twinkletag.js
+++ b/src/modules/twinkletag.js
@@ -299,7 +299,8 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			// except when they are within {{multiple issues}}
 			const $parserOutput = $('.mw-parser-output');
 			const $leadSection = $parserOutput.children('section[data-mw-section-id="0"]');
-			($leadSection.length ? $leadSection : $parserOutput).children().each((i, e) => {
+			const $scanTarget = $leadSection.length ? $leadSection : $parserOutput;
+			$scanTarget.children().each((i, e) => {
 
 				// break out on encountering the first heading, which means we are no
 				// longer in the lead section

--- a/src/modules/twinkletag.js
+++ b/src/modules/twinkletag.js
@@ -297,9 +297,10 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			// All tags are HTML table elements that are direct children of .mw-parser-output
 			// (legacy parser) or the first <section> child (Parsoid),
 			// except when they are within {{multiple issues}}
-			const $parserOutput = $('.mw-parser-output');
-			const $leadSection = $parserOutput.children('section[data-mw-section-id="0"]');
-			const $scanTarget = $leadSection.length ? $leadSection : $parserOutput;
+			// TODO: clean up after legacy parser is permanently replaced with Parsoid
+			const $oldParser = $('.mw-parser-output');
+			const $newParser = $('.mw-parser-output section[data-mw-section-id="0"]');
+			const $scanTarget = $newParser.length ? $newParser : $oldParser;
 			$scanTarget.children().each((i, e) => {
 
 				// break out on encountering the first heading, which means we are no

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -480,7 +480,10 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				] : [
 					{ value: 'standard', label: 'Standard', selected: true },
 					{ value: 'sidebar', label: 'Sidebar/infobox', selected: $('.infobox').length },
-					{ value: 'inline', label: 'Inline template', selected: $('.mw-parser-output > p .Inline-Template').length },
+					{ value: 'inline', label: 'Inline template', selected: (function() {
+						var $lead = $('.mw-parser-output').children('section[data-mw-section-id="0"]');
+						return ($lead.length ? $lead : $('.mw-parser-output')).find('p .Inline-Template').length;
+					}()) },
 					{ value: 'tiny', label: 'Tiny inline' },
 					{ value: 'disabled', label: 'Disabled' }
 				]

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -482,7 +482,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 					{ value: 'sidebar', label: 'Sidebar/infobox', selected: $('.infobox').length },
 					{ value: 'inline', label: 'Inline template', selected: (() => {
 						// TODO: clean up after legacy parser is permanently replaced with Parsoid
-						const $oldParser = $('.mw-parser-output p .Inline-Template');
+						const $oldParser = $('.mw-parser-output > p .Inline-Template');
 						const $newParser = $('.mw-parser-output section[data-mw-section-id="0"] p .Inline-Template');
 						const $scanTarget = $newParser.length ? $newParser : $oldParser;
 						return $scanTarget.length;

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -480,11 +480,13 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				] : [
 					{ value: 'standard', label: 'Standard', selected: true },
 					{ value: 'sidebar', label: 'Sidebar/infobox', selected: $('.infobox').length },
-					{ value: 'inline', label: 'Inline template', selected: (function() {
-						var $lead = $('.mw-parser-output').children('section[data-mw-section-id="0"]');
-						var $scanTarget = $lead.length ? $lead : $('.mw-parser-output');
-						return $scanTarget.find('p .Inline-Template').length;
-					}()) },
+					{ value: 'inline', label: 'Inline template', selected: (() => {
+						// TODO: clean up after legacy parser is permanently replaced with Parsoid
+						const $oldParser = $('.mw-parser-output p .Inline-Template');
+						const $newParser = $('.mw-parser-output section[data-mw-section-id="0"] p .Inline-Template');
+						const $scanTarget = $newParser.length ? $newParser : $oldParser;
+						return $scanTarget.length;
+					})() },
 					{ value: 'tiny', label: 'Tiny inline' },
 					{ value: 'disabled', label: 'Disabled' }
 				]

--- a/src/modules/twinklexfd.js
+++ b/src/modules/twinklexfd.js
@@ -482,7 +482,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 					{ value: 'sidebar', label: 'Sidebar/infobox', selected: $('.infobox').length },
 					{ value: 'inline', label: 'Inline template', selected: (function() {
 						var $lead = $('.mw-parser-output').children('section[data-mw-section-id="0"]');
-						return ($lead.length ? $lead : $('.mw-parser-output')).find('p .Inline-Template').length;
+						var $scanTarget = $lead.length ? $lead : $('.mw-parser-output');
+						return $scanTarget.find('p .Inline-Template').length;
 					}()) },
 					{ value: 'tiny', label: 'Tiny inline' },
 					{ value: 'disabled', label: 'Disabled' }


### PR DESCRIPTION
Parsoid wraps page content in `<section>` elements, so selectors using direct children of `.mw-parser-output` fail silently.

**twinkletag.js**: ambox tags are no longer direct children, breaking existing tag detection.

**twinklexfd.js**: `> p` selector can't find paragraphs inside section wrappers, breaking inline template auto-detection in the TfD dialog.

Both fixes target the Parsoid lead section (`section[data-mw-section-id="0"]`) when present, falling back to `.mw-parser-output` for the legacy parser.

Fixes #2387

Ref: [T333031](https://phabricator.wikimedia.org/T333031), [T430194](https://phabricator.wikimedia.org/T430194)